### PR TITLE
Fix exercise question card headspace

### DIFF
--- a/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
+++ b/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
@@ -5,9 +5,12 @@ import { StatusBar } from "expo-status-bar";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	ActivityIndicator,
+	Dimensions,
+	Keyboard,
 	Platform,
 	ScrollView,
 	TouchableOpacity,
+	useWindowDimensions,
 	View,
 } from "react-native";
 import type {
@@ -35,6 +38,13 @@ import { Surface } from "~/components/ui/surface";
 import { Text } from "~/components/ui/text";
 import { Textarea } from "~/components/ui/textarea";
 import { useAuth } from "~/context/AuthContext";
+import {
+	getCenteredQuestionRegionHeight,
+	getQuestionContentWidth,
+	getStableViewportHeight,
+	sessionContentTopPadding,
+	sessionQuestionHorizontalPadding,
+} from "~/features/learning-plans/session-content-layout";
 import {
 	createTheoryCardQueue,
 	repeatCurrentTheoryCard as queueRepeatCurrentTheoryCard,
@@ -335,6 +345,7 @@ function TagPill({
 }
 
 function ActionRow({
+	className,
 	secondaryLabel,
 	primaryLabel,
 	onSecondary,
@@ -342,6 +353,7 @@ function ActionRow({
 	primaryDisabled,
 	isBusy,
 }: {
+	className?: string;
 	secondaryLabel: string;
 	primaryLabel: string;
 	onSecondary: () => void;
@@ -350,7 +362,7 @@ function ActionRow({
 	isBusy?: boolean;
 }) {
 	return (
-		<View className="mt-8 flex-row gap-3">
+		<View className={cn("mt-8 flex-row gap-3", className)}>
 			<Button
 				className="flex-1 px-4"
 				disabled={isBusy}
@@ -811,6 +823,11 @@ function AnalysisView({
 
 export default function LearningSessionContentScreen() {
 	const router = useRouter();
+	const { width: viewportWidth } = useWindowDimensions();
+	const [stableViewportHeight, setStableViewportHeight] = useState(
+		() => Dimensions.get("window").height,
+	);
+	const isKeyboardVisibleRef = useRef(Keyboard.isVisible());
 	const params = useLocalSearchParams<{
 		planId?: string;
 		sessionId?: string;
@@ -863,6 +880,40 @@ export default function LearningSessionContentScreen() {
 	const startSessionPromiseRef = useRef<ReturnType<typeof startSession> | null>(
 		null,
 	);
+
+	useEffect(() => {
+		const keyboardShowSubscription = Keyboard.addListener(
+			Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow",
+			() => {
+				isKeyboardVisibleRef.current = true;
+			},
+		);
+		const keyboardHideSubscription = Keyboard.addListener(
+			"keyboardDidHide",
+			() => {
+				isKeyboardVisibleRef.current = false;
+				setStableViewportHeight(Dimensions.get("window").height);
+			},
+		);
+		const subscription = Dimensions.addEventListener("change", ({ window }) => {
+			// Android resize mode reports a smaller window while typing. Freeze the
+			// question geometry only for that keyboard-driven resize; real window
+			// changes must still be accepted for multi-window and foldable layouts.
+			setStableViewportHeight((currentHeight) =>
+				getStableViewportHeight(
+					currentHeight,
+					window.height,
+					isKeyboardVisibleRef.current || Keyboard.isVisible(),
+				),
+			);
+		});
+
+		return () => {
+			keyboardShowSubscription.remove();
+			keyboardHideSubscription.remove();
+			subscription.remove();
+		};
+	}, []);
 
 	const recognizerCallbacks = useMemo<RecognizerCallbacks>(
 		() => ({
@@ -1323,6 +1374,21 @@ export default function LearningSessionContentScreen() {
 			: content
 				? phaseTitle(content.session.phase)
 				: "Lernblock";
+	const isQuestionVisible = Boolean(
+		content &&
+			!showAnalysis &&
+			!completionPhase &&
+			!visibleAttempt &&
+			currentItem &&
+			currentItem.kind !== "learnCard",
+	);
+	const centeredQuestionRegionHeight =
+		getCenteredQuestionRegionHeight(stableViewportHeight);
+	// Runtime viewport geometry is a documented style-prop exception.
+	const questionColumnStyle = useMemo(
+		() => ({ width: getQuestionContentWidth(viewportWidth) }),
+		[viewportWidth],
+	);
 
 	return (
 		<View className="flex-1 bg-background">
@@ -1332,14 +1398,18 @@ export default function LearningSessionContentScreen() {
 				className="flex-1"
 				contentContainerStyle={{
 					flexGrow: 1,
-					paddingHorizontal: 32,
-					paddingTop: 80,
+					paddingHorizontal: isQuestionVisible
+						? sessionQuestionHorizontalPadding
+						: 32,
+					paddingTop: sessionContentTopPadding,
 					paddingBottom: 60,
 				}}
 				keyboardShouldPersistTaps="handled"
 				showsVerticalScrollIndicator={false}
 			>
 				<ScreenHeader
+					className={isQuestionVisible ? "self-center" : undefined}
+					runtimeStyle={isQuestionVisible ? questionColumnStyle : undefined}
 					title={title}
 					onBack={goBack}
 					right={
@@ -1407,49 +1477,55 @@ export default function LearningSessionContentScreen() {
 						/>
 					</View>
 				) : currentItem ? (
-					<View className="flex-1 justify-between">
-						<Surface className="rounded-[32px] px-6 py-8" variant="flat">
-							<TagPill label="Frage" icon="question" />
-							<Text className="mt-8 font-poppins font-semibold text-body-1 text-text">
-								{currentItem.prompt}
-							</Text>
-							<View className="my-7 h-px bg-border" />
+					<View className="self-center" style={questionColumnStyle}>
+						<View
+							className="shrink-0 justify-center"
+							style={{ minHeight: centeredQuestionRegionHeight }}
+						>
+							<Surface className="rounded-[32px] px-6 py-8" variant="flat">
+								<TagPill label="Frage" icon="question" />
+								<Text className="mt-8 font-poppins font-semibold text-body-1 text-text">
+									{currentItem.prompt}
+								</Text>
+								<View className="my-7 h-px bg-border" />
 
-							{currentItem.kind === "multipleChoice" ? (
-								<ChoiceList
-									item={currentItem}
-									selectedChoiceId={selectedChoiceId}
-									onSelect={setSelectedChoiceId}
-									disabled={isBusy}
-								/>
-							) : currentItem.kind === "voice" ? (
-								<VoiceAnswer
-									value={answerText}
-									onChange={setAnswerText}
-									editable={!isBusy}
-									isRecognizing={isRecognizing}
-									speechErrorMessage={speechErrorMessage}
-									speechCaptureUnavailableMessage={
-										speechCaptureUnavailableMessage
-									}
-									onToggleRecording={toggleVoiceRecording}
-								/>
-							) : (
-								<TextAnswer
-									value={answerText}
-									onChange={setAnswerText}
-									placeholder="Schreibe hier deine Antwort."
-									editable={!isBusy}
-								/>
-							)}
-						</Surface>
+								{currentItem.kind === "multipleChoice" ? (
+									<ChoiceList
+										item={currentItem}
+										selectedChoiceId={selectedChoiceId}
+										onSelect={setSelectedChoiceId}
+										disabled={isBusy}
+									/>
+								) : currentItem.kind === "voice" ? (
+									<VoiceAnswer
+										value={answerText}
+										onChange={setAnswerText}
+										editable={!isBusy}
+										isRecognizing={isRecognizing}
+										speechErrorMessage={speechErrorMessage}
+										speechCaptureUnavailableMessage={
+											speechCaptureUnavailableMessage
+										}
+										onToggleRecording={toggleVoiceRecording}
+									/>
+								) : (
+									<TextAnswer
+										value={answerText}
+										onChange={setAnswerText}
+										placeholder="Schreibe hier deine Antwort."
+										editable={!isBusy}
+									/>
+								)}
+							</Surface>
 
-						{errorMessage ? (
-							<Text className="mt-4 font-poppins text-body-4 text-destructive">
-								{errorMessage}
-							</Text>
-						) : null}
+							{errorMessage ? (
+								<Text className="mt-4 font-poppins text-body-4 text-destructive">
+									{errorMessage}
+								</Text>
+							) : null}
+						</View>
 						<ActionRow
+							className="mt-0"
 							secondaryLabel="Weiß ich nicht"
 							primaryLabel={
 								content.session.phase === "rehearsal"

--- a/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
+++ b/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
@@ -1408,7 +1408,7 @@ export default function LearningSessionContentScreen() {
 					</View>
 				) : currentItem ? (
 					<View className="flex-1 justify-between">
-						<Surface className="mt-24 rounded-[32px] px-6 py-8" variant="flat">
+						<Surface className="rounded-[32px] px-6 py-8" variant="flat">
 							<TagPill label="Frage" icon="question" />
 							<Text className="mt-8 font-poppins font-semibold text-body-1 text-text">
 								{currentItem.prompt}

--- a/src/components/screen-header.tsx
+++ b/src/components/screen-header.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { View } from "react-native";
+import { type StyleProp, View, type ViewStyle } from "react-native";
 import { BackButton } from "~/components/ui/button";
 import { Text } from "~/components/ui/text";
 
@@ -9,6 +9,7 @@ export function ScreenHeader({
 	right,
 	showBack = true,
 	className = "mb-7",
+	runtimeStyle,
 	titleClassName,
 }: {
 	title?: string;
@@ -16,10 +17,15 @@ export function ScreenHeader({
 	right?: ReactNode;
 	showBack?: boolean;
 	className?: string;
+	// Reserved for caller-computed viewport geometry; static styling belongs in className.
+	runtimeStyle?: StyleProp<ViewStyle>;
 	titleClassName?: string;
 }) {
 	return (
-		<View className={`relative min-h-12 justify-center ${className}`}>
+		<View
+			className={`relative min-h-12 justify-center ${className}`}
+			style={runtimeStyle}
+		>
 			{showBack ? (
 				<View className="absolute left-0 z-10">
 					<BackButton onPress={onBack} />

--- a/src/features/learning-plans/session-content-layout.test.ts
+++ b/src/features/learning-plans/session-content-layout.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import {
+	getCenteredQuestionRegionCenter,
+	getCenteredQuestionRegionHeight,
+	getQuestionContentWidth,
+	getStableViewportHeight,
+} from "./session-content-layout";
+
+describe("session content layout", () => {
+	test.each([
+		[812, 556],
+		[852, 596],
+		[874, 618],
+	])("centers the question region in a %i point viewport", (viewportHeight, expectedRegionHeight) => {
+		expect(getCenteredQuestionRegionHeight(viewportHeight)).toBe(
+			expectedRegionHeight,
+		);
+	});
+
+	test("lets very short viewports fall back to natural content height", () => {
+		expect(getCenteredQuestionRegionHeight(240)).toBe(0);
+	});
+
+	test("centers the reference region on the Figma viewport", () => {
+		expect(getCenteredQuestionRegionCenter(852)).toBe(426);
+	});
+
+	test.each([
+		[375, 327],
+		[393, 345],
+		[402, 345],
+		[768, 345],
+	])("uses a responsive, capped question width in a %i point viewport", (viewportWidth, expectedContentWidth) => {
+		expect(getQuestionContentWidth(viewportWidth)).toBe(expectedContentWidth);
+	});
+
+	test("ignores only keyboard-driven viewport height reductions", () => {
+		expect(getStableViewportHeight(874, 512, true)).toBe(874);
+		expect(getStableViewportHeight(874, 512, false)).toBe(512);
+		expect(getStableViewportHeight(812, 874, false)).toBe(874);
+	});
+});

--- a/src/features/learning-plans/session-content-layout.ts
+++ b/src/features/learning-plans/session-content-layout.ts
@@ -1,0 +1,25 @@
+export const sessionContentTopPadding = 80;
+export const sessionQuestionHorizontalPadding = 24;
+export const sessionQuestionMaxWidth = 345;
+
+const sessionHeaderHeight = 48;
+const centeredQuestionTopInset = sessionContentTopPadding + sessionHeaderHeight;
+
+export const getCenteredQuestionRegionHeight = (viewportHeight: number) =>
+	Math.max(0, viewportHeight - 2 * centeredQuestionTopInset);
+
+export const getCenteredQuestionRegionCenter = (viewportHeight: number) =>
+	centeredQuestionTopInset +
+	getCenteredQuestionRegionHeight(viewportHeight) / 2;
+
+export const getQuestionContentWidth = (viewportWidth: number) =>
+	Math.min(
+		sessionQuestionMaxWidth,
+		Math.max(0, viewportWidth - 2 * sessionQuestionHorizontalPadding),
+	);
+
+export const getStableViewportHeight = (
+	stableViewportHeight: number,
+	observedViewportHeight: number,
+	isKeyboardVisible: boolean,
+) => (isKeyboardVisible ? stableViewportHeight : observedViewportHeight);


### PR DESCRIPTION
## Summary

* centers Üben/Praxis question cards on the full viewport to match the Figma vertical-center constraint
* keeps question content responsive with 24 pt side padding and a 345 pt maximum width
* keeps answer actions visible below the centered region while preserving ScrollView fallback for oversized content
* prevents keyboard-driven Android window resizing from moving the card, while still accepting genuine multi-window and foldable viewport changes

## Root cause

Removing the original fixed top margin eliminated the excessive headspace, but it left the card positioned directly after the header. The approved Figma frames instead constrain the card to the vertical center of the full screen. The final implementation derives a symmetric center region from the live viewport and keeps the header, card, and action widths aligned responsively.

## Verification

* `pnpm test` — 27 files, 128 tests passed
* `pnpm format:check`
* `pnpm typecheck`
* `pnpm lint`
* Matt Pocock two-axis review — Standards: 0 remaining findings; Spec: 0 findings
* CodeRabbit CLI final review — 0 findings
* CodeRabbit cloud review — 0 actionable comments
* GitHub/Expo CI — all 6 checks passed
* isolated iPhone 17 and iPhone 13 mini simulator QA via Computer Use
* full-timeline video inspection — 4.90 seconds; 10 frames at 2 fps; every sampled frame shows only the centered Üben card and the `x=2` → `x=4` selection change; no onboarding or unrelated screen

## Before — reported issue

The original issue screenshot shows the excessive blank space above the exercise question card.

<img src="https://uploads.linear.app/25636614-9b48-4853-ae2c-f1d96a015b4e/c9fad156-a70f-42a2-9004-6ce05a9042ad/014024b4-7202-4158-8fa3-2fb47232627f?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzI1NjM2NjE0LTliNDgtNDg1My1hZTJjLWYxZDk2YTAxNWI0ZS9jOWZhZDE1Ni1hNzBmLTQyYTItOTAwNC02Y2UwNWE5MDQyYWQvMDE0MDI0YjQtNzIwMi00MTU4LThmYTMtMmZiNDcyMzI2MjdmIiwiaWF0IjoxNzg0MjA2ODc4LCJleHAiOjE4MTU3Nzc0Mzh9.7ydqxqmc2iiz_YAbPJl9GHlqEocU1IN78xatRrTSLCw " alt="DAY-166 before fix — excessive headspace above the exercise question card" width="480" />

Source: [DAY-166 / GitHub issue #218](<https://github.com/Dayova/dayova-mvp/issues/218>)

## After — final visual evidence

### iPhone 17

<img src="https://github.com/user-attachments/assets/da215840-7dbf-4c21-b55a-1e3c97bf1f74 " alt="DAY-166 centered Üben card on iPhone 17" width="402" />

### iPhone 13 mini

<img src="https://github.com/user-attachments/assets/624b4f23-d167-4652-b524-5a36b2c15c42 " alt="DAY-166 centered Üben card on iPhone 13 mini" width="375" />

### Interaction recording

https://github.com/user-attachments/assets/12e2e24e-04b4-495a-90d9-e74fc8a1ec98

## Design references

* [Üben — Figma](<https://www.figma.com/design/hYwGEiBKByoJxqxrJcS69y/LernApp?node-id=1982-4947>)
* [Praxis — Figma](<https://www.figma.com/design/hYwGEiBKByoJxqxrJcS69y/LernApp?node-id=2077-2998>)
* [Lernkarten — intentionally unchanged](<https://www.figma.com/design/hYwGEiBKByoJxqxrJcS69y/LernApp?node-id=1937-2482>)

Dayova/dayova-mvp#218

Closes Dayova/dayova-mvp#218