### PR TITLE
[codex] Prevent overlapping schedule entries

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type * as env from "../env.js";
 import type * as fileStorage from "../fileStorage.js";
 import type * as learningPlanAi from "../learningPlanAi.js";
 import type * as learningPlans from "../learningPlans.js";
+import type * as scheduleConflicts from "../scheduleConflicts.js";
 import type * as users from "../users.js";
 
 import type {
@@ -27,6 +28,7 @@ declare const fullApi: ApiFromModules<{
   fileStorage: typeof fileStorage;
   learningPlanAi: typeof learningPlanAi;
   learningPlans: typeof learningPlans;
+  scheduleConflicts: typeof scheduleConflicts;
   users: typeof users;
 }>;
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as dayEntries from "../dayEntries.js";
+import type * as dayKeyVariants from "../dayKeyVariants.js";
 import type * as env from "../env.js";
 import type * as fileStorage from "../fileStorage.js";
 import type * as learningPlanAi from "../learningPlanAi.js";
@@ -24,6 +25,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   dayEntries: typeof dayEntries;
+  dayKeyVariants: typeof dayKeyVariants;
   env: typeof env;
   fileStorage: typeof fileStorage;
   learningPlanAi: typeof learningPlanAi;

--- a/convex/dayEntries.test.ts
+++ b/convex/dayEntries.test.ts
@@ -37,6 +37,32 @@ test("manual timed entry overlapping an existing entry is rejected with conflict
 	);
 });
 
+test("manual timed entry conflicts with Berlin-midnight ISO day keys", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+
+	await t.mutation(api.dayEntries.create, {
+		dayKey: "2026-05-30T22:00:00.000Z",
+		title: "Englisch Kurzkontrolle",
+		time: "16:00",
+		kind: "Leistungskontrolle",
+		plannedDateLabel: "31. Mai 2026",
+		durationMinutes: 30,
+	});
+
+	await expect(
+		t.mutation(api.dayEntries.create, {
+			dayKey: "2026-05-31",
+			title: "Mathe Hausaufgabe",
+			time: "16:15",
+			kind: "Hausaufgabe",
+			plannedDateLabel: "31. Mai 2026",
+			durationMinutes: 30,
+		}),
+	).rejects.toThrow(
+		'Dieser Zeitraum überschneidet sich mit "Englisch Kurzkontrolle" am 31. Mai 2026 von 16:00 bis 16:30.',
+	);
+});
+
 test("manual timed entry adjacent to an existing entry is allowed", async () => {
 	const t = convexTest(schema, modules).withIdentity(user);
 

--- a/convex/dayEntries.test.ts
+++ b/convex/dayEntries.test.ts
@@ -1,0 +1,62 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+const user = {
+	tokenIdentifier: "test:user",
+};
+
+test("manual timed entry overlapping an existing entry is rejected with conflict details", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+
+	await t.mutation(api.dayEntries.create, {
+		dayKey: "2026-05-23",
+		title: "Mathe Hausaufgabe",
+		time: "16:00",
+		kind: "Hausaufgabe",
+		plannedDateLabel: "23. Mai 2026",
+		durationMinutes: 30,
+	});
+
+	await expect(
+		t.mutation(api.dayEntries.create, {
+			dayKey: "2026-05-23",
+			title: "Deutsch Hausaufgabe",
+			time: "16:15",
+			kind: "Hausaufgabe",
+			plannedDateLabel: "23. Mai 2026",
+			durationMinutes: 30,
+		}),
+	).rejects.toThrow(
+		'Dieser Zeitraum überschneidet sich mit "Mathe Hausaufgabe" am 23. Mai 2026 von 16:00 bis 16:30.',
+	);
+});
+
+test("manual timed entry adjacent to an existing entry is allowed", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+
+	await t.mutation(api.dayEntries.create, {
+		dayKey: "2026-05-23",
+		title: "Mathe Hausaufgabe",
+		time: "16:00",
+		kind: "Hausaufgabe",
+		plannedDateLabel: "23. Mai 2026",
+		durationMinutes: 30,
+	});
+
+	const createdId = await t.mutation(api.dayEntries.create, {
+		dayKey: "2026-05-23",
+		title: "Deutsch Hausaufgabe",
+		time: "16:30",
+		kind: "Hausaufgabe",
+		plannedDateLabel: "23. Mai 2026",
+		durationMinutes: 30,
+	});
+
+	expect(createdId).toBeTruthy();
+});

