### PR TITLE
Avoid duplicate before-event reminders after offset changes

### DIFF
--- a/convex/notifications.test.ts
+++ b/convex/notifications.test.ts
@@ -92,6 +92,46 @@ test("due entry reminders create one unread in-app notification", async () => {
 	]);
 });
 
+test("changing reminder offset does not duplicate an already-created before-event notification", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+
+	await t.mutation(api.dayEntries.create, {
+		dayKey: "2026-06-16",
+		title: "Mathe Hausaufgabe",
+		time: "16:00",
+		kind: "Hausaufgabe",
+		plannedDateLabel: "16. Juni 2026",
+		durationMinutes: 45,
+	});
+
+	await expect(
+		t.mutation(api.notifications.syncDueNotifications, {
+			now: "2026-06-16T15:45:00.000Z",
+			localDayKey: "2026-06-16",
+			localMinutes: 15 * 60 + 45,
+		}),
+	).resolves.toEqual({ created: 1 });
+
+	await t.mutation(api.notifications.updatePreferences, {
+		reminderOffsetMinutes: 30,
+	});
+
+	await expect(
+		t.mutation(api.notifications.syncDueNotifications, {
+			now: "2026-06-16T15:46:00.000Z",
+			localDayKey: "2026-06-16",
+			localMinutes: 15 * 60 + 46,
+		}),
+	).resolves.toEqual({ created: 0 });
+
+	const inbox = await t.query(api.notifications.listInbox, { category: "all" });
+	expect(inbox).toHaveLength(1);
+	expect(inbox[0]).toMatchObject({
+		type: "beforeEvent",
+		body: "Mathe Hausaufgabe startet in 15 Minuten.",
+	});
+});
+
 test("forgotten event notifications are created only for incomplete entries", async () => {
 	const t = convexTest(schema, modules).withIdentity(user);
 

--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -441,7 +441,7 @@ export const syncDueNotifications = mutation({
 				) {
 					const didCreate = await insertNotificationOnce(ctx, {
 						ownerTokenIdentifier,
-						eventKey: `before:${entry._id}:${preferences.reminderOffsetMinutes}`,
+						eventKey: `before:${entry._id}`,
 						category: getEntryNotificationCategory(entry),
 						type: "beforeEvent",
 						title: getBeforeEventTitle(entry),

--- a/src/lib/local-notification-scheduler.test.ts
+++ b/src/lib/local-notification-scheduler.test.ts
@@ -22,7 +22,7 @@ test("syncPlannedLocalNotifications replaces Dayova-owned scheduled notification
 	};
 	const plan: PlannedLocalNotification[] = [
 		{
-			key: "before:entry-1:15",
+			key: "before:entry-1",
 			type: "beforeEvent",
 			category: "task",
 			title: "Hausaufgabe",
@@ -44,7 +44,7 @@ test("syncPlannedLocalNotifications replaces Dayova-owned scheduled notification
 			title: "Hausaufgabe",
 			body: "Mathe Hausaufgabe startet in 15 Minuten.",
 			data: {
-				dayovaNotificationKey: "before:entry-1:15",
+				dayovaNotificationKey: "before:entry-1",
 				type: "beforeEvent",
 				category: "task",
 				relatedEntryId: "entry-1",

--- a/src/lib/notification-planner.test.ts
+++ b/src/lib/notification-planner.test.ts
@@ -44,7 +44,7 @@ test("local notification planner creates briefing, before-event, and forgotten r
 
 	expect(plan.map((notification) => notification.key)).toEqual([
 		"briefing:2026-06-16:07:30",
-		"before:entry-1:15",
+		"before:entry-1",
 		"forgotten:entry-1",
 	]);
 	expect(plan.map((notification) => notification.triggerAt.getHours())).toEqual([

--- a/src/lib/notification-planner.ts
+++ b/src/lib/notification-planner.ts
@@ -156,7 +156,7 @@ export const buildLocalNotificationPlan = ({
 				if (beforeDate && beforeDate.getTime() > now.getTime()) {
 					const eventTitle = getEventTitle(entry);
 					plan.push({
-						key: `before:${entry.id}:${preferences.reminderOffsetMinutes}`,
+						key: `before:${entry.id}`,
 						type: "beforeEvent",
 						category: getCategory(entry),
 						title: eventTitle,


### PR DESCRIPTION
### Motivation

- Prevent creating duplicate in-app "before-event" notifications when a user changes the `reminderOffsetMinutes` preference after a before-event notification has already been created. 
- Keep on-device scheduled notification metadata aligned with Convex inbox de-duplication so preference edits still allow rescheduling without producing extra inbox items. 

### Description

- Use a stable per-entry before-event event key `before:<entryId>` in the Convex mutation `syncDueNotifications` and in local planner output so de-duplication ignores the reminder offset value. 
- Update the local notification planner to emit `key: "before:<entryId>"` and adjust the local notification scheduler expectations to include the same stable key in scheduled notification `data.dayovaNotificationKey`. 
- Add a regression test `changing reminder offset does not duplicate an already-created before-event notification` to `convex/notifications.test.ts` that asserts updating `reminderOffsetMinutes` does not create a second inbox notification. 

### Testing

- Ran unit tests with `pnpm test src/lib/notification-planner.test.ts src/lib/local-notification-scheduler.test.ts convex/notifications.test.ts` and all tests passed (`3 files, 9 tests`).
- Ran full checks with `pnpm check` (lint + `tsc --noEmit`) and the checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a281e3f0d8c832292a24895936b0088)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where changing your reminder offset would create duplicate before-event notifications instead of updating the existing one.

* **Tests**
  * Added test coverage for notification deduplication when reminder preferences change.
  * Updated test expectations to reflect new notification key format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->