### PR TITLE
[codex] Remove duplicate warning colour token

### DIFF
--- a/docs/contexts/design-system/CONTEXT.md
+++ b/docs/contexts/design-system/CONTEXT.md
@@ -30,14 +30,14 @@ The Figma light palette is the source of truth: background `#F6F6F4`, light 1
 `#FFFFFF`, light 2 `#F3F6FA`, light 3 `#FAFAFC`, border `#DCE6EE`, path 1/2
 `#D7DCE3`, path 3 `#8A8D92`, path 4/secondary text `#697586`, path 5/primary
 strong `#00A0E6`, path 6/primary/system cyan `#00BAFF`, path 7 `#4FD8FF`, and
-primary text `#1A1A1A`. The Figma orange `#FF9500` is the `wrong`/warning
-status color; `destructive` remains a separate functional action/error token.
+primary text `#1A1A1A`. The Figma orange `#FF9500` is the `wrong` status color;
+`destructive` remains a separate functional action/error token.
 Dark-mode variables and classes should not be introduced until the dark-mode
 design is finalized.
 
-Badge fills use wrong/warning `#FF9500`, info `#C9A100`, system `#00BAFF`,
-success `#34C759`, theorie `#5856D6`, ueben `#AF52DE`, praxis `#00C7BE`, and
-hausaufgabe `#B88AAE`. Badge subtle fills match Figma exactly: wrong/warning
+Badge fills use wrong `#FF9500`, info `#C9A100`, system `#00BAFF`, success
+`#34C759`, theorie `#5856D6`, ueben `#AF52DE`, praxis `#00C7BE`, and
+hausaufgabe `#B88AAE`. Badge subtle fills match Figma exactly: wrong
 `#FFECD6`, info `#FFF8CC`, system `#F1F7FB`, success `#EAFFF1`, theorie
 `#EEECFF`, ueben `#F4ECFF`, praxis `#E7FBF6`, and hausaufgabe `#F3E8F0`.
 

--- a/src/components/ui/warning-banner.tsx
+++ b/src/components/ui/warning-banner.tsx
@@ -28,7 +28,7 @@ function WarningBanner({
 	return (
 		<View
 			className={cn(
-				"flex-row items-start gap-4 rounded-[28px] bg-warning-subtle px-5 py-5",
+				"flex-row items-start gap-4 rounded-[28px] bg-info-subtle px-5 py-5",
 				className,
 			)}
 			style={style}
@@ -37,7 +37,7 @@ function WarningBanner({
 			<View className="h-10 w-10 items-center justify-center rounded-full bg-card/65">
 				<CircleAlert
 					size={21}
-					color={DAYOVA_DESIGN_SYSTEM.colors.warning}
+					color={DAYOVA_DESIGN_SYSTEM.colors.info}
 					strokeWidth={2.2}
 				/>
 			</View>

--- a/src/global.css
+++ b/src/global.css
@@ -55,8 +55,6 @@
 		--success-subtle: 140 100% 95.9%;
 		--wrong: 35.1 100% 50%;
 		--wrong-subtle: 32.2 100% 92%;
-		--warning: 35.1 100% 50%;
-		--warning-subtle: 32.2 100% 92%;
 		--info: 48.1 100% 39.4%;
 		--info-subtle: 51.8 100% 90%;
 		--system: 196.2 100% 50%;

--- a/src/lib/design-system.ts
+++ b/src/lib/design-system.ts
@@ -24,8 +24,6 @@ export const DAYOVA_DESIGN_SYSTEM = {
 		successSubtle: "#EAFFF1",
 		wrong: "#FF9500",
 		wrongSubtle: "#FFECD6",
-		warning: "#FF9500",
-		warningSubtle: "#FFECD6",
 		destructive: "#FF3B30",
 		info: "#C9A100",
 		infoSubtle: "#FFF8CC",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -54,10 +54,6 @@ const config = {
 					DEFAULT: "hsl(var(--wrong))",
 					subtle: "hsl(var(--wrong-subtle))",
 				},
-				warning: {
-					DEFAULT: "hsl(var(--warning))",
-					subtle: "hsl(var(--warning-subtle))",
-				},
 				info: {
 					DEFAULT: "hsl(var(--info))",
 					subtle: "hsl(var(--info-subtle))",


### PR DESCRIPTION
## Summary

- Removed the duplicated `warning`/`warningSubtle` colour tokens from the design-system constants, Tailwind palette, and global CSS variables.
- Updated the newly shared `WarningBanner` component to use the existing `info` colour token for advisory banner styling.
- Kept the new `PlanningHintBanner`/shared-banner system from PR #140 intact, so learning-plan hints and notification guidance now pick up the semantic colour change from one place.
- Updated the design-system context docs so `#FF9500` is documented only as the `wrong` status colour.

## Why

The `warning` token duplicated the `wrong` colour values, which made the design system carry two names for the same visual role. After PR #140 introduced a reusable warning banner system, the right integration point is the shared banner component rather than the individual screens.

## Impact

- Design tokens now have one canonical orange status colour: `wrong`.
- Advisory banners rendered through the shared banner system now use the yellow `info` colour instead of the orange `wrong` duplicate.
- Tailwind no longer exposes `warning` classes, so new UI should choose the more specific `info`, `wrong`, or `destructive` token.
- The PR is rebased onto the current `release-v-1.0.3` branch so it works with the reusable warning-link changes from PR #140.

## Validation

- `env PATH="/Users/jakobroessner/.local/share/fnm/node-versions/v22.23.1/installation/bin:$PATH" node_modules/.bin/tsc --noEmit`
- `env PATH="/Users/jakobroessner/.local/share/fnm/node-versions/v22.23.1/installation/bin:$PATH" node_modules/.bin/biome lint .`
- `env PATH="/Users/jakobroessner/.local/share/fnm/node-versions/v22.23.1/installation/bin:$PATH" node_modules/.bin/eslint src convex index.ts`

Note: `pnpm typecheck` could not run through the current shell because the active global runtime is Node 24 with pnpm 11, while the repo expects Node >=22 <24 and pnpm 10. The checks above were run directly against the installed repo dependencies using local Node 22.23.1.

## Base branch

This PR targets `release-v-1.0.3` because the cleanup belongs on the release branch where the design-system and reusable warning-banner work has landed.