--- a/convex/dayEntries.ts
+++ b/convex/dayEntries.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { mutation, query } from "./_generated/server";
+import { assertNoScheduleConflict } from "./scheduleConflicts";
 
 type OptionalEntryFields = {
 	time?: string;
@@ -251,6 +252,12 @@ export const create = mutation({
 		if (!title) {
 			throw new Error("Titel darf nicht leer sein.");
 		}
+		await assertNoScheduleConflict(ctx, {
+			ownerTokenIdentifier,
+			dayKey: args.dayKey,
+			time: args.time,
+			durationMinutes: args.durationMinutes,
+		});
 
 		return await ctx.db.insert("dayEntries", {
 			ownerTokenIdentifier,

--- a/convex/dayEntries.ts
+++ b/convex/dayEntries.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { mutation, query } from "./_generated/server";
+import { getBerlinDayKey, getDayKeyQueryVariants } from "./dayKeyVariants";
 import { assertNoScheduleConflict } from "./scheduleConflicts";
 
 type OptionalEntryFields = {
@@ -76,42 +77,6 @@ const publicLearningSessionEntry = (
 	relatedLearningPlanId: session.learningPlanId,
 	relatedLearningPlanSessionId: session._id,
 });
-
-const dayKeyPattern = /^(\d{4})-(\d{2})-(\d{2})$/;
-
-const getBerlinDayKey = (value: string) => {
-	if (dayKeyPattern.test(value)) return value;
-
-	const date = new Date(value);
-	if (Number.isNaN(date.getTime())) return null;
-
-	const parts = new Intl.DateTimeFormat("en-US", {
-		timeZone: "Europe/Berlin",
-		year: "numeric",
-		month: "2-digit",
-		day: "2-digit",
-	}).formatToParts(date);
-	const year = parts.find((part) => part.type === "year")?.value;
-	const month = parts.find((part) => part.type === "month")?.value;
-	const day = parts.find((part) => part.type === "day")?.value;
-	if (!year || !month || !day) return null;
-
-	return `${year}-${month}-${day}`;
-};
-
-const getDayKeyQueryVariants = (dayKey: string) => {
-	const variants = new Set([dayKey]);
-	const match = dayKeyPattern.exec(dayKey);
-	if (match) {
-		variants.add(
-			new Date(
-				Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])),
-			).toISOString(),
-		);
-	}
-
-	return [...variants];
-};
 
 const getRequestedDayKey = (
 	storedDayKey: string,

--- a/convex/dayKeyVariants.ts
+++ b/convex/dayKeyVariants.ts
@@ -1,0 +1,48 @@
+const dayKeyPattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export const getBerlinDayKey = (value: string) => {
+	if (dayKeyPattern.test(value)) return value;
+
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) return null;
+
+	const parts = new Intl.DateTimeFormat("en-US", {
+		timeZone: "Europe/Berlin",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).formatToParts(date);
+	const year = parts.find((part) => part.type === "year")?.value;
+	const month = parts.find((part) => part.type === "month")?.value;
+	const day = parts.find((part) => part.type === "day")?.value;
+	if (!year || !month || !day) return null;
+
+	return `${year}-${month}-${day}`;
+};
+
+const addIsoVariantsForDateOnlyKey = (
+	variants: Set<string>,
+	dayKey: string,
+) => {
+	const match = dayKeyPattern.exec(dayKey);
+	if (!match) return;
+
+	const year = Number(match[1]);
+	const monthIndex = Number(match[2]) - 1;
+	const day = Number(match[3]);
+	const utcMidnight = Date.UTC(year, monthIndex, day);
+	variants.add(new Date(utcMidnight).toISOString());
+	variants.add(new Date(utcMidnight - 60 * 60 * 1000).toISOString());
+	variants.add(new Date(utcMidnight - 2 * 60 * 60 * 1000).toISOString());
+};
+
+export const getDayKeyQueryVariants = (dayKey: string) => {
+	const variants = new Set([dayKey]);
+	const berlinDayKey = getBerlinDayKey(dayKey);
+	if (berlinDayKey) {
+		variants.add(berlinDayKey);
+		addIsoVariantsForDateOnlyKey(variants, berlinDayKey);
+	}
+
+	return [...variants];
+};

--- a/convex/learningPlans.test.ts
+++ b/convex/learningPlans.test.ts
@@ -1,0 +1,120 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+type TestBackend = ReturnType<ReturnType<typeof convexTest>["withIdentity"]>;
+
+const user = {
+	tokenIdentifier: "test:user",
+};
+
+const createPlan = async (t: TestBackend) => {
+	const examDayEntryId = await t.mutation(api.dayEntries.create, {
+		dayKey: "2026-06-05",
+		title: "Mathe Klausur",
+		time: "09:00",
+		kind: "Leistungskontrolle",
+		plannedDateLabel: "5. Juni 2026",
+		durationMinutes: 90,
+		examTypeLabel: "Klausur",
+	});
+
+	return await t.mutation(api.learningPlans.start, {
+		examDayEntryId,
+		subject: "Mathe",
+		examTypeLabel: "Klausur",
+		examDateKey: "2026-06-05",
+		examDateLabel: "5. Juni 2026",
+		examTime: "09:00",
+		durationMinutes: 90,
+		topicDescription: "Lineare Funktionen",
+	});
+};
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date("2026-05-30T10:00:00.000Z"));
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+test("adding a learning plan session into an occupied time range is rejected with conflict details", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	const learningPlanId = await createPlan(t);
+
+	await t.mutation(api.dayEntries.create, {
+		dayKey: "2026-05-31",
+		title: "Deutsch Hausaufgabe",
+		time: "17:15",
+		kind: "Hausaufgabe",
+		plannedDateLabel: "31. Mai 2026",
+		durationMinutes: 30,
+	});
+
+	await expect(
+		t.mutation(api.learningPlans.addSession, { learningPlanId }),
+	).rejects.toThrow(
+		'Dieser Zeitraum überschneidet sich mit "Deutsch Hausaufgabe" am 31. Mai 2026 von 17:15 bis 17:45.',
+	);
+});
+
+test("moving a learning plan session into an occupied time range is rejected with conflict details", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	const learningPlanId = await createPlan(t);
+	await t.mutation(api.learningPlans.addSession, { learningPlanId });
+	const snapshot = await t.query(api.learningPlans.getSnapshot, {
+		id: learningPlanId,
+	});
+	const session = snapshot?.sessions[0];
+	if (!session) throw new Error("Expected a learning plan session.");
+
+	await t.mutation(api.dayEntries.create, {
+		dayKey: session.dateKey,
+		title: "Deutsch Hausaufgabe",
+		time: "18:00",
+		kind: "Hausaufgabe",
+		plannedDateLabel: "31. Mai 2026",
+		durationMinutes: 30,
+	});
+
+	await expect(
+		t.mutation(api.learningPlans.updateSession, {
+			id: session.id,
+			phase: session.phase,
+			dateKey: session.dateKey,
+			dateLabel: session.dateLabel,
+			startTime: "18:15",
+			durationMinutes: 45,
+		}),
+	).rejects.toThrow(
+		'Dieser Zeitraum überschneidet sich mit "Deutsch Hausaufgabe" am 31. Mai 2026 von 18:00 bis 18:30.',
+	);
+});
+
+test("updating a learning plan session at its own synced time is allowed", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	const learningPlanId = await createPlan(t);
+	await t.mutation(api.learningPlans.addSession, { learningPlanId });
+	const snapshot = await t.query(api.learningPlans.getSnapshot, {
+		id: learningPlanId,
+	});
+	const session = snapshot?.sessions[0];
+	if (!session) throw new Error("Expected a learning plan session.");
+
+	await expect(
+		t.mutation(api.learningPlans.updateSession, {
+			id: session.id,
+			phase: "theory",
+			dateKey: session.dateKey,
+			dateLabel: session.dateLabel,
+			startTime: session.startTime,
+			durationMinutes: session.durationMinutes,
+		}),
+	).resolves.toBeNull();
+});

