### PR TITLE
Polish app copy and fix German text throughout the UI

### DIFF
--- a/src/app/(app)/home.tsx
+++ b/src/app/(app)/home.tsx
@@ -610,7 +610,7 @@ export default function HomeScreen() {
 								includeFontPadding: false,
 							}}
 						>
-							schön dass du da bist
+							schön, dass du da bist!
 						</Text>
 					</View>
 					<NotificationButton />

--- a/src/app/(app)/learning-plans.tsx
+++ b/src/app/(app)/learning-plans.tsx
@@ -189,8 +189,8 @@ export default function LearningPlansScreen() {
 									includeFontPadding: false,
 								}}
 							>
-								Erstelle einen Lernplan aus einer Leistungskontrolle, damit er
-								hier als Übersicht erscheint.
+								Erstelle einen Lernplan aus einer Prüfung, damit er hier als
+								Übersicht erscheint.
 							</Text>
 							<TouchableOpacity
 								accessibilityRole="button"

--- a/src/app/(app)/settings.tsx
+++ b/src/app/(app)/settings.tsx
@@ -185,7 +185,7 @@ export default function SettingsScreen() {
 					/>
 					<SettingsRow
 						icon={Logout}
-						label="Logout"
+						label="Abmelden"
 						onPress={async () => {
 							await logout();
 							router.replace("/");

--- a/src/app/(auth)/index.tsx
+++ b/src/app/(auth)/index.tsx
@@ -8,7 +8,7 @@ import { Text } from "~/components/ui/text";
 export default function AuthChoiceScreen() {
 	return (
 		<SafeAreaView className="flex-1 bg-[#F7F6F8]">
-			<Stack.Screen options={{ title: "MVP Login / Registrierung" }} />
+			<Stack.Screen options={{ title: "Anmelden / Registrieren" }} />
 			<StatusBar style="dark" />
 
 			<ScrollView
@@ -41,7 +41,7 @@ export default function AuthChoiceScreen() {
 					<View className="gap-64">
 						<View className="items-center gap-[14px]">
 							<Text className="max-w-[260px] text-center font-bold font-poppins text-[#0B0B0F] text-[22px] leading-[27px]">
-								Du hast schon einen{"\n"}Account?
+								Du hast schon ein{"\n"}Konto?
 							</Text>
 							<Text className="text-center font-poppins text-[#8C8A91] text-[11px] leading-4">
 								Melde dich direkt an und mach dort weiter, wo du aufgehört hast.
@@ -49,11 +49,11 @@ export default function AuthChoiceScreen() {
 						</View>
 
 						<Button
-							accessibilityLabel="Login"
+							accessibilityLabel="Anmelden"
 							onPress={() => router.push("/login")}
 							variant="neutral"
 						>
-							<Text>Login</Text>
+							<Text>Anmelden</Text>
 						</Button>
 					</View>
 				</View>

--- a/src/app/(auth)/onboarding.tsx
+++ b/src/app/(auth)/onboarding.tsx
@@ -91,7 +91,7 @@ const FLOW_STEPS: readonly FlowStep[] = [
 		kind: "intro",
 		title: "Keine Motivation.\nKein Plan. Zu viel Stress?",
 		description:
-			"Prokrastination, Ablenkung und Unklarheit halten dich davon ab wirklich voranzukommen",
+			"Prokrastination, Ablenkung und Unklarheit halten dich davon ab, wirklich voranzukommen.",
 	},
 	{
 		kind: "intro",
@@ -103,7 +103,7 @@ const FLOW_STEPS: readonly FlowStep[] = [
 		kind: "intro",
 		title: "Dayova bringt dich ans Ziel.",
 		description:
-			"Individuell, strukturiert und motiviert - mehr Fortschritt, weniger Stress und echte Erfolge",
+			"Individuell, strukturiert und motivierend: mehr Fortschritt, weniger Stress und echte Erfolge.",
 	},
 	{
 		kind: "select",
@@ -118,9 +118,9 @@ const FLOW_STEPS: readonly FlowStep[] = [
 	},
 	{
 		kind: "info",
-		title: "Das ist toll! Pro Tag 30min reichen aus um....",
+		title: "Schon 30 Minuten am Tag können viel bewirken.",
 		description:
-			"Schon kurze, regelmäßige Lerneinheiten können einen großen Unterschied machen.",
+			"Regelmäßige kurze Lerneinheiten helfen dir, ohne zusätzlichen Stress dranzubleiben.",
 	},
 	{
 		kind: "select",
@@ -135,7 +135,7 @@ const FLOW_STEPS: readonly FlowStep[] = [
 	},
 	{
 		kind: "select",
-		title: "Was sind deine größten Baustellen in der Schule",
+		title: "Was sind deine größten Baustellen in der Schule?",
 		field: "challenge",
 		options: ["Konzentration", "Motivation", "Organisation", "Prüfungsstress"],
 	},
@@ -152,9 +152,9 @@ const FLOW_STEPS: readonly FlowStep[] = [
 	},
 	{
 		kind: "info",
-		title: "Gute Nachricht, eine Studie zeigt, dass...",
+		title: "Gute Nachricht: Kleine Routinen helfen.",
 		description:
-			"kleine Routinen und ein klarer Plan oft wichtiger sind als besonders lange Lernsessions.",
+			"Ein klarer Plan ist oft wichtiger als besonders lange Lernsessions.",
 	},
 	{
 		kind: "input",
@@ -666,7 +666,7 @@ export default function WelcomeScreen() {
 										includeFontPadding: false,
 									}}
 								>
-									{activeStep.kind === "info" ? "Gute Nachricht" : "Sag mal..."}
+									{activeStep.kind === "info" ? "Gute Nachricht" : "Sag mal"}
 								</Text>
 								<Text
 									className="text-center font-bold font-poppins text-[#111111]"
@@ -880,7 +880,7 @@ export default function WelcomeScreen() {
 								label={
 									activeStep.kind === "password"
 										? isLoading || isCompletingOnboarding
-											? "Registriert..."
+											? "Konto wird erstellt..."
 											: "Konto erstellen"
 										: "Weiter"
 								}

--- a/src/app/entry/new.tsx
+++ b/src/app/entry/new.tsx
@@ -264,8 +264,8 @@ export default function NewEntryScreen() {
 	const subtitle = isHomework
 		? step === "basics"
 			? "Trage zuerst Fälligkeit, Fach und Notiz ein."
-			: "Plane jetzt, wann du daran arbeitest."
-		: "Trage zuerst Fälligkeit, Fach und Notiz ein.";
+			: "Plane jetzt, wann du die Hausaufgabe erledigst."
+		: "Trage Datum, Uhrzeit, Fach und Prüfungsart ein.";
 
 	const closePicker = () => setPickerTarget(null);
 	const closeSelect = () => setSelectTarget(null);
@@ -608,7 +608,7 @@ export default function NewEntryScreen() {
 									Hausaufgabe eintragen
 								</Text>
 								<Text className="mt-2 font-poppins text-14 text-text/42">
-									Trage nun ein wann du es machst.
+									Plane jetzt, wann du die Hausaufgabe erledigst.
 								</Text>
 							</View>
 
@@ -625,7 +625,7 @@ export default function NewEntryScreen() {
 								<View className="flex-1">
 									<HomeworkPillField
 										value={formatTime(plannedTime)}
-										placeholder="Von..."
+										placeholder="Von"
 										icon={
 											<Clock3 size={19} color="#9EA1A8" strokeWidth={2.1} />
 										}
@@ -636,7 +636,7 @@ export default function NewEntryScreen() {
 								<View className="flex-1">
 									<HomeworkPillField
 										value={formatTime(plannedEndTime)}
-										placeholder="Bis..."
+										placeholder="Bis"
 										icon={
 											<Clock3 size={19} color="#9EA1A8" strokeWidth={2.1} />
 										}
@@ -687,7 +687,7 @@ export default function NewEntryScreen() {
 								visible={step === "success"}
 								dismissible
 								onClose={finish}
-								accessibilityLabel="Entfernen-Dialog schließen"
+								accessibilityLabel="Erfolgsdialog schließen"
 								title="Hausaufgabe ist eingetragen"
 								description="Deine Hausaufgabe wurde erfolgreich eingetragen."
 								icon={<Check size={48} color="#28C76F" strokeWidth={1.2} />}
@@ -732,7 +732,7 @@ export default function NewEntryScreen() {
 							<View className="flex-1">
 								<HomeworkPillField
 									value={formatTime(plannedTime)}
-									placeholder="Von..."
+									placeholder="Von"
 									icon={<Clock3 size={19} color="#9EA1A8" strokeWidth={2.1} />}
 									onPress={() => setPickerTarget("plannedTime")}
 									className="min-h-[64px] px-5"
@@ -741,7 +741,7 @@ export default function NewEntryScreen() {
 							<View className="flex-1">
 								<HomeworkPillField
 									value={formatTime(plannedEndTime)}
-									placeholder="Bis..."
+									placeholder="Bis"
 									icon={<Clock3 size={19} color="#9EA1A8" strokeWidth={2.1} />}
 									onPress={() => setPickerTarget("plannedEndTime")}
 									className="min-h-[64px] px-5"

--- a/src/app/learning-plans/[planId]/index.tsx
+++ b/src/app/learning-plans/[planId]/index.tsx
@@ -60,7 +60,7 @@ function SessionOverviewCard({ session }: { session: PlanSession }) {
 						className="font-poppins font-semibold text-[#3A7BFF]"
 						style={{ fontSize: 12, lineHeight: 15, includeFontPadding: false }}
 					>
-						{`${session.durationMinutes} min`}
+						{`${session.durationMinutes} Min.`}
 					</Text>
 				</View>
 			</View>

--- a/src/app/learning-plans/[planId]/review.tsx
+++ b/src/app/learning-plans/[planId]/review.tsx
@@ -174,7 +174,7 @@ export default function LearningPlanReviewScreen() {
 			>
 				<Button
 					accessibilityLabel={
-						isBusy ? "Lernplan erstellen, wird geladen" : "Lernplan erstellen"
+						isBusy ? "Lernplan eintragen, wird geladen" : "Lernplan eintragen"
 					}
 					accessibilityLiveRegion={isBusy ? "polite" : undefined}
 					accessibilityState={{
@@ -191,7 +191,7 @@ export default function LearningPlanReviewScreen() {
 						<ActivityIndicator color="#1A1A1A" />
 					) : (
 						<Text className="font-bold font-poppins text-15 text-text">
-							Lernplan erstellen
+							Lernplan eintragen
 						</Text>
 					)}
 				</Button>
@@ -221,7 +221,7 @@ export default function LearningPlanReviewScreen() {
 			<ActionModal
 				visible={Boolean(successDayKey)}
 				title="Lernplan ist eingetragen"
-				description="Deine Lernplan wurde erfolgreich eingetragen."
+				description="Dein Lernplan wurde erfolgreich eingetragen."
 				icon={<Check size={48} color="#28C76F" strokeWidth={1.2} />}
 			>
 				<Button

--- a/src/app/learning-plans/[planId]/sessions/[sessionId]/edit.tsx
+++ b/src/app/learning-plans/[planId]/sessions/[sessionId]/edit.tsx
@@ -208,7 +208,7 @@ function LoadedSessionEditScreen({
 				onClose={() => setIsDeleteVisible(false)}
 				accessibilityLabel="Entfernen-Dialog schließen"
 				title="Bist du dir sicher?"
-				description="Klicke auf Entfernen wenn du dir sicher bist den Lerntag zu entfernen."
+				description="Tippe auf Entfernen, wenn du diesen Lerntag wirklich löschen möchtest."
 				icon={<X size={48} color="#FF5147" strokeWidth={1.8} />}
 				iconContainerClassName="bg-red-100"
 			>

--- a/src/app/learning-plans/new.tsx
+++ b/src/app/learning-plans/new.tsx
@@ -441,7 +441,7 @@ export default function NewLearningPlanScreen() {
 					/>
 				</FieldControl>
 
-				<FieldLabel>Notizen</FieldLabel>
+				<FieldLabel>Materialien</FieldLabel>
 				<ActionSurface
 					accessibilityLabel="Material hochladen"
 					accessibilityRole="button"
@@ -557,7 +557,7 @@ export default function NewLearningPlanScreen() {
 										includeFontPadding: false,
 									}}
 								>
-									Wähle zuerst die Art aus.
+									Wähle aus, wie du deine Unterlagen hinzufügen möchtest.
 								</Text>
 							</View>
 							<TouchableOpacity

--- a/src/app/learning-times/edit.tsx
+++ b/src/app/learning-times/edit.tsx
@@ -267,8 +267,7 @@ export default function LearningTimesScreen() {
 								includeFontPadding: false,
 							}}
 						>
-							Hier kannst du individuell deine Lernzeiten anpassen, so wie es
-							passt.
+							Passe deine Lernzeiten so an, wie sie für dich passen.
 						</Text>
 					</View>
 
@@ -360,7 +359,7 @@ export default function LearningTimesScreen() {
 					<Text>Entfernen</Text>
 				</Button>
 				<Button className="flex-1" disabled={!canSave} onPress={save}>
-					<Text>{isSaving ? "Speichern..." : "Speichern"}</Text>
+					<Text>{isSaving ? "Speichert..." : "Speichern"}</Text>
 				</Button>
 			</View>
 

--- a/src/app/learning-times/index.tsx
+++ b/src/app/learning-times/index.tsx
@@ -160,7 +160,7 @@ export default function LearningTimesOverviewScreen() {
 									includeFontPadding: false,
 								}}
 							>
-								Füge mit dem Plus deine erste wiederkehrende Lernzeit hinzu.
+								Füge über das Plus deine erste wiederkehrende Lernzeit hinzu.
 							</Text>
 						</View>
 					) : null}

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -692,7 +692,9 @@ export default function AuthScreen({ initialMode }: { initialMode: Mode }) {
 								className="mt-10"
 								style={{ marginTop: otpButtonMarginTop }}
 							>
-								<Text>{isLoading ? "Prüft..." : "Code bestätigen"}</Text>
+								<Text>
+									{isLoading ? "Code wird geprüft..." : "Code bestätigen"}
+								</Text>
 							</Button>
 						</KeyboardSafeScrollView>
 					</View>
@@ -1042,7 +1044,7 @@ export default function AuthScreen({ initialMode }: { initialMode: Mode }) {
 					>
 						<Text>
 							{isLoading
-								? "Lädt..."
+								? "Wird geladen..."
 								: isRegisterIdentityStep
 									? "Weiter"
 									: isRegisterMode

--- a/src/features/learning-plans/learning-plan-ui.tsx
+++ b/src/features/learning-plans/learning-plan-ui.tsx
@@ -248,7 +248,7 @@ export function SessionEditForm({
 				{getSessionEditTitle({ ...session, phase: editPhase })}
 			</Text>
 			<Text className="mt-2 mb-7 font-poppins text-14 text-text/42">
-				Hier kannst du individuell deinen Lernplan anpassen, so wie es passt
+				Passe deinen Lernplan so an, wie er für dich passt.
 			</Text>
 
 			<FieldLabel>Lerndatum</FieldLabel>

--- a/src/features/learning-plans/quiz-step.tsx
+++ b/src/features/learning-plans/quiz-step.tsx
@@ -134,7 +134,7 @@ export function QuizStep({
 					<Textarea
 						value={answer}
 						onChangeText={onAnswerChange}
-						placeholder="Schreibe hier deine Antwort rein..."
+						placeholder="Schreibe hier deine Antwort."
 						style={{ height: ANSWER_TEXTAREA_HEIGHT }}
 					/>
 				</FieldControl>


### PR DESCRIPTION
## Summary
- Aligned the app’s user-facing copy with the Figma intent where it was already correct.
- Corrected grammar, punctuation, and terminology across onboarding, auth, home, settings, entry creation, learning times, and learning plans.
- Replaced rough placeholder text and mixed-language labels with cleaner German copy.

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI & Text Improvements**
  * Enhanced German language text across authentication, onboarding, learning plans, settings, and other screens for improved consistency.
  * Refined button labels, helper text, and loading state messages to provide clearer user guidance throughout the app.
  * Updated input placeholders and dialog descriptions for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->