### PR TITLE
Remove unnecessary dot indicators from home component (Issue 59)

### DIFF
--- a/src/app/(app)/home.tsx
+++ b/src/app/(app)/home.tsx
@@ -708,23 +708,6 @@ export default function HomeScreen() {
 						) : null}
 					</View>
 
-					<View
-						className="flex-row items-center"
-						style={{ marginTop: 25 * compactScale, columnGap: 7 * screenScale }}
-					>
-						<View
-							className="rounded-full bg-[#0A0A0A]"
-							style={{ width: 7 * screenScale, height: 7 * screenScale }}
-						/>
-						<View
-							className="rounded-full bg-black/15"
-							style={{ width: 7 * screenScale, height: 7 * screenScale }}
-						/>
-						<View
-							className="rounded-full bg-black/15"
-							style={{ width: 7 * screenScale, height: 7 * screenScale }}
-						/>
-					</View>
 				</View>
 
 				<View


### PR DESCRIPTION
Removes the unused three-dot side-scroll indicator from the top dashboard area. The dashboard content and timeline scrolling behavior are unchanged; this only cleans up the stale visual indicator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary placeholder indicator elements from the lesson card layout, streamlining the visual display and improving overall interface clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->