--- a/convex/learningPlans.ts
+++ b/convex/learningPlans.ts
@@ -1,16 +1,15 @@
-import { components } from "./_generated/api";
-import { internal } from "./_generated/api";
+import { v } from "convex/values";
+import { components, internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import {
 	action,
 	internalMutation,
 	internalQuery,
-	mutation,
-	query,
 	type MutationCtx,
+	mutation,
 	type QueryCtx,
+	query,
 } from "./_generated/server";
-import { v } from "convex/values";
 import {
 	deleteManagedFile,
 	getConfiguredStorageProvider,
@@ -962,6 +961,12 @@ export const acceptPlan = mutation({
 		const now = Date.now();
 		let examDayEntryId = plan.examDayEntryId;
 		if (!examDayEntryId) {
+			await assertNoScheduleConflict(ctx, {
+				ownerTokenIdentifier,
+				dayKey: plan.examDateKey,
+				time: plan.examTime,
+				durationMinutes: plan.durationMinutes,
+			});
 			examDayEntryId = await ctx.db.insert("dayEntries", {
 				ownerTokenIdentifier,
 				dayKey: plan.examDateKey,

--- a/convex/learningPlans.ts
+++ b/convex/learningPlans.ts
@@ -16,6 +16,7 @@ import {
 	getConfiguredStorageProvider,
 	getR2ConfigOrThrow,
 } from "./fileStorage";
+import { assertNoScheduleConflict } from "./scheduleConflicts";
 
 const phaseValidator = v.union(
 	v.literal("theory"),
@@ -185,6 +186,15 @@ const syncSessionDayEntry = async (
 	plan: Doc<"learningPlans">,
 	session: Doc<"learningPlanSessions">,
 ) => {
+	await assertNoScheduleConflict(ctx, {
+		ownerTokenIdentifier: session.ownerTokenIdentifier,
+		dayKey: session.dateKey,
+		time: session.startTime,
+		durationMinutes: session.durationMinutes,
+		excludeDayEntryId: session.dayEntryId,
+		excludeLearningPlanSessionId: session._id,
+	});
+
 	if (!session.dayEntryId) {
 		const dayEntryId = await createSessionDayEntry(ctx, plan, session);
 		await ctx.db.patch("learningPlanSessions", session._id, {
@@ -750,6 +760,14 @@ export const updateSession = mutation({
 		if (args.durationMinutes <= 0) {
 			throw new Error("Die Dauer muss größer als 0 sein.");
 		}
+		await assertNoScheduleConflict(ctx, {
+			ownerTokenIdentifier,
+			dayKey: args.dateKey,
+			time: args.startTime,
+			durationMinutes: args.durationMinutes,
+			excludeDayEntryId: session.dayEntryId,
+			excludeLearningPlanSessionId: session._id,
+		});
 
 		await ctx.db.patch("learningPlanSessions", args.id, {
 			phase: args.phase,
@@ -802,15 +820,25 @@ export const addSession = mutation({
 		}
 
 		const now = Date.now();
+		const dateKey = getDateKey(nextDate);
+		const startTime = lastSession?.startTime ?? "17:00";
+		const durationMinutes = lastSession?.durationMinutes ?? 45;
+		await assertNoScheduleConflict(ctx, {
+			ownerTokenIdentifier,
+			dayKey: dateKey,
+			time: startTime,
+			durationMinutes,
+		});
+
 		const sessionId = await ctx.db.insert("learningPlanSessions", {
 			ownerTokenIdentifier,
 			learningPlanId: args.learningPlanId,
 			phase: "practice",
 			title: "Zusatzübung",
-			dateKey: getDateKey(nextDate),
+			dateKey,
 			dateLabel: formatDateLabel(nextDate),
-			startTime: lastSession?.startTime ?? "17:00",
-			durationMinutes: lastSession?.durationMinutes ?? 45,
+			startTime,
+			durationMinutes,
 			goal: "Zusätzlichen Lernblock ergänzen und individuell bearbeiten.",
 			tasks: ["Aufgaben festlegen", "Ergebnis kontrollieren"],
 			expectedOutcome: "Ein zusätzlicher Lernblock ist im Plan ergänzt.",

--- a/convex/scheduleConflicts.ts
+++ b/convex/scheduleConflicts.ts
@@ -1,8 +1,8 @@
 import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
+import { getDayKeyQueryVariants } from "./dayKeyVariants";
 
 const timePattern = /^(\d{1,2}):(\d{2})$/;
-const dayKeyPattern = /^(\d{4})-(\d{2})-(\d{2})$/;
 
 const minutesFromTime = (time: string) => {
 	const match = timePattern.exec(time.trim());
@@ -58,44 +58,6 @@ const getConflictMessage = (
 	interval: { start: number; end: number },
 ) =>
 	`Dieser Zeitraum überschneidet sich mit "${entry.title}" am ${getConflictDateLabel(entry)} von ${timeFromMinutes(interval.start)} bis ${timeFromMinutes(interval.end)}.`;
-
-const getBerlinDayKey = (value: string) => {
-	if (dayKeyPattern.test(value)) return value;
-
-	const date = new Date(value);
-	if (Number.isNaN(date.getTime())) return null;
-
-	const parts = new Intl.DateTimeFormat("en-US", {
-		timeZone: "Europe/Berlin",
-		year: "numeric",
-		month: "2-digit",
-		day: "2-digit",
-	}).formatToParts(date);
-	const year = parts.find((part) => part.type === "year")?.value;
-	const month = parts.find((part) => part.type === "month")?.value;
-	const day = parts.find((part) => part.type === "day")?.value;
-	if (!year || !month || !day) return null;
-
-	return `${year}-${month}-${day}`;
-};
-
-const getDayKeyQueryVariants = (dayKey: string) => {
-	const variants = new Set([dayKey]);
-	const berlinDayKey = getBerlinDayKey(dayKey);
-	if (berlinDayKey) {
-		variants.add(berlinDayKey);
-		const match = dayKeyPattern.exec(berlinDayKey);
-		if (match) {
-			variants.add(
-				new Date(
-					Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])),
-				).toISOString(),
-			);
-		}
-	}
-
-	return [...variants];
-};
 
 export const assertNoScheduleConflict = async (
 	ctx: MutationCtx,

--- a/convex/scheduleConflicts.ts
+++ b/convex/scheduleConflicts.ts
@@ -1,0 +1,152 @@
+import type { Doc, Id } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
+
+const timePattern = /^(\d{1,2}):(\d{2})$/;
+const dayKeyPattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const minutesFromTime = (time: string) => {
+	const match = timePattern.exec(time.trim());
+	if (!match) return null;
+
+	const hours = Number(match[1]);
+	const minutes = Number(match[2]);
+	if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
+
+	return hours * 60 + minutes;
+};
+
+const timeFromMinutes = (minutes: number) => {
+	const normalized = Math.max(0, minutes);
+	const minutesInDay = 24 * 60;
+	const dayOffset = Math.floor(normalized / minutesInDay);
+	const minutesOfDay = normalized % minutesInDay;
+	const hours = Math.floor(minutesOfDay / 60);
+	const rest = minutesOfDay % 60;
+	const daySuffix =
+		dayOffset > 0 ? ` (+${dayOffset} ${dayOffset === 1 ? "Tag" : "Tage"})` : "";
+	return `${String(hours).padStart(2, "0")}:${String(rest).padStart(2, "0")}${daySuffix}`;
+};
+
+const getInterval = ({
+	time,
+	durationMinutes,
+}: {
+	time?: string;
+	durationMinutes?: number;
+}) => {
+	if (!time || !durationMinutes || durationMinutes <= 0) return null;
+
+	const start = minutesFromTime(time);
+	if (start === null) return null;
+
+	return {
+		start,
+		end: start + durationMinutes,
+	};
+};
+
+const overlaps = (
+	first: { start: number; end: number },
+	second: { start: number; end: number },
+) => first.start < second.end && first.end > second.start;
+
+const getConflictDateLabel = (entry: Doc<"dayEntries">) =>
+	entry.plannedDateLabel ?? entry.dueDateLabel ?? entry.dayKey;
+
+const getConflictMessage = (
+	entry: Doc<"dayEntries">,
+	interval: { start: number; end: number },
+) =>
+	`Dieser Zeitraum überschneidet sich mit "${entry.title}" am ${getConflictDateLabel(entry)} von ${timeFromMinutes(interval.start)} bis ${timeFromMinutes(interval.end)}.`;
+
+const getBerlinDayKey = (value: string) => {
+	if (dayKeyPattern.test(value)) return value;
+
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) return null;
+
+	const parts = new Intl.DateTimeFormat("en-US", {
+		timeZone: "Europe/Berlin",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).formatToParts(date);
+	const year = parts.find((part) => part.type === "year")?.value;
+	const month = parts.find((part) => part.type === "month")?.value;
+	const day = parts.find((part) => part.type === "day")?.value;
+	if (!year || !month || !day) return null;
+
+	return `${year}-${month}-${day}`;
+};
+
+const getDayKeyQueryVariants = (dayKey: string) => {
+	const variants = new Set([dayKey]);
+	const berlinDayKey = getBerlinDayKey(dayKey);
+	if (berlinDayKey) {
+		variants.add(berlinDayKey);
+		const match = dayKeyPattern.exec(berlinDayKey);
+		if (match) {
+			variants.add(
+				new Date(
+					Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])),
+				).toISOString(),
+			);
+		}
+	}
+
+	return [...variants];
+};
+
+export const assertNoScheduleConflict = async (
+	ctx: MutationCtx,
+	{
+		ownerTokenIdentifier,
+		dayKey,
+		time,
+		durationMinutes,
+		excludeDayEntryId,
+		excludeLearningPlanSessionId,
+	}: {
+		ownerTokenIdentifier: string;
+		dayKey: string;
+		time?: string;
+		durationMinutes?: number;
+		excludeDayEntryId?: Id<"dayEntries">;
+		excludeLearningPlanSessionId?: Id<"learningPlanSessions">;
+	},
+) => {
+	const newInterval = getInterval({ time, durationMinutes });
+	if (!newInterval) return;
+
+	const existingEntries = [];
+	for (const queryDayKey of getDayKeyQueryVariants(dayKey)) {
+		const entries = ctx.db
+			.query("dayEntries")
+			.withIndex("by_ownerTokenIdentifier_and_dayKey", (q) =>
+				q
+					.eq("ownerTokenIdentifier", ownerTokenIdentifier)
+					.eq("dayKey", queryDayKey),
+			);
+		for await (const entry of entries) {
+			existingEntries.push(entry);
+		}
+	}
+
+	const seenEntryIds = new Set<string>();
+	for (const entry of existingEntries) {
+		if (seenEntryIds.has(entry._id)) continue;
+		seenEntryIds.add(entry._id);
+		if (excludeDayEntryId && entry._id === excludeDayEntryId) continue;
+		if (
+			excludeLearningPlanSessionId &&
+			entry.relatedLearningPlanSessionId === excludeLearningPlanSessionId
+		) {
+			continue;
+		}
+
+		const existingInterval = getInterval(entry);
+		if (existingInterval && overlaps(newInterval, existingInterval)) {
+			throw new Error(getConflictMessage(entry, existingInterval));
+		}
+	}
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"format:check": "run-s format:biome:check format:tailwind:check",
 		"format:biome:check": "biome format .",
 		"format:tailwind:check": "biome lint . --only=nursery/useSortedClasses",
+		"test": "vitest run",
 		"check": "run-s lint typecheck",
 		"typecheck": "tsc --noEmit",
 		"check:unused": "knip"
@@ -82,16 +83,20 @@
 		"@babel/plugin-transform-react-jsx": "^7.28.6",
 		"@biomejs/biome": "^2.4.14",
 		"@convex-dev/eslint-plugin": "^2.0.0",
+		"@edge-runtime/vm": "^5.0.0",
 		"@types/node": "^25.6.0",
 		"@types/react": "~19.2.14",
 		"babel-preset-expo": "~56.0.10",
+		"convex-test": "^0.0.53",
 		"eslint": "^10.3.0",
 		"eslint-plugin-react-hooks": "^7.1.1",
 		"knip": "^6.13.1",
 		"npm-run-all2": "^8.0.4",
 		"only-allow": "^1.2.2",
 		"typescript": "~6.0.3",
-		"typescript-eslint": "^8.59.1"
+		"typescript-eslint": "^8.59.1",
+		"vite": "^8.0.14",
+		"vitest": "^4.1.7"
 	},
 	"private": true,
 	"engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       '@convex-dev/eslint-plugin':
         specifier: ^2.0.0
         version: 2.0.0(convex@1.39.1(@clerk/react@6.6.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
+      '@edge-runtime/vm':
+        specifier: ^5.0.0
+        version: 5.0.0
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -179,6 +182,9 @@ importers:
       babel-preset-expo:
         specifier: ~56.0.10
         version: 56.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@56.0.2)(react-refresh@0.14.2)
+      convex-test:
+        specifier: ^0.0.53
+        version: 0.0.53(convex@1.39.1(@clerk/react@6.6.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))
       eslint:
         specifier: ^10.3.0
         version: 10.3.0(jiti@2.7.0)
@@ -200,6 +206,12 @@ importers:
       typescript-eslint:
         specifier: ^8.59.1
         version: 8.59.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
+      vite:
+        specifier: ^8.0.14
+        version: 8.0.14(@types/node@25.6.0)(esbuild@0.27.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))
 
 packages:
 
@@ -920,6 +932,14 @@ packages:
     resolution: {integrity: sha512-GxYe0b5RoAb7c7JzcAX3t+UrdT6edQDtSgJ2F9UPECLyQGU0TeTkyGsDXNm3HK+MnWYi8isRlqaqoYTUD0Ko+Q==}
     peerDependencies:
       convex: ^1.34.1
+
+  '@edge-runtime/primitives@6.0.0':
+    resolution: {integrity: sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA==}
+    engines: {node: '>=18'}
+
+  '@edge-runtime/vm@5.0.0':
+    resolution: {integrity: sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==}
+    engines: {node: '>=18'}
 
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
@@ -1662,6 +1682,9 @@ packages:
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
+
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
     cpu: [arm]
@@ -2076,6 +2099,98 @@ packages:
       react-native-web:
         optional: true
 
+  '@rolldown/binding-android-arm64@1.0.2':
+    resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
@@ -2443,6 +2558,12 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -2582,6 +2703,35 @@ packages:
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   '@wallet-standard/app@1.1.0':
     resolution: {integrity: sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==}
@@ -2744,6 +2894,10 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   babel-plugin-polyfill-corejs2@0.4.17:
     resolution: {integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==}
     peerDependencies:
@@ -2887,6 +3041,10 @@ packages:
 
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -3035,6 +3193,11 @@ packages:
         optional: true
       zod:
         optional: true
+
+  convex-test@0.0.53:
+    resolution: {integrity: sha512-bouZQTnTvZi8IHljHL++yClj1vcV+/9ZxEcd8JZz7RDxOfPkRKrkMgkk/xlX4M1EAiwcEJPNiQE7VJFvDM3lCQ==}
+    peerDependencies:
+      convex: ^1.32.0
 
   convex@1.39.1:
     resolution: {integrity: sha512-W+gVXA7BpRF1xLlS1kGTtKVaqd5yonqbGESKiPtIUXjV744GdDz8IG7RVsSY5KzHbgxuJBHKaJYk+92OIHTskQ==}
@@ -3220,6 +3383,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   esbuild@0.27.0:
     resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
     engines: {node: '>=18'}
@@ -3289,6 +3455,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -3310,6 +3479,10 @@ packages:
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expo-application@56.0.3:
     resolution: {integrity: sha512-DdGGPlMuM6cSTeKhbvh6OeLr2O/+EI5BHKYrD+Do8sJPYgLwzGrgESELfyjJCpEhFzT+TgKIdmLmWXhNUQnHiw==}
@@ -4160,6 +4333,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
@@ -4318,6 +4494,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nativewind@4.2.3:
     resolution: {integrity: sha512-HglF1v6A8CqBFpXWs0d3yf4qQGurrreLuyE8FTRI/VDH8b0npZa2SDG5tviTkLiBg0s5j09mQALZOjxuocgMLA==}
     engines: {node: '>=16'}
@@ -4408,6 +4589,9 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   officeparser@6.1.1:
     resolution: {integrity: sha512-C8XcY7h/4It+ZZDTnPs9p7v2c09zcJUVQKZH4Q8ZtBLeVrauSSrJvvV8Orcq8fSJjxPFuQAueQqkqTfGv3HlPw==}
@@ -4520,6 +4704,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pdfjs-dist@5.6.205:
     resolution: {integrity: sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==}
     engines: {node: '>=20.19.0 || >=22.13.0 || >=24'}
@@ -4603,6 +4790,10 @@ packages:
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.24.2:
@@ -4891,6 +5082,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4953,6 +5149,9 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -4992,6 +5191,9 @@ packages:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
@@ -5009,6 +5211,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-buffers@2.2.0:
     resolution: {integrity: sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==}
@@ -5111,9 +5316,20 @@ packages:
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.3:
+    resolution: {integrity: sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -5271,6 +5487,90 @@ packages:
       typescript:
         optional: true
 
+  vite@8.0.14:
+    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
@@ -5329,6 +5629,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -6638,6 +6943,12 @@ snapshots:
       - supports-color
       - typescript
 
+  '@edge-runtime/primitives@6.0.0': {}
+
+  '@edge-runtime/vm@5.0.0':
+    dependencies:
+      '@edge-runtime/primitives': 6.0.0
+
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.46
@@ -7409,6 +7720,8 @@ snapshots:
 
   '@oxc-project/types@0.130.0': {}
 
+  '@oxc-project/types@0.132.0': {}
+
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     optional: true
 
@@ -7764,6 +8077,57 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3)
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@scure/base@1.2.6': {}
 
@@ -8318,6 +8682,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -8500,6 +8871,47 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.14(@types/node@25.6.0)(esbuild@0.27.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@wallet-standard/app@1.1.0':
     dependencies:
       '@wallet-standard/base': 1.1.0
@@ -8630,6 +9042,8 @@ snapshots:
   array-timsort@1.0.3: {}
 
   asap@2.0.6: {}
+
+  assertion-error@2.0.1: {}
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
@@ -8806,6 +9220,8 @@ snapshots:
 
   caniuse-lite@1.0.30001788: {}
 
+  chai@6.2.2: {}
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -8959,6 +9375,10 @@ snapshots:
       typescript: 6.0.3
       zod: 4.4.2
 
+  convex-test@0.0.53(convex@1.39.1(@clerk/react@6.6.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)):
+    dependencies:
+      convex: 1.39.1(@clerk/react@6.6.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+
   convex@1.39.1(@clerk/react@6.6.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
     dependencies:
       esbuild: 0.27.0
@@ -9094,6 +9514,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   esbuild@0.27.0:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.0
@@ -9208,6 +9630,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -9219,6 +9645,8 @@ snapshots:
   eventemitter3@5.0.4: {}
 
   eventsource-parser@3.0.8: {}
+
+  expect-type@1.3.0: {}
 
   expo-application@56.0.3(expo@56.0.2):
     dependencies:
@@ -10080,6 +10508,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
@@ -10338,6 +10770,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.12: {}
+
   nativewind@4.2.3(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.0)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-safe-area-context@5.7.0(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(tailwindcss@3.4.1):
     dependencies:
       comment-json: 4.6.2
@@ -10421,6 +10855,8 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
+
+  obug@2.1.1: {}
 
   officeparser@6.1.1:
     dependencies:
@@ -10593,6 +11029,8 @@ snapshots:
       lru-cache: 11.3.5
       minipass: 7.1.3
 
+  pathe@2.0.3: {}
+
   pdfjs-dist@5.6.205:
     optionalDependencies:
       '@napi-rs/canvas': 0.1.100
@@ -10660,6 +11098,12 @@ snapshots:
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -10977,6 +11421,27 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.0.2:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.2
+      '@rolldown/binding-darwin-arm64': 1.0.2
+      '@rolldown/binding-darwin-x64': 1.0.2
+      '@rolldown/binding-freebsd-x64': 1.0.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
+      '@rolldown/binding-linux-arm64-gnu': 1.0.2
+      '@rolldown/binding-linux-arm64-musl': 1.0.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
+      '@rolldown/binding-linux-s390x-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-musl': 1.0.2
+      '@rolldown/binding-openharmony-arm64': 1.0.2
+      '@rolldown/binding-wasm32-wasi': 1.0.2
+      '@rolldown/binding-win32-arm64-msvc': 1.0.2
+      '@rolldown/binding-win32-x64-msvc': 1.0.2
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -11038,6 +11503,8 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   simple-plist@1.3.1:
@@ -11069,6 +11536,8 @@ snapshots:
 
   split-on-first@1.1.0: {}
 
+  stackback@0.0.2: {}
+
   stackframe@1.3.4: {}
 
   stacktrace-parser@0.1.11:
@@ -11080,6 +11549,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  std-env@4.1.0: {}
 
   stream-buffers@2.2.0: {}
 
@@ -11213,10 +11684,16 @@ snapshots:
 
   throat@5.0.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.3: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tmpl@1.0.5: {}
 
@@ -11349,6 +11826,50 @@ snapshots:
       - utf-8-validate
       - zod
 
+  vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.27.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.46.1
+      yaml: 2.9.0
+
+  vitest@4.1.7(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.3
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@25.6.0)(esbuild@0.27.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 5.0.0
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - msw
+
   vlq@1.0.1: {}
 
   walk-up-path@4.0.0: {}
@@ -11397,6 +11918,11 @@ snapshots:
   which@5.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/app/entry/new.tsx
+++ b/src/app/entry/new.tsx
@@ -49,6 +49,7 @@ import { SelectSheet } from "~/components/ui/select-sheet";
 import { Text } from "~/components/ui/text";
 import { Textarea } from "~/components/ui/textarea";
 import { useAuth } from "~/context/AuthContext";
+import { getErrorMessage } from "~/features/learning-plans/utils";
 import { getDayKey, parseDayKey, startOfLocalDay } from "~/lib/day-key";
 import { goBackOrReplace, useBackIntent } from "~/lib/navigation";
 import { ROUTES } from "~/lib/routes";
@@ -167,9 +168,7 @@ function HomeworkPillField({
 
 	return (
 		<Field className="mb-5">
-			{label ? (
-				<FieldLabel>{label}</FieldLabel>
-			) : null}
+			{label ? <FieldLabel>{label}</FieldLabel> : null}
 			{onPress ? (
 				<FieldTrigger
 					activeOpacity={0.86}
@@ -247,6 +246,7 @@ export default function NewEntryScreen() {
 	const [remindMe, setRemindMe] = useState(false);
 	const [createdDayKey, setCreatedDayKey] = useState(getDayKey(initialDate));
 	const [isCreating, setIsCreating] = useState(false);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [pickerTarget, setPickerTarget] = useState<PickerTarget | null>(null);
 	const [selectTarget, setSelectTarget] = useState<SelectTarget | null>(null);
 	const scrollViewRef = useRef<ScrollView | null>(null);
@@ -330,6 +330,7 @@ export default function NewEntryScreen() {
 
 		try {
 			setIsCreating(true);
+			setErrorMessage(null);
 			createdEntryId = await createDayEntry({
 				dayKey: nextDayKey,
 				title: entryTitle,
@@ -346,6 +347,11 @@ export default function NewEntryScreen() {
 				durationMinutes: resolvedDurationMinutes,
 				...(!isHomework ? { examTypeLabel: trimmedExamType } : {}),
 			});
+		} catch (error) {
+			setErrorMessage(
+				getErrorMessage(error, "Der Eintrag konnte nicht gespeichert werden."),
+			);
+			return;
 		} finally {
 			setIsCreating(false);
 		}
@@ -850,6 +856,11 @@ export default function NewEntryScreen() {
 						paddingBottom: Math.max(insets.bottom + 10, 24),
 					}}
 				>
+					{errorMessage ? (
+						<Text className="mb-3 text-center font-poppins text-12 text-destructive">
+							{errorMessage}
+						</Text>
+					) : null}
 					<Button
 						className="w-full"
 						disabled={
@@ -870,32 +881,37 @@ export default function NewEntryScreen() {
 				</View>
 			) : (
 				<View
-					className="flex-row"
 					style={{
-						columnGap: 12,
 						paddingHorizontal: 24,
 						paddingBottom: Math.max(insets.bottom + 10, 24),
 					}}
 				>
-					<Button
-						className="flex-1"
-						variant="neutral"
-						disabled={!canCreateExam || isCreating || !canWriteEntries}
-						onPress={() => {
-							void createEntry();
-						}}
-					>
-						<Text>Eintragen</Text>
-					</Button>
-					<Button
-						className="flex-1"
-						disabled={!canCreateExam || isCreating || !canWriteEntries}
-						onPress={() => {
-							void createLearningPlan();
-						}}
-					>
-						<Text>Lernplan</Text>
-					</Button>
+					{errorMessage ? (
+						<Text className="mb-3 text-center font-poppins text-12 text-destructive">
+							{errorMessage}
+						</Text>
+					) : null}
+					<View className="flex-row" style={{ columnGap: 12 }}>
+						<Button
+							className="flex-1"
+							variant="neutral"
+							disabled={!canCreateExam || isCreating || !canWriteEntries}
+							onPress={() => {
+								void createEntry();
+							}}
+						>
+							<Text>Eintragen</Text>
+						</Button>
+						<Button
+							className="flex-1"
+							disabled={!canCreateExam || isCreating || !canWriteEntries}
+							onPress={() => {
+								void createLearningPlan();
+							}}
+						>
+							<Text>Lernplan</Text>
+						</Button>
+					</View>
 				</View>
 			)}
 			{renderPicker()}

--- a/src/app/entry/new.tsx
+++ b/src/app/entry/new.tsx
@@ -857,7 +857,11 @@ export default function NewEntryScreen() {
 					}}
 				>
 					{errorMessage ? (
-						<Text className="mb-3 text-center font-poppins text-12 text-destructive">
+						<Text
+							accessibilityRole="alert"
+							accessibilityLiveRegion="polite"
+							className="mb-3 text-center font-poppins text-12 text-destructive"
+						>
 							{errorMessage}
 						</Text>
 					) : null}
@@ -887,7 +891,11 @@ export default function NewEntryScreen() {
 					}}
 				>
 					{errorMessage ? (
-						<Text className="mb-3 text-center font-poppins text-12 text-destructive">
+						<Text
+							accessibilityRole="alert"
+							accessibilityLiveRegion="polite"
+							className="mb-3 text-center font-poppins text-12 text-destructive"
+						>
 							{errorMessage}
 						</Text>
 					) : null}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -32,12 +32,17 @@ function Textarea({
 			style={[
 				{
 					margin: 0,
-					paddingTop: Platform.OS === "ios" ? 2 : 0,
-					paddingBottom: 2,
+					paddingTop: 4,
+					paddingBottom: 4,
 					paddingHorizontal: 0,
 					lineHeight: 22,
 					letterSpacing: 0,
 					verticalAlign: "top",
+					...Platform.select({
+						android: {
+							includeFontPadding: false,
+						},
+					}),
 				},
 				style,
 			]}

--- a/src/features/learning-plans/utils.test.ts
+++ b/src/features/learning-plans/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+import { getErrorMessage } from "./utils";
+
+describe("getErrorMessage", () => {
+	test("extracts user-facing messages from Convex server errors", () => {
+		const error = new Error(
+			' [CONVEX M(dayEntries:create)] [Request ID: abc] Server Error\nUncaught Error: Dieser Zeitraum überschneidet sich mit "Englisch Kurzkontrolle" am Samstag, 30. Mai von 16:00 bis 16:30.\n    at async handler (../convex/dayEntries.ts:255:3)\n\nCalled by client',
+		);
+
+		expect(getErrorMessage(error, "Fallback")).toBe(
+			'Dieser Zeitraum überschneidet sich mit "Englisch Kurzkontrolle" am Samstag, 30. Mai von 16:00 bis 16:30.',
+		);
+	});
+});

--- a/src/features/learning-plans/utils.ts
+++ b/src/features/learning-plans/utils.ts
@@ -56,8 +56,23 @@ export const dateWithTime = (dateKey: string, time: string) => {
 	return next;
 };
 
-export const getErrorMessage = (error: unknown, fallback: string) =>
-	error instanceof Error ? error.message : fallback;
+const cleanConvexErrorMessage = (message: string) => {
+	const uncaughtErrorMatch =
+		/Uncaught Error:\s*([\s\S]*?)(?:\n\s*at |\n\s*Called by client|$)/.exec(
+			message,
+		);
+	const cleaned = (uncaughtErrorMatch?.[1] ?? message)
+		.replace(/^\[CONVEX[^\n]*\]\s*/i, "")
+		.replace(/^Server Error\s*/i, "")
+		.trim();
+
+	return cleaned || null;
+};
+
+export const getErrorMessage = (error: unknown, fallback: string) => {
+	if (!(error instanceof Error)) return fallback;
+	return cleanConvexErrorMessage(error.message) ?? fallback;
+};
 
 const wait = (milliseconds: number) =>
 	new Promise<void>((resolve) => setTimeout(resolve, milliseconds));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "edge-runtime",
+		include: ["convex/**/*.test.ts"],
+	},
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		environment: "edge-runtime",
-		include: ["convex/**/*.test.ts"],
+		include: ["convex/**/*.test.ts", "src/**/*.test.ts"],
 	},
 });


### PR DESCRIPTION
## Summary

- Add server-side schedule conflict validation for manual day entries and learning-plan sessions.
- Return detailed German conflict errors that name the overlapping entry, date, and time range.
- Add Convex integration tests with Vitest/convex-test for overlap rejection, adjacent entries, learning-plan edits, and self-sync updates.

## Root Cause

Schedule writes were accepted independently across `dayEntries` and `learningPlans`, so overlapping time ranges for the same user/day could be created through multiple paths.

## Linked Issue

Closes #65

## Validation

- `pnpm test`
- `pnpm check`
- CodeRabbit CLI in WSL found two minor issues; both were addressed. Final rerun was blocked by the free CLI rate limit after the fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schedule conflict detection now blocks overlapping day entries and learning-plan sessions and surfaces descriptive error text with conflicting entry title and time range.
  * Entry creation UI shows inline error messages when scheduling conflicts occur.

* **Tests**
  * Added end-to-end tests covering conflict validation, edge-case day-key handling near midnight, and allowed boundary behaviors (adjacent times).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dayova/dayova-mvp/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->