### PR TITLE
Rebuild dashboard and learning path navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"expo-updates": "~56.0.19",
 		"nativewind": "^4.2.3",
 		"officeparser": "^6.1.0",
+		"phosphor-react-native": "3.0.6",
 		"posthog-react-native": "^4.50.0",
 		"react": "19.2.3",
 		"react-dom": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       officeparser:
         specifier: ^6.1.0
         version: 6.1.1
+      phosphor-react-native:
+        specifier: 3.0.6
+        version: 3.0.6(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       posthog-react-native:
         specifier: ^4.50.0
         version: 4.50.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3)))(expo-application@56.0.3(expo@56.0.12))(expo-device@56.0.4(expo@56.0.12))(expo-file-system@56.0.8(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3)))(expo-localization@56.0.6(expo@56.0.12)(react@19.2.3))(react-native-safe-area-context@5.7.0(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))
@@ -4897,6 +4900,13 @@ packages:
   pdfjs-dist@5.6.205:
     resolution: {integrity: sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==}
     engines: {node: '>=20.19.0 || >=22.13.0 || >=24'}
+
+  phosphor-react-native@3.0.6:
+    resolution: {integrity: sha512-mIhv+hBbDWz3yLbTOq/esVUkrMoKzEvLIcSeZo3YTdT+sbOBxzxKg5WZN3wpqt3pkkhKf0wVpOyZ3d9mNBNRhg==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+      react-native-svg: '*'
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -11496,6 +11506,12 @@ snapshots:
     optionalDependencies:
       '@napi-rs/canvas': 0.1.100
       node-readable-to-web-readable-stream: 0.4.2
+
+  phosphor-react-native@3.0.6(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3)
+      react-native-svg: 15.15.4(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
 
   picocolors@1.1.1: {}
 

--- a/src/app/(app)/home.tsx
+++ b/src/app/(app)/home.tsx
@@ -6,7 +6,6 @@ import {
 	type NativeScrollEvent,
 	type NativeSyntheticEvent,
 	ScrollView,
-	type StyleProp,
 	TouchableOpacity,
 	useWindowDimensions,
 	View,
@@ -29,6 +28,7 @@ import Svg, {
 } from "react-native-svg";
 import { api } from "#convex/_generated/api";
 import { CreateTypePickerModal } from "~/components/create-type-picker-modal";
+import { DashboardDateHeader } from "~/components/dashboard/dashboard-date-header";
 import { NotificationButton } from "~/components/notification-button";
 import { NotchedActionCard } from "~/components/ui/notched-action-card";
 import {
@@ -69,6 +69,7 @@ const TIMELINE_MARKER_HOURS = Array.from({ length: 25 }, (_, hour) => hour);
 const TIMELINE_PAST_DAYS = 3;
 const TIMELINE_FUTURE_DAYS = 14;
 const DAY_ENTRY_QUERY_BATCH_SIZE = 31;
+const HEADER_VISIBLE_DAYS = 7;
 const PRIMARY_INTERACTIVE_GRADIENT =
 	DAYOVA_DESIGN_SYSTEM.gradients.primaryInteractive;
 
@@ -82,55 +83,6 @@ const chunkArray = <T,>(items: T[], chunkSize: number) => {
 	}
 	return chunks;
 };
-
-function SideScrollIndicator({
-	scale,
-	style,
-}: {
-	scale: number;
-	style?: StyleProp<ViewStyle>;
-}) {
-	const { colors } = useDayovaTheme();
-
-	return (
-		<Svg
-			accessible={false}
-			accessibilityElementsHidden
-			importantForAccessibility="no-hide-descendants"
-			pointerEvents="none"
-			width={8 * scale}
-			height={36 * scale}
-			viewBox="0 0 8 36"
-			fill="none"
-			style={style}
-		>
-			<Path
-				d="M0 16H6C7.10457 16 8 16.8954 8 18C8 19.1046 7.10457 20 6 20H0V16Z"
-				fill={colors.text}
-			/>
-			<Path
-				d="M0 8H4C5.10457 8 6 8.89543 6 10C6 11.1046 5.10457 12 4 12H0V8Z"
-				fill={colors.text}
-				fillOpacity={0.35}
-			/>
-			<Path
-				d="M0 2H2C3.10457 2 4 2.89543 4 4C4 5.10457 3.10457 6 2 6H0V2Z"
-				fill={colors.text}
-				fillOpacity={0.15}
-			/>
-			<Path
-				d="M0 23H4C5.10457 23 6 23.8954 6 25C6 26.1046 5.10457 27 4 27H0V23Z"
-				fill={colors.text}
-				fillOpacity={0.35}
-			/>
-			<Path
-				d="M0 30H2C3.10457 30 4 30.8954 4 32C4 33.1046 3.10457 34 2 34H0V30Z"
-				fill={colors.text}
-				fillOpacity={0.15}
-			/>
-		</Svg>
-	);
-}
 
 function LearningSessionCard({
 	entry,
@@ -445,7 +397,6 @@ export default function HomeScreen() {
 		entry: DayEntry | null;
 	} | null>(null);
 	const timelineScrollRef = useRef<ScrollView | null>(null);
-	const dayStripScrollRef = useRef<ScrollView | null>(null);
 	const hasCenteredTimelineRef = useRef(false);
 	const pendingTimelineSelectionRef = useRef<string | null>(null);
 	const didCaptureDashboardViewRef = useRef(false);
@@ -561,9 +512,6 @@ export default function HomeScreen() {
 		};
 	});
 	const horizontalPadding = clamp((width - 369 * screenScale) / 2, 12, 24);
-	const headerInset = clamp(24 * screenScale - horizontalPadding, 0, 12);
-	const contentTop = Math.max(insets.top + 16 * heightScale, 48 * compactScale);
-	const sideHandleTop = contentTop + 170 * compactScale;
 	const planCardWidth = Math.min(
 		width - horizontalPadding * 2,
 		369 * screenScale,
@@ -595,25 +543,9 @@ export default function HomeScreen() {
 	const timelineHomeworkCardColor = isDark
 		? colors.hausaufgabeSubtle
 		: "#F3E8F0";
-	const dayStripGap = 10 * scheduleScale;
-	const getDayStripItemWidth = useCallback(
-		(_isToday?: boolean) => 42 * scheduleScale,
-		[scheduleScale],
-	);
-	const dayStripOffsets = useMemo(() => {
-		let offset = 0;
-		return visibleDays.map((day) => {
-			const dayOffset = offset;
-			offset += getDayStripItemWidth(day.isToday) + dayStripGap;
-			return dayOffset;
-		});
-	}, [dayStripGap, getDayStripItemWidth, visibleDays]);
-	const dayStripContentWidth =
-		dayStripOffsets[dayStripOffsets.length - 1] +
-		getDayStripItemWidth(visibleDays[visibleDays.length - 1]?.isToday ?? false);
 	const navClearance = Math.max(insets.bottom + 108 * screenScale, 132);
 	const scheduleInnerWidth = scheduleCardWidth - 24 * screenScale;
-	const scheduleCardHeight = 434 * compactScale;
+	const scheduleCardHeight = 400 * compactScale;
 	const selectedDayLabel = new Intl.DateTimeFormat("de-DE", {
 		weekday: "long",
 		day: "numeric",
@@ -622,12 +554,23 @@ export default function HomeScreen() {
 	const firstName =
 		typeof user?.name === "string" && user.name.trim().length > 0
 			? user.name.trim().split(/\s+/)[0]
-			: "Max";
+			: undefined;
 	const todayIndex = visibleDays.findIndex(
 		(day) => day.key === getDayKey(today),
 	);
 	const selectedDayIndex = visibleDays.findIndex(
 		(day) => day.key === selectedDayKey,
+	);
+	const headerCenterIndex =
+		selectedDayIndex >= 0 ? selectedDayIndex : Math.max(todayIndex, 0);
+	const headerStartIndex = clamp(
+		headerCenterIndex - Math.floor(HEADER_VISIBLE_DAYS / 2),
+		0,
+		Math.max(visibleDays.length - HEADER_VISIBLE_DAYS, 0),
+	);
+	const headerDays = visibleDays.slice(
+		headerStartIndex,
+		headerStartIndex + HEADER_VISIBLE_DAYS,
 	);
 	const selectedDayEntries = useMemo(
 		() =>
@@ -688,34 +631,6 @@ export default function HomeScreen() {
 		[timelineContentWidth, timelineViewportWidth],
 	);
 
-	const scrollDayStripToIndex = useCallback(
-		(dayIndex: number, animated = true) => {
-			const itemOffset = dayStripOffsets[dayIndex] ?? 0;
-			const itemWidth = getDayStripItemWidth(
-				visibleDays[dayIndex]?.isToday ?? false,
-			);
-			const maxScrollX = Math.max(
-				dayStripContentWidth - timelineViewportWidth,
-				0,
-			);
-			dayStripScrollRef.current?.scrollTo({
-				x: clamp(
-					itemOffset + itemWidth / 2 - timelineViewportWidth / 2,
-					0,
-					maxScrollX,
-				),
-				animated,
-			});
-		},
-		[
-			dayStripContentWidth,
-			dayStripOffsets,
-			getDayStripItemWidth,
-			timelineViewportWidth,
-			visibleDays,
-		],
-	);
-
 	const updateSelectedDayFromTimelineScroll = useCallback(
 		(event: NativeSyntheticEvent<NativeScrollEvent>) => {
 			if (dayWidth <= 0 || visibleDays.length === 0) return;
@@ -741,9 +656,8 @@ export default function HomeScreen() {
 			setSelectedDayKey((currentDayKey) =>
 				currentDayKey === centeredDayKey ? currentDayKey : centeredDayKey,
 			);
-			scrollDayStripToIndex(centeredDayIndex);
 		},
-		[dayWidth, scrollDayStripToIndex, timelineViewportWidth, visibleDays],
+		[dayWidth, timelineViewportWidth, visibleDays],
 	);
 
 	useEffect(() => {
@@ -755,23 +669,16 @@ export default function HomeScreen() {
 			return;
 		const frame = requestAnimationFrame(() => {
 			scrollTimelineToX(currentTimelineX, false);
-			scrollDayStripToIndex(todayIndex, false);
 			hasCenteredTimelineRef.current = true;
 		});
 		return () => cancelAnimationFrame(frame);
-	}, [
-		currentTimelineX,
-		scrollDayStripToIndex,
-		scrollTimelineToX,
-		timelineContentWidth,
-		todayIndex,
-	]);
+	}, [currentTimelineX, scrollTimelineToX, timelineContentWidth, todayIndex]);
 
 	const selectVisibleDay = useCallback(
 		(
 			dayKey: string,
 			dayIndex: number,
-			source: "day_strip" | "today_button" | "hero_handle" = "day_strip",
+			source: "date_header" | "today_button" | "date_swipe" = "date_header",
 		) => {
 			pendingTimelineSelectionRef.current = dayKey;
 			setSelectedDayKey(dayKey);
@@ -780,7 +687,6 @@ export default function HomeScreen() {
 			scrollTimelineToX(
 				dayIndex * dayWidth + (minuteToCenter / 60) * hourWidth,
 			);
-			scrollDayStripToIndex(dayIndex);
 			capture(
 				source === "today_button"
 					? "dashboard_today_selected"
@@ -792,22 +698,14 @@ export default function HomeScreen() {
 				},
 			);
 		},
-		[
-			capture,
-			currentMinute,
-			dayWidth,
-			hourWidth,
-			scrollDayStripToIndex,
-			scrollTimelineToX,
-			today,
-		],
+		[capture, currentMinute, dayWidth, hourWidth, scrollTimelineToX, today],
 	);
 
 	const clearPreviousBlueContainer = useCallback(() => {
 		setPreviousBlueContainer(null);
 	}, []);
 
-	const navigateHeroDay = useCallback(
+	const navigateSelectedDay = useCallback(
 		(direction: 1 | -1) => {
 			const baseIndex =
 				selectedDayIndex >= 0 ? selectedDayIndex : Math.max(todayIndex, 0);
@@ -827,7 +725,7 @@ export default function HomeScreen() {
 			});
 			blueCardSlideDirection.set(direction);
 			blueCardSlide.set(0);
-			selectVisibleDay(nextDay.key, nextIndex, "hero_handle");
+			selectVisibleDay(nextDay.key, nextIndex, "date_swipe");
 			blueCardSlide.set(
 				withTiming(1, { duration: 420 }, () => {
 					"worklet";
@@ -888,35 +786,19 @@ export default function HomeScreen() {
 					paddingHorizontal: horizontalPadding,
 				}}
 			>
-				<View
-					className="flex-row items-start justify-between"
-					// Runtime-scaled typography keeps this dense home layout fitting device width.
-					style={{ paddingHorizontal: headerInset }}
-				>
-					<View>
-						<Text
-							className="font-poppins font-semibold text-text"
-							// Runtime-scaled typography keeps this dense home layout fitting device width.
-							style={{
-								fontSize: 24 * screenScale,
-								lineHeight: 36 * screenScale,
-							}}
-						>
-							{`Hi ${firstName},`}
-						</Text>
-						<Text
-							className="font-poppins text-secondary-text"
-							// Runtime-scaled typography keeps this dense home layout fitting device width.
-							style={{
-								fontSize: 16 * screenScale,
-								lineHeight: 24 * screenScale,
-							}}
-						>
-							schön, dass du da bist!
-						</Text>
-					</View>
-					<NotificationButton />
-				</View>
+				<DashboardDateHeader
+					days={headerDays}
+					firstName={firstName}
+					notificationButton={<NotificationButton />}
+					onSelectDay={(dayKey) => {
+						const dayIndex = visibleDays.findIndex((day) => day.key === dayKey);
+						if (dayIndex >= 0)
+							selectVisibleDay(dayKey, dayIndex, "date_header");
+					}}
+					onSwipeDay={navigateSelectedDay}
+					scale={screenScale}
+					selectedDayKey={selectedDayKey}
+				/>
 
 				<View className="items-center">
 					<LearningSessionCard
@@ -1138,92 +1020,17 @@ export default function HomeScreen() {
 							</View>
 						</View>
 
-						<ScrollView
-							ref={dayStripScrollRef}
-							horizontal
-							showsHorizontalScrollIndicator={false}
-							style={{ marginTop: 23 * compactScale, alignSelf: "center" }}
-							contentContainerStyle={{ width: dayStripContentWidth }}
+						<Text
+							className="ml-3 font-poppins text-secondary-text"
+							selectable
+							style={{
+								marginTop: 23 * compactScale,
+								fontSize: 14 * screenScale,
+								lineHeight: 21 * screenScale,
+							}}
 						>
-							<View
-								className="flex-row"
-								style={{
-									columnGap: dayStripGap,
-									width: dayStripContentWidth,
-								}}
-							>
-								{visibleDays.map((day, dayIndex) => {
-									const selected = selectedDayKey === day.key;
-									const itemWidth = 42 * scheduleScale;
-									const content = (
-										<Text
-											key={`${day.key}-label`}
-											className={`font-poppins font-semibold ${selected ? "text-white" : "text-text"}`}
-											style={{
-												fontSize: 16 * screenScale,
-												lineHeight: 24 * screenScale,
-											}}
-										>
-											{day.dayOfMonth}
-										</Text>
-									);
-
-									return (
-										<View
-											key={day.key}
-											className="items-center"
-											style={{ width: itemWidth, rowGap: 4 * compactScale }}
-										>
-											<Text
-												className="font-poppins font-semibold text-secondary-text"
-												style={{
-													fontSize: 12 * screenScale,
-													lineHeight: 18 * screenScale,
-												}}
-											>
-												{day.weekday}
-											</Text>
-											<TouchableOpacity
-												activeOpacity={0.82}
-												accessibilityRole="button"
-												accessibilityState={{ selected }}
-												accessibilityLabel={`${day.weekday}, ${day.dayOfMonth}`}
-												onPress={() =>
-													selectVisibleDay(day.key, dayIndex, "day_strip")
-												}
-											>
-												{selected ? (
-													<LinearGradient
-														colors={PRIMARY_INTERACTIVE_GRADIENT.colors}
-														start={PRIMARY_INTERACTIVE_GRADIENT.start}
-														end={PRIMARY_INTERACTIVE_GRADIENT.end}
-														style={{
-															width: itemWidth,
-															height: 42 * screenScale,
-															borderRadius: 99,
-															alignItems: "center",
-															justifyContent: "center",
-														}}
-													>
-														{content}
-													</LinearGradient>
-												) : (
-													<View
-														className="items-center justify-center rounded-full"
-														style={{
-															width: itemWidth,
-															height: 42 * screenScale,
-														}}
-													>
-														{content}
-													</View>
-												)}
-											</TouchableOpacity>
-										</View>
-									);
-								})}
-							</View>
-						</ScrollView>
+							{selectedDayLabel}
+						</Text>
 
 						<View
 							className="overflow-hidden bg-light-2"
@@ -1469,53 +1276,6 @@ export default function HomeScreen() {
 					</View>
 				</View>
 			</ScrollView>
-
-			<View
-				className="absolute"
-				style={{
-					left: 0,
-					top: sideHandleTop,
-					width: 32 * screenScale,
-					height: 84 * screenScale,
-					zIndex: 50,
-				}}
-			>
-				<SideScrollIndicator
-					scale={screenScale}
-					style={{
-						position: "absolute",
-						left: 0,
-						top: 24 * screenScale,
-					}}
-				/>
-				<TouchableOpacity
-					accessibilityRole="button"
-					accessibilityLabel="Nächsten Tag anzeigen"
-					activeOpacity={0.5}
-					onPress={() => navigateHeroDay(1)}
-					style={{
-						position: "absolute",
-						left: 0,
-						top: 0,
-						width: 32 * screenScale,
-						height: 42 * screenScale,
-					}}
-				/>
-				<TouchableOpacity
-					accessibilityRole="button"
-					accessibilityLabel="Vorherigen Tag anzeigen"
-					activeOpacity={0.5}
-					onPress={() => navigateHeroDay(-1)}
-					style={{
-						position: "absolute",
-						left: 0,
-						bottom: 0,
-						width: 32 * screenScale,
-						height: 42 * screenScale,
-					}}
-				/>
-			</View>
-
 			<CreateTypePickerModal
 				visible={showCreateTypePicker}
 				onRequestClose={() => setShowCreateTypePicker(false)}

--- a/src/app/learning-plans/[planId]/index.tsx
+++ b/src/app/learning-plans/[planId]/index.tsx
@@ -3,23 +3,24 @@ import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
 import {
 	ActivityIndicator,
-	Pressable,
 	ScrollView,
 	View,
 	type ViewStyle,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import Svg, { Path } from "react-native-svg";
 import { api } from "#convex/_generated/api";
 import type { Id } from "#convex/_generated/dataModel";
+import {
+	getCurrentLearningPathIndex,
+	getLearningPathNodeState,
+} from "~/components/learning-plans/learning-path-layout";
+import { LearningPath } from "~/components/learning-plans/learning-path";
 import { ScreenHeader } from "~/components/screen-header";
 import {
 	ArrowUpRight,
 	BookOpen,
 	Dumbbell,
-	Note,
 	Rocket,
-	SquareLock,
 	Time04,
 } from "~/components/ui/icon";
 import { CompactNotchedActionCard } from "~/components/ui/notched-action-card";
@@ -76,12 +77,12 @@ const getSessionRoute = (
 
 function SessionPreviewCard({
 	canOpen,
-	session,
 	onOpen,
+	session,
 }: {
 	canOpen: boolean;
-	session: PlanSession;
 	onOpen: () => void;
+	session: PlanSession;
 }) {
 	const { colors } = useDayovaTheme();
 	const phase = PHASE_COLOR[session.phase];
@@ -110,13 +111,10 @@ function SessionPreviewCard({
 				/>
 			}
 			actionOffsetBottom={4}
+			cardHeight={SESSION_PREVIEW_CARD_HEIGHT}
+			cardStyle={{ paddingTop: 22, paddingBottom: 24 }}
 			onPress={onOpen}
 			pressType="action"
-			cardHeight={SESSION_PREVIEW_CARD_HEIGHT}
-			cardStyle={{
-				paddingTop: 22,
-				paddingBottom: 24,
-			}}
 		>
 			<View className="gap-2">
 				<View className="flex-row items-start justify-between gap-3">
@@ -167,408 +165,6 @@ function SessionPreviewCard({
 	);
 }
 
-type PathNodeState = "completed" | "current" | "locked";
-
-const PATH_NODE_STATE_LABEL: Record<PathNodeState, string> = {
-	completed: "abgeschlossen",
-	current: "verfügbar",
-	locked: "gesperrt",
-};
-
-type PathNodeFrame = {
-	left: number;
-	top: number;
-	width: number;
-	height: number;
-};
-
-const FIGMA_PATH_WIDTH = 345;
-const FIGMA_PATH_HEIGHT = 444;
-const FIGMA_PATH_CYCLE_HEIGHT = 384;
-const FIGMA_FIRST_NODE_FRAME = {
-	left: 138.5,
-	top: 0,
-	width: 68,
-	height: 64,
-} satisfies PathNodeFrame;
-const FIGMA_REPEATING_NODE_FRAMES = [
-	{ left: 237, top: 88, width: 100, height: 92 },
-	{ left: 138.5, top: 204, width: 68, height: 64 },
-	{ left: 24, top: 292, width: 68, height: 64 },
-	{ left: 138.5, top: 380, width: 68, height: 64 },
-] satisfies PathNodeFrame[];
-
-const getFigmaNodeFrame = (index: number): PathNodeFrame => {
-	if (index === 0) return FIGMA_FIRST_NODE_FRAME;
-
-	const repeatingIndex = (index - 1) % FIGMA_REPEATING_NODE_FRAMES.length;
-	const cycle = Math.floor((index - 1) / FIGMA_REPEATING_NODE_FRAMES.length);
-	const frame =
-		FIGMA_REPEATING_NODE_FRAMES[repeatingIndex] ??
-		FIGMA_REPEATING_NODE_FRAMES[0];
-
-	return {
-		...frame,
-		top: frame.top + cycle * FIGMA_PATH_CYCLE_HEIGHT,
-	};
-};
-
-const getFigmaSegmentPath = (index: number) => {
-	const segmentIndex = index % FIGMA_REPEATING_NODE_FRAMES.length;
-	const y =
-		Math.floor(index / FIGMA_REPEATING_NODE_FRAMES.length) *
-		FIGMA_PATH_CYCLE_HEIGHT;
-
-	if (segmentIndex === 0) {
-		return `M 206 ${26 + y} H 249 Q 289 ${26 + y} 289 ${66 + y} V ${102 + y}`;
-	}
-	if (segmentIndex === 1) {
-		return `M 289 ${158 + y} V ${194 + y} Q 289 ${234 + y} 249 ${234 + y} H 206`;
-	}
-	if (segmentIndex === 2) {
-		return `M 139 ${230 + y} H 96 Q 56 ${230 + y} 56 ${270 + y} V ${293 + y}`;
-	}
-
-	return `M 56 ${348 + y} V ${370 + y} Q 56 ${410 + y} 96 ${410 + y} H 139`;
-};
-
-const getFigmaPathHeight = (sessionCount: number) => {
-	const lastFrame = getFigmaNodeFrame(Math.max(sessionCount - 1, 0));
-
-	return Math.max(FIGMA_PATH_HEIGHT, lastFrame.top + lastFrame.height + 20);
-};
-
-const getCurrentSessionIndex = (sessions: PlanSession[]) => {
-	const firstOpenIndex = sessions.findIndex((session) => !session.completed);
-	return firstOpenIndex === -1 ? null : firstOpenIndex;
-};
-
-const getActiveSegmentLimit = (sessions: PlanSession[]) => {
-	const currentIndex = getCurrentSessionIndex(sessions);
-	return currentIndex ?? Math.max(sessions.length - 1, 0);
-};
-
-const getPathNodeState = (
-	session: PlanSession,
-	index: number,
-	currentIndex: number | null,
-): PathNodeState => {
-	if (session.completed) return "completed";
-	if (currentIndex !== null && index === currentIndex) return "current";
-	return "locked";
-};
-
-const STEP_PUCK_WIDTH = 68;
-const STEP_PUCK_HEIGHT = 64;
-const STEP_LOCKED_FACE_WIDTH = 58;
-const STEP_LOCKED_FACE_HEIGHT = 50;
-const STEP_SELECTION_WIDTH = 92;
-const STEP_SELECTION_HEIGHT = 86;
-const STEP_SELECTION_STROKE_WIDTH = 7;
-
-function SelectedStepRing() {
-	return (
-		<Svg
-			pointerEvents="none"
-			width={STEP_SELECTION_WIDTH}
-			height={STEP_SELECTION_HEIGHT}
-			viewBox={`0 0 ${STEP_SELECTION_WIDTH} ${STEP_SELECTION_HEIGHT}`}
-			style={{ position: "absolute", left: 0, top: 0 }}
-		>
-			<Path
-				d="M46 3.5C69.4721 3.5 88.5 21.1848 88.5 43C88.5 64.8152 69.4721 82.5 46 82.5C22.5279 82.5 3.5 64.8152 3.5 43C3.5 21.1848 22.5279 3.5 46 3.5Z"
-				fill={DAYOVA_DESIGN_SYSTEM.colors.light1}
-				stroke={DAYOVA_DESIGN_SYSTEM.colors.path4}
-				strokeWidth={STEP_SELECTION_STROKE_WIDTH}
-			/>
-		</Svg>
-	);
-}
-
-function CompletedStepPuck() {
-	return (
-		<Svg
-			pointerEvents="none"
-			width={92}
-			height={88}
-			viewBox="0 0 92 88"
-			style={{ position: "absolute", left: -12, top: -9 }}
-		>
-			<Path
-				d="M46 12.5C64.5705 12.5 79.5 25.548 79.5 41.5C79.5 57.452 64.5705 70.5 46 70.5C27.4295 70.5 12.5 57.452 12.5 41.5C12.5 25.548 27.4295 12.5 46 12.5Z"
-				fill={DAYOVA_DESIGN_SYSTEM.colors.path5}
-				stroke={DAYOVA_DESIGN_SYSTEM.colors.path5}
-			/>
-			<Path
-				d="M46 9.5C64.2349 9.5 78.5 21.6237 78.5 36C78.5 50.3763 64.2349 62.5 46 62.5C27.7651 62.5 13.5 50.3763 13.5 36C13.5 21.6237 27.7651 9.5 46 9.5Z"
-				fill={DAYOVA_DESIGN_SYSTEM.colors.path6}
-				stroke={DAYOVA_DESIGN_SYSTEM.colors.path6}
-				strokeWidth={3}
-			/>
-			<Path
-				d="M30.903 51.7622L64.11 20.7115C64.6597 20.1975 65.4516 20.0363 66.1352 20.3511C67.4469 20.9552 69.6663 22.1316 71.5059 23.8738C72.701 25.0056 73.9512 26.8471 74.7291 28.0839C75.204 28.839 75.0746 29.8117 74.4487 30.4472L45.3875 59.9555C43.8835 61.4827 41.7537 62.2676 39.6626 61.7967C38.2507 61.4787 36.668 61.0154 35.5059 60.3738C34.2835 59.6989 33.0612 59.0586 31.929 58.4839C29.3791 57.1896 28.8143 53.7152 30.903 51.7622Z"
-				fill={DAYOVA_DESIGN_SYSTEM.colors.path7}
-				stroke={DAYOVA_DESIGN_SYSTEM.colors.path6}
-			/>
-			<Path
-				d="M24.908 48.3639L53.6381 18.3474C54.6965 17.2416 54.1599 15.4799 52.6404 15.2961C46.6945 14.5769 34.1009 14.4277 25.0055 23.8734C15.7121 33.5246 18.4286 43.1756 20.7331 47.8944C21.5365 49.5396 23.642 49.6866 24.908 48.3639Z"
-				fill={DAYOVA_DESIGN_SYSTEM.colors.path7}
-				stroke={DAYOVA_DESIGN_SYSTEM.colors.path6}
-				strokeLinecap="round"
-			/>
-			<Path
-				d="M39.5 37.2591L42.0858 39.9567C42.7525 40.6522 43.0858 41 43.5 41C43.9143 41 44.2476 40.6522 44.9143 39.9567L53.5 31"
-				fill="none"
-				stroke={DAYOVA_DESIGN_SYSTEM.colors.light1}
-				strokeWidth={4}
-				strokeLinecap="round"
-				strokeLinejoin="round"
-			/>
-		</Svg>
-	);
-}
-
-function CurrentStepPuck() {
-	return (
-		<View
-			pointerEvents="none"
-			style={{
-				position: "absolute",
-				left: 0,
-				top: 0,
-				width: STEP_PUCK_WIDTH,
-				height: STEP_PUCK_HEIGHT,
-				alignItems: "center",
-				justifyContent: "center",
-			}}
-		>
-			<Svg
-				width={STEP_PUCK_WIDTH}
-				height={STEP_PUCK_HEIGHT}
-				viewBox={`0 0 ${STEP_PUCK_WIDTH} ${STEP_PUCK_HEIGHT}`}
-			>
-				<Path
-					d="M34 4.5C52.5705 4.5 67.5 17.548 67.5 33.5C67.5 49.452 52.5705 62.5 34 62.5C15.4295 62.5 0.5 49.452 0.5 33.5C0.5 17.548 15.4295 4.5 34 4.5Z"
-					fill={DAYOVA_DESIGN_SYSTEM.colors.path5}
-					stroke={DAYOVA_DESIGN_SYSTEM.colors.path5}
-				/>
-
-				<Path
-					d="M34 1.5C52.2349 1.5 66.5 13.6237 66.5 28C66.5 42.3763 52.2349 54.5 34 54.5C15.7651 54.5 1.5 42.3763 1.5 28C1.5 13.6237 15.7651 1.5 34 1.5Z"
-					fill={DAYOVA_DESIGN_SYSTEM.colors.path6}
-					stroke={DAYOVA_DESIGN_SYSTEM.colors.path6}
-					strokeWidth={3}
-				/>
-			</Svg>
-
-			<View
-				style={{
-					position: "absolute",
-					top: 15,
-					left: 22,
-				}}
-			>
-				<Note
-					width={24}
-					height={24}
-					color={DAYOVA_DESIGN_SYSTEM.colors.light1}
-					stroke={DAYOVA_DESIGN_SYSTEM.colors.light1}
-				/>
-			</View>
-		</View>
-	);
-}
-
-function PathNode({
-	frame,
-	selected,
-	session,
-	state,
-	onPress,
-}: {
-	frame: PathNodeFrame;
-	selected: boolean;
-	session: PlanSession;
-	state: PathNodeState;
-	onPress: () => void;
-}) {
-	const isLocked = state === "locked";
-	const title = formatGermanUiText(session.title);
-	const stateLabel = PATH_NODE_STATE_LABEL[state];
-	const position = {
-		left: frame.left,
-		top: frame.top,
-		width: frame.width,
-		height: frame.height,
-	} satisfies ViewStyle;
-
-	const selectedRing = selected ? (
-		<View
-			pointerEvents="none"
-			className="absolute"
-			style={{
-				left: (frame.width - STEP_SELECTION_WIDTH) / 2,
-				top: (frame.height - STEP_SELECTION_HEIGHT) / 2,
-				width: STEP_SELECTION_WIDTH,
-				height: STEP_SELECTION_HEIGHT,
-				zIndex: 0,
-			}}
-		>
-			<SelectedStepRing />
-		</View>
-	) : null;
-
-	const lockedIcon = (
-		<SquareLock
-			size={25}
-			color={DAYOVA_DESIGN_SYSTEM.colors.light1}
-			strokeWidth={1.9}
-		/>
-	);
-
-	return (
-		<Pressable
-			accessibilityLabel={`${title}, ${PHASE_LABEL[session.phase]}, ${session.dateLabel}, ${stateLabel}`}
-			accessibilityHint={
-				isLocked
-					? "Wählt diesen gesperrten Lernblock aus und zeigt die Vorschau. Gesperrte Lernblöcke können noch nicht geöffnet werden."
-					: "Wählt diesen Lernblock aus und zeigt die Vorschau. Öffnen kannst du ihn danach über die Pfeiltaste in der Vorschau."
-			}
-			accessibilityRole="button"
-			accessibilityState={{ selected }}
-			onPress={onPress}
-			className="absolute items-center justify-center"
-			style={position}
-		>
-			{selectedRing}
-			<View
-				className="absolute items-center"
-				style={{
-					left: (frame.width - STEP_PUCK_WIDTH) / 2,
-					top: (frame.height - STEP_PUCK_HEIGHT) / 2,
-					width: STEP_PUCK_WIDTH,
-					height: STEP_PUCK_HEIGHT,
-					borderRadius: STEP_PUCK_HEIGHT / 2,
-					zIndex: 1,
-					backgroundColor:
-						state === "completed"
-							? DAYOVA_DESIGN_SYSTEM.colors.path5
-							: "transparent",
-					boxShadow:
-						state === "completed"
-							? "0 4px 12px rgba(0, 0, 0, 0.1)"
-							: isLocked
-								? "0 8px 14px rgba(105, 117, 134, 0.22)"
-								: "0 4px 12px rgba(0, 0, 0, 0.1)",
-				}}
-			>
-				{state === "completed" ? (
-					<CompletedStepPuck />
-				) : isLocked ? (
-					<>
-						<View
-							className="absolute rounded-full"
-							style={{
-								top: 0,
-								width: STEP_PUCK_WIDTH,
-								height: STEP_PUCK_HEIGHT,
-								backgroundColor: DAYOVA_DESIGN_SYSTEM.colors.path1,
-								borderRadius: STEP_PUCK_HEIGHT / 2,
-							}}
-						/>
-						<View
-							className="absolute items-center justify-center rounded-full"
-							style={{
-								top: 5,
-								width: STEP_LOCKED_FACE_WIDTH,
-								height: STEP_LOCKED_FACE_HEIGHT,
-								backgroundColor: DAYOVA_DESIGN_SYSTEM.colors.path3,
-								borderRadius: STEP_LOCKED_FACE_HEIGHT / 2,
-							}}
-						>
-							{lockedIcon}
-						</View>
-					</>
-				) : (
-					<CurrentStepPuck />
-				)}
-			</View>
-		</Pressable>
-	);
-}
-
-function LearningPath({
-	onSelectSession,
-	selectedSessionId,
-	sessions,
-}: {
-	onSelectSession: (session: PlanSession) => void;
-	selectedSessionId: Id<"learningPlanSessions"> | null;
-	sessions: PlanSession[];
-}) {
-	const currentIndex = getCurrentSessionIndex(sessions);
-	const activeSegmentLimit = getActiveSegmentLimit(sessions);
-	const pathHeight = getFigmaPathHeight(sessions.length);
-	const segments = sessions.slice(1).map((_, index) => ({
-		d: getFigmaSegmentPath(index),
-		active: index < activeSegmentLimit,
-	}));
-
-	return (
-		<View
-			className="relative self-center"
-			style={{ width: FIGMA_PATH_WIDTH, height: pathHeight }}
-		>
-			<Svg
-				width={FIGMA_PATH_WIDTH}
-				height={pathHeight}
-				viewBox={`0 0 ${FIGMA_PATH_WIDTH} ${pathHeight}`}
-				style={{ position: "absolute", left: 0, top: 0 }}
-			>
-				{segments.map((segment) => (
-					<Path
-						key={`track-${segment.d}`}
-						d={segment.d}
-						fill="none"
-						stroke={DAYOVA_DESIGN_SYSTEM.colors.path1}
-						strokeWidth={4}
-						strokeLinecap="round"
-						strokeLinejoin="round"
-					/>
-				))}
-				{segments
-					.filter((segment) => segment.active)
-					.map((segment) => (
-						<Path
-							key={`active-${segment.d}`}
-							d={segment.d}
-							fill="none"
-							stroke={DAYOVA_DESIGN_SYSTEM.colors.primary}
-							strokeWidth={4}
-							strokeLinecap="round"
-							strokeLinejoin="round"
-						/>
-					))}
-			</Svg>
-
-			{sessions.map((session, index) => {
-				const state = getPathNodeState(session, index, currentIndex);
-
-				return (
-					<PathNode
-						key={session.id}
-						frame={getFigmaNodeFrame(index)}
-						selected={session.id === selectedSessionId}
-						session={session}
-						state={state}
-						onPress={() => onSelectSession(session)}
-					/>
-				);
-			})}
-		</View>
-	);
-}
-
 export default function LearningPlanSessionsScreen() {
 	const router = useRouter();
 	const insets = useSafeAreaInsets();
@@ -597,10 +193,10 @@ export default function LearningPlanSessionsScreen() {
 			: -1;
 	const selectedSessionState =
 		snapshot && selectedSession && selectedSessionIndex >= 0
-			? getPathNodeState(
+			? getLearningPathNodeState(
 					selectedSession,
 					selectedSessionIndex,
-					getCurrentSessionIndex(snapshot.sessions),
+					getCurrentLearningPathIndex(snapshot.sessions),
 				)
 			: null;
 	const canOpenSelectedSession =
@@ -622,9 +218,9 @@ export default function LearningPlanSessionsScreen() {
 				}}
 			>
 				<ScreenHeader
-					title="Lernplan"
-					onBack={goBack}
 					className="mb-0"
+					onBack={goBack}
+					title="Lernplan"
 					titleClassName="text-center font-poppins font-semibold text-[22px] text-text leading-[30px]"
 				/>
 			</View>
@@ -641,13 +237,13 @@ export default function LearningPlanSessionsScreen() {
 				) : selectedSession ? (
 					<SessionPreviewCard
 						canOpen={canOpenSelectedSession}
-						session={selectedSession}
 						onOpen={() => {
 							if (!canOpenSelectedSession) return;
 							router.push(
 								getSessionRoute(snapshot.plan.id, selectedSession.id),
 							);
 						}}
+						session={selectedSession}
 					/>
 				) : (
 					<View className="items-center rounded-[28px] bg-card px-5 py-7">
@@ -660,6 +256,7 @@ export default function LearningPlanSessionsScreen() {
 
 			<ScrollView
 				className="flex-1 bg-background"
+				contentInsetAdjustmentBehavior="automatic"
 				contentContainerStyle={[
 					{
 						paddingHorizontal: 16,
@@ -674,9 +271,9 @@ export default function LearningPlanSessionsScreen() {
 					<View />
 				) : selectedSession ? (
 					<LearningPath
+						onSelectSession={(session) => setSelectedSessionId(session.id)}
 						selectedSessionId={selectedSession.id}
 						sessions={snapshot.sessions}
-						onSelectSession={(session) => setSelectedSessionId(session.id)}
 					/>
 				) : (
 					<View />

--- a/src/components/dashboard/dashboard-date-header.tsx
+++ b/src/components/dashboard/dashboard-date-header.tsx
@@ -1,0 +1,202 @@
+import type { ReactNode } from "react";
+import { TouchableOpacity, View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, {
+	FadeIn,
+	FadeOut,
+	useAnimatedStyle,
+	useSharedValue,
+	withSpring,
+} from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+import {
+	resolveDashboardDaySwipe,
+	type DashboardDayDirection,
+} from "~/components/dashboard/dashboard-day-swipe";
+import { Text } from "~/components/ui/text";
+import { useDayovaTheme } from "~/lib/theme";
+
+export type DashboardHeaderDay = {
+	key: string;
+	weekday: string;
+	dayOfMonth: string;
+	isToday: boolean;
+};
+
+type DashboardDateHeaderProps = {
+	days: DashboardHeaderDay[];
+	firstName?: string;
+	notificationButton: ReactNode;
+	onSelectDay: (dayKey: string) => void;
+	onSwipeDay: (direction: Exclude<DashboardDayDirection, 0>) => void;
+	scale: number;
+	selectedDayKey: string;
+};
+
+export function DashboardDateHeader({
+	days,
+	firstName,
+	notificationButton,
+	onSelectDay,
+	onSwipeDay,
+	scale,
+	selectedDayKey,
+}: DashboardDateHeaderProps) {
+	const { colors } = useDayovaTheme();
+	const translateX = useSharedValue(0);
+	const animatedStyle = useAnimatedStyle(() => ({
+		transform: [{ translateX: translateX.get() }],
+	}));
+	const panGesture = Gesture.Pan()
+		.activeOffsetX([-18, 18])
+		.failOffsetY([-14, 14])
+		.onUpdate((event) => {
+			"worklet";
+			translateX.set(Math.max(Math.min(event.translationX * 0.16, 18), -18));
+		})
+		.onEnd((event) => {
+			"worklet";
+			const direction = resolveDashboardDaySwipe(
+				event.translationX,
+				event.velocityX,
+			);
+			if (direction !== 0) scheduleOnRN(onSwipeDay, direction);
+			translateX.set(
+				withSpring(0, {
+					damping: 20,
+					mass: 0.65,
+					overshootClamping: true,
+					stiffness: 260,
+				}),
+			);
+		});
+	const greeting = firstName ? `Hi ${firstName}.` : "Hi.";
+
+	return (
+		<View style={{ gap: 20 * scale }}>
+			<View
+				style={{
+					position: "relative",
+					minHeight: 56 * scale,
+					paddingHorizontal: 62 * scale,
+					alignItems: "center",
+					justifyContent: "center",
+				}}
+			>
+				<Text
+					adjustsFontSizeToFit
+					minimumFontScale={0.72}
+					numberOfLines={1}
+					selectable
+					style={{
+						color: colors.text,
+						fontFamily: "Poppins",
+						fontSize: 34 * scale,
+						fontWeight: "600",
+						lineHeight: 46 * scale,
+						textAlign: "center",
+					}}
+				>
+					{greeting}
+				</Text>
+				<View
+					style={{
+						position: "absolute",
+						right: 0,
+						top: 0,
+						transform: [{ scale: Math.min(scale, 1) }],
+					}}
+				>
+					{notificationButton}
+				</View>
+			</View>
+
+			<GestureDetector gesture={panGesture}>
+				<Animated.View
+					style={[
+						{
+							flexDirection: "row",
+							alignItems: "stretch",
+							justifyContent: "space-between",
+							gap: 4 * scale,
+						},
+						animatedStyle,
+					]}
+				>
+					{days.map((day) => {
+						const selected = day.key === selectedDayKey;
+						const textColor = selected
+							? colors.text
+							: day.isToday
+								? colors.primaryStrong
+								: colors.secondaryText;
+
+						return (
+							<TouchableOpacity
+								key={day.key}
+								accessibilityLabel={`${day.weekday}, ${day.dayOfMonth}`}
+								accessibilityRole="button"
+								accessibilityState={{ selected }}
+								activeOpacity={0.72}
+								onPress={() => onSelectDay(day.key)}
+								style={{
+									position: "relative",
+									flex: 1,
+									maxWidth: 48 * scale,
+									height: 64 * scale,
+									alignItems: "center",
+									justifyContent: "center",
+									gap: 2 * scale,
+								}}
+							>
+								{selected ? (
+									<Animated.View
+										entering={FadeIn.duration(140)}
+										exiting={FadeOut.duration(100)}
+										pointerEvents="none"
+										style={{
+											position: "absolute",
+											inset: 0,
+											borderWidth: 1,
+											borderColor: colors.border,
+											borderRadius: 12 * scale,
+											borderCurve: "continuous",
+											backgroundColor: colors.surface,
+											boxShadow: "0 2px 8px rgba(21, 29, 48, 0.06)",
+										}}
+									/>
+								) : null}
+								<Text
+									selectable
+									style={{
+										color: textColor,
+										fontFamily: "Poppins",
+										fontSize: 12 * scale,
+										lineHeight: 17 * scale,
+									}}
+								>
+									{day.weekday}
+								</Text>
+								<Text
+									selectable
+									style={{
+										color: textColor,
+										fontFamily: "Poppins",
+										fontSize: 17 * scale,
+										fontWeight: "600",
+										fontVariant: ["tabular-nums"],
+										lineHeight: 22 * scale,
+									}}
+								>
+									{day.dayOfMonth}
+								</Text>
+							</TouchableOpacity>
+						);
+					})}
+				</Animated.View>
+			</GestureDetector>
+
+			<View style={{ height: 1, backgroundColor: colors.border }} />
+		</View>
+	);
+}

--- a/src/components/dashboard/dashboard-day-swipe.test.ts
+++ b/src/components/dashboard/dashboard-day-swipe.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+import { resolveDashboardDaySwipe } from "./dashboard-day-swipe";
+
+describe("resolveDashboardDaySwipe", () => {
+	test("moves to the previous day for a rightward swipe", () => {
+		expect(resolveDashboardDaySwipe(64, 120)).toBe(-1);
+	});
+
+	test("moves to the next day for a leftward swipe", () => {
+		expect(resolveDashboardDaySwipe(-64, -120)).toBe(1);
+	});
+
+	test("uses fling velocity when the swipe distance is short", () => {
+		expect(resolveDashboardDaySwipe(18, 640)).toBe(-1);
+		expect(resolveDashboardDaySwipe(-18, -640)).toBe(1);
+	});
+
+	test("ignores movement below both thresholds", () => {
+		expect(resolveDashboardDaySwipe(30, 300)).toBe(0);
+	});
+});

--- a/src/components/dashboard/dashboard-day-swipe.ts
+++ b/src/components/dashboard/dashboard-day-swipe.ts
@@ -1,0 +1,25 @@
+export type DashboardDayDirection = -1 | 0 | 1;
+
+const SWIPE_DISTANCE_THRESHOLD = 44;
+const SWIPE_VELOCITY_THRESHOLD = 500;
+
+export function resolveDashboardDaySwipe(
+	translationX: number,
+	velocityX: number,
+): DashboardDayDirection {
+	"worklet";
+
+	if (
+		Math.abs(translationX) < SWIPE_DISTANCE_THRESHOLD &&
+		Math.abs(velocityX) < SWIPE_VELOCITY_THRESHOLD
+	) {
+		return 0;
+	}
+
+	const horizontalSignal =
+		Math.abs(translationX) >= SWIPE_DISTANCE_THRESHOLD
+			? translationX
+			: velocityX;
+
+	return horizontalSignal > 0 ? -1 : 1;
+}

--- a/src/components/learning-plans/learning-path-layout.test.ts
+++ b/src/components/learning-plans/learning-path-layout.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import {
+	getCurrentLearningPathIndex,
+	getLearningPathHeight,
+	getLearningPathNodeFrame,
+	getLearningPathNodeState,
+	LEARNING_PATH_WIDTH,
+} from "./learning-path-layout";
+
+describe("learning path layout", () => {
+	test("moves nodes through a repeating center-left-center-right wave", () => {
+		const centers = Array.from({ length: 9 }, (_, index) => {
+			const frame = getLearningPathNodeFrame(index);
+			return frame.left + frame.width / 2;
+		});
+
+		expect(centers[0]).toBe(LEARNING_PATH_WIDTH / 2);
+		expect(centers[2]).toBeLessThan(centers[1] ?? 0);
+		expect(centers[4]).toBe(LEARNING_PATH_WIDTH / 2);
+		expect(centers[6]).toBeGreaterThan(centers[5] ?? 0);
+		expect(centers[8]).toBe(LEARNING_PATH_WIDTH / 2);
+	});
+
+	test("gives every node increasing vertical space", () => {
+		const first = getLearningPathNodeFrame(0);
+		const second = getLearningPathNodeFrame(1);
+		const fifth = getLearningPathNodeFrame(4);
+
+		expect(second.top).toBeGreaterThan(first.top + first.height);
+		expect(fifth.top).toBeGreaterThan(second.top);
+		expect(getLearningPathHeight(5)).toBeGreaterThan(fifth.top + fifth.height);
+	});
+});
+
+describe("learning path state", () => {
+	test("selects the first incomplete session as current", () => {
+		expect(
+			getCurrentLearningPathIndex([
+				{ completed: true },
+				{ completed: false },
+				{ completed: false },
+			]),
+		).toBe(1);
+	});
+
+	test("marks completed, current, and future sessions", () => {
+		expect(getLearningPathNodeState({ completed: true }, 0, 1)).toBe(
+			"completed",
+		);
+		expect(getLearningPathNodeState({ completed: false }, 1, 1)).toBe(
+			"current",
+		);
+		expect(getLearningPathNodeState({ completed: false }, 2, 1)).toBe("locked");
+	});
+});

--- a/src/components/learning-plans/learning-path-layout.ts
+++ b/src/components/learning-plans/learning-path-layout.ts
@@ -1,0 +1,60 @@
+export type LearningPathNodeState = "completed" | "current" | "locked";
+
+export type LearningPathNodeFrame = {
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+};
+
+type LearningPathSessionStatus = {
+	completed: boolean;
+};
+
+export const LEARNING_PATH_WIDTH = 345;
+
+const NODE_FRAME_WIDTH = 96;
+const NODE_FRAME_HEIGHT = 88;
+const NODE_TOP_INSET = 12;
+const NODE_VERTICAL_STEP = 96;
+const PATH_BOTTOM_INSET = 28;
+const HORIZONTAL_WAVE = [0, -74, -112, -74, 0, 74, 112, 74] as const;
+
+export function getLearningPathNodeFrame(index: number): LearningPathNodeFrame {
+	const safeIndex = Math.max(0, index);
+	const waveIndex = safeIndex % HORIZONTAL_WAVE.length;
+	const centerOffset = HORIZONTAL_WAVE[waveIndex] ?? 0;
+
+	return {
+		left: LEARNING_PATH_WIDTH / 2 + centerOffset - NODE_FRAME_WIDTH / 2,
+		top: NODE_TOP_INSET + safeIndex * NODE_VERTICAL_STEP,
+		width: NODE_FRAME_WIDTH,
+		height: NODE_FRAME_HEIGHT,
+	};
+}
+
+export function getLearningPathHeight(sessionCount: number) {
+	if (sessionCount <= 0) return 0;
+
+	const lastFrame = getLearningPathNodeFrame(sessionCount - 1);
+	return lastFrame.top + lastFrame.height + PATH_BOTTOM_INSET;
+}
+
+export function getCurrentLearningPathIndex(
+	sessions: LearningPathSessionStatus[],
+) {
+	const firstIncompleteIndex = sessions.findIndex(
+		(session) => !session.completed,
+	);
+	return firstIncompleteIndex === -1 ? null : firstIncompleteIndex;
+}
+
+export function getLearningPathNodeState(
+	session: LearningPathSessionStatus,
+	index: number,
+	currentIndex: number | null,
+): LearningPathNodeState {
+	if (session.completed) return "completed";
+	if (currentIndex !== null && index === currentIndex) return "current";
+	return "locked";
+}

--- a/src/components/learning-plans/learning-path-presentation.test.ts
+++ b/src/components/learning-plans/learning-path-presentation.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+import { getLearningPathNodeIconKind } from "./learning-path-presentation";
+
+describe("learning path presentation", () => {
+	test("uses a completion mark or the session type icon for every node", () => {
+		expect(getLearningPathNodeIconKind("theory", "completed")).toBe(
+			"completed",
+		);
+		expect(getLearningPathNodeIconKind("theory", "current")).toBe("theory");
+		expect(getLearningPathNodeIconKind("practice", "locked")).toBe("practice");
+		expect(getLearningPathNodeIconKind("rehearsal", "locked")).toBe("repeat");
+	});
+});

--- a/src/components/learning-plans/learning-path-presentation.ts
+++ b/src/components/learning-plans/learning-path-presentation.ts
@@ -1,0 +1,17 @@
+import type { LearningPathNodeState } from "~/components/learning-plans/learning-path-layout";
+import type { SessionPhase } from "~/features/learning-plans/types";
+
+export type LearningPathNodeIconKind =
+	| "completed"
+	| "theory"
+	| "practice"
+	| "repeat";
+
+export function getLearningPathNodeIconKind(
+	phase: SessionPhase,
+	state: LearningPathNodeState,
+): LearningPathNodeIconKind {
+	if (state === "completed") return "completed";
+	if (phase === "rehearsal") return "repeat";
+	return phase;
+}

--- a/src/components/learning-plans/learning-path.tsx
+++ b/src/components/learning-plans/learning-path.tsx
@@ -1,0 +1,252 @@
+import type { ComponentType } from "react";
+import { Pressable, View } from "react-native";
+import Animated, { FadeIn, FadeOut, ZoomIn } from "react-native-reanimated";
+import Svg, { Circle } from "react-native-svg";
+import type { Id } from "#convex/_generated/dataModel";
+import {
+	getCurrentLearningPathIndex,
+	getLearningPathHeight,
+	getLearningPathNodeFrame,
+	getLearningPathNodeState,
+	LEARNING_PATH_WIDTH,
+	type LearningPathNodeFrame,
+	type LearningPathNodeState,
+} from "~/components/learning-plans/learning-path-layout";
+import {
+	BookOpen,
+	Check,
+	Dumbbell,
+	Rocket,
+	SquareLock,
+} from "~/components/ui/icon";
+import type { PlanSession } from "~/features/learning-plans/types";
+import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
+import { formatGermanUiText } from "~/lib/german-ui-text";
+import { useDayovaTheme } from "~/lib/theme";
+
+const NODE_STATE_LABEL: Record<LearningPathNodeState, string> = {
+	completed: "abgeschlossen",
+	current: "verfügbar",
+	locked: "gesperrt",
+};
+
+const PHASE_LABEL: Record<PlanSession["phase"], string> = {
+	theory: "Theorie",
+	practice: "Üben",
+	rehearsal: "Praxis",
+};
+
+const PHASE_ICON = {
+	theory: BookOpen,
+	practice: Dumbbell,
+	rehearsal: Rocket,
+} satisfies Record<
+	PlanSession["phase"],
+	ComponentType<React.ComponentProps<typeof Dumbbell>>
+>;
+
+const NODE_BUTTON_SIZE = 72;
+const NODE_FACE_HEIGHT = 64;
+const NODE_DEPTH = 8;
+const NODE_ORBIT_WIDTH = 96;
+const NODE_ORBIT_HEIGHT = 88;
+
+function SelectionOrbit({ color }: { color: string }) {
+	return (
+		<Animated.View
+			entering={ZoomIn.duration(180)}
+			exiting={FadeOut.duration(120)}
+			pointerEvents="none"
+			style={{
+				position: "absolute",
+				left: 0,
+				top: 0,
+				width: NODE_ORBIT_WIDTH,
+				height: NODE_ORBIT_HEIGHT,
+			}}
+		>
+			<Svg
+				accessible={false}
+				width={NODE_ORBIT_WIDTH}
+				height={NODE_ORBIT_HEIGHT}
+				viewBox={`0 0 ${NODE_ORBIT_WIDTH} ${NODE_ORBIT_HEIGHT}`}
+			>
+				<Circle
+					cx={NODE_ORBIT_WIDTH / 2}
+					cy={NODE_ORBIT_HEIGHT / 2}
+					r={41}
+					fill="none"
+					stroke={color}
+					strokeDasharray={[62, 69]}
+					strokeLinecap="round"
+					strokeWidth={5}
+					transform={`rotate(-20 ${NODE_ORBIT_WIDTH / 2} ${NODE_ORBIT_HEIGHT / 2})`}
+				/>
+			</Svg>
+		</Animated.View>
+	);
+}
+
+function LearningPathNode({
+	frame,
+	onPress,
+	selected,
+	session,
+	state,
+}: {
+	frame: LearningPathNodeFrame;
+	onPress: () => void;
+	selected: boolean;
+	session: PlanSession;
+	state: LearningPathNodeState;
+}) {
+	const { colors, isDark } = useDayovaTheme();
+	const locked = state === "locked";
+	const completed = state === "completed";
+	const PhaseIcon = PHASE_ICON[session.phase];
+	const faceColor = locked
+		? isDark
+			? colors.path3
+			: colors.path1
+		: colors.primary;
+	const baseColor = locked
+		? isDark
+			? colors.path1
+			: colors.path3
+		: colors.primaryStrong;
+	const orbitColor = locked ? colors.secondaryText : colors.primary;
+	const title = formatGermanUiText(session.title);
+
+	return (
+		<Pressable
+			accessible
+			accessibilityHint={
+				locked
+					? "Wählt diesen gesperrten Lernblock aus und zeigt die Vorschau. Gesperrte Lernblöcke können noch nicht geöffnet werden."
+					: "Wählt diesen Lernblock aus und zeigt die Vorschau. Öffnen kannst du ihn danach über die Pfeiltaste in der Vorschau."
+			}
+			accessibilityLabel={`${title}, ${PHASE_LABEL[session.phase]}, ${session.dateLabel}, ${NODE_STATE_LABEL[state]}`}
+			accessibilityRole="button"
+			accessibilityState={{ selected }}
+			focusable
+			onPress={onPress}
+			style={({ pressed }) => ({
+				position: "absolute",
+				left: frame.left,
+				top: frame.top,
+				width: frame.width,
+				height: frame.height,
+				alignItems: "center",
+				justifyContent: "center",
+				opacity: pressed ? 0.92 : 1,
+				transform: [{ scale: pressed ? 0.96 : 1 }],
+			})}
+		>
+			{selected ? <SelectionOrbit color={orbitColor} /> : null}
+
+			<View
+				pointerEvents="none"
+				style={{
+					position: "absolute",
+					left: (frame.width - NODE_BUTTON_SIZE) / 2,
+					top: (frame.height - NODE_BUTTON_SIZE) / 2,
+					width: NODE_BUTTON_SIZE,
+					height: NODE_BUTTON_SIZE,
+				}}
+			>
+				<View
+					style={{
+						position: "absolute",
+						left: 0,
+						top: NODE_DEPTH,
+						width: NODE_BUTTON_SIZE,
+						height: NODE_FACE_HEIGHT,
+						borderRadius: NODE_BUTTON_SIZE / 2,
+						backgroundColor: baseColor,
+					}}
+				/>
+				<View
+					style={{
+						position: "absolute",
+						left: 0,
+						top: 0,
+						width: NODE_BUTTON_SIZE,
+						height: NODE_FACE_HEIGHT,
+						borderRadius: NODE_BUTTON_SIZE / 2,
+						backgroundColor: faceColor,
+						alignItems: "center",
+						justifyContent: "center",
+					}}
+				>
+					<View
+						style={{
+							position: "absolute",
+							left: 16,
+							top: 7,
+							width: 40,
+							height: 7,
+							borderRadius: 99,
+							backgroundColor: "rgba(255, 255, 255, 0.18)",
+						}}
+					/>
+					{locked ? (
+						<SquareLock
+							size={27}
+							color={DAYOVA_DESIGN_SYSTEM.colors.light1}
+							strokeWidth={2}
+						/>
+					) : completed ? (
+						<Check
+							size={29}
+							color={DAYOVA_DESIGN_SYSTEM.colors.light1}
+							strokeWidth={2.5}
+						/>
+					) : (
+						<PhaseIcon
+							size={28}
+							color={DAYOVA_DESIGN_SYSTEM.colors.light1}
+							strokeWidth={2.2}
+						/>
+					)}
+				</View>
+			</View>
+		</Pressable>
+	);
+}
+
+export function LearningPath({
+	onSelectSession,
+	selectedSessionId,
+	sessions,
+}: {
+	onSelectSession: (session: PlanSession) => void;
+	selectedSessionId: Id<"learningPlanSessions"> | null;
+	sessions: PlanSession[];
+}) {
+	const currentIndex = getCurrentLearningPathIndex(sessions);
+	const pathHeight = getLearningPathHeight(sessions.length);
+
+	return (
+		<Animated.View
+			entering={FadeIn.duration(180)}
+			exiting={FadeOut.duration(120)}
+			style={{
+				position: "relative",
+				alignSelf: "center",
+				width: LEARNING_PATH_WIDTH,
+				height: pathHeight,
+			}}
+		>
+			{sessions.map((session, index) => (
+				<LearningPathNode
+					key={session.id}
+					frame={getLearningPathNodeFrame(index)}
+					onPress={() => onSelectSession(session)}
+					selected={session.id === selectedSessionId}
+					session={session}
+					state={getLearningPathNodeState(session, index, currentIndex)}
+				/>
+			))}
+		</Animated.View>
+	);
+}

--- a/src/components/learning-plans/learning-path.tsx
+++ b/src/components/learning-plans/learning-path.tsx
@@ -1,6 +1,23 @@
-import type { ComponentType } from "react";
+import { useEffect } from "react";
+import type { Icon } from "phosphor-react-native";
+import { ArrowsClockwiseIcon } from "phosphor-react-native/src/icons/ArrowsClockwise";
+import { CheckIcon } from "phosphor-react-native/src/icons/Check";
+import { FileTextIcon } from "phosphor-react-native/src/icons/FileText";
+import { WrenchIcon } from "phosphor-react-native/src/icons/Wrench";
 import { Pressable, View } from "react-native";
-import Animated, { FadeIn, FadeOut, ZoomIn } from "react-native-reanimated";
+import Animated, {
+	cancelAnimation,
+	Easing,
+	FadeIn,
+	FadeOut,
+	useAnimatedStyle,
+	useReducedMotion,
+	useSharedValue,
+	withRepeat,
+	withSequence,
+	withTiming,
+	ZoomIn,
+} from "react-native-reanimated";
 import Svg, { Circle } from "react-native-svg";
 import type { Id } from "#convex/_generated/dataModel";
 import {
@@ -13,12 +30,9 @@ import {
 	type LearningPathNodeState,
 } from "~/components/learning-plans/learning-path-layout";
 import {
-	BookOpen,
-	Check,
-	Dumbbell,
-	Rocket,
-	SquareLock,
-} from "~/components/ui/icon";
+	getLearningPathNodeIconKind,
+	type LearningPathNodeIconKind,
+} from "~/components/learning-plans/learning-path-presentation";
 import type { PlanSession } from "~/features/learning-plans/types";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 import { formatGermanUiText } from "~/lib/german-ui-text";
@@ -33,25 +47,52 @@ const NODE_STATE_LABEL: Record<LearningPathNodeState, string> = {
 const PHASE_LABEL: Record<PlanSession["phase"], string> = {
 	theory: "Theorie",
 	practice: "Üben",
-	rehearsal: "Praxis",
+	rehearsal: "Wiederholen",
 };
 
-const PHASE_ICON = {
-	theory: BookOpen,
-	practice: Dumbbell,
-	rehearsal: Rocket,
-} satisfies Record<
-	PlanSession["phase"],
-	ComponentType<React.ComponentProps<typeof Dumbbell>>
->;
+const NODE_ICON = {
+	completed: CheckIcon,
+	theory: FileTextIcon,
+	practice: WrenchIcon,
+	repeat: ArrowsClockwiseIcon,
+} satisfies Record<LearningPathNodeIconKind, Icon>;
 
-const NODE_BUTTON_SIZE = 72;
-const NODE_FACE_HEIGHT = 64;
-const NODE_DEPTH = 8;
+const NODE_BUTTON_SIZE = 68;
+const NODE_FACE_HEIGHT = 61;
+const NODE_DEPTH = 7;
 const NODE_ORBIT_WIDTH = 96;
 const NODE_ORBIT_HEIGHT = 88;
+const NODE_ORBIT_RADIUS = 40;
+const COMPLETED_RIM_SIZE = 78;
 
-function SelectionOrbit({ color }: { color: string }) {
+const LOCKED_FACE_COLOR = "#E4E6E9";
+const LOCKED_BASE_COLOR = "#BFC3C8";
+const LOCKED_ICON_COLOR = "#A7ABB0";
+const ORBIT_IDLE_COLOR = "#DFE2E6";
+
+function ActiveOrbit({ color }: { color: string }) {
+	const reduceMotion = useReducedMotion();
+	const rotation = useSharedValue(0);
+
+	useEffect(() => {
+		if (reduceMotion) return;
+
+		rotation.value = withRepeat(
+			withTiming(360, {
+				duration: 5200,
+				easing: Easing.linear,
+			}),
+			-1,
+			false,
+		);
+
+		return () => cancelAnimation(rotation);
+	}, [reduceMotion, rotation]);
+
+	const animatedStyle = useAnimatedStyle(() => ({
+		transform: [{ rotate: `${rotation.value}deg` }],
+	}));
+
 	return (
 		<Animated.View
 			entering={ZoomIn.duration(180)}
@@ -65,25 +106,129 @@ function SelectionOrbit({ color }: { color: string }) {
 				height: NODE_ORBIT_HEIGHT,
 			}}
 		>
-			<Svg
-				accessible={false}
-				width={NODE_ORBIT_WIDTH}
-				height={NODE_ORBIT_HEIGHT}
-				viewBox={`0 0 ${NODE_ORBIT_WIDTH} ${NODE_ORBIT_HEIGHT}`}
-			>
-				<Circle
-					cx={NODE_ORBIT_WIDTH / 2}
-					cy={NODE_ORBIT_HEIGHT / 2}
-					r={41}
-					fill="none"
-					stroke={color}
-					strokeDasharray={[62, 69]}
-					strokeLinecap="round"
-					strokeWidth={5}
-					transform={`rotate(-20 ${NODE_ORBIT_WIDTH / 2} ${NODE_ORBIT_HEIGHT / 2})`}
-				/>
-			</Svg>
+			<Animated.View style={animatedStyle}>
+				<Svg
+					accessible={false}
+					width={NODE_ORBIT_WIDTH}
+					height={NODE_ORBIT_HEIGHT}
+					viewBox={`0 0 ${NODE_ORBIT_WIDTH} ${NODE_ORBIT_HEIGHT}`}
+				>
+					<Circle
+						cx={NODE_ORBIT_WIDTH / 2}
+						cy={NODE_ORBIT_HEIGHT / 2}
+						r={NODE_ORBIT_RADIUS}
+						fill="none"
+						stroke={ORBIT_IDLE_COLOR}
+						strokeDasharray={[54, 30]}
+						strokeLinecap="round"
+						strokeWidth={5}
+						transform={`rotate(-72 ${NODE_ORBIT_WIDTH / 2} ${NODE_ORBIT_HEIGHT / 2})`}
+					/>
+					<Circle
+						cx={NODE_ORBIT_WIDTH / 2}
+						cy={NODE_ORBIT_HEIGHT / 2}
+						r={NODE_ORBIT_RADIUS}
+						fill="none"
+						stroke={color}
+						strokeDasharray={[58, 13, 58, 122]}
+						strokeLinecap="round"
+						strokeWidth={5}
+						transform={`rotate(-72 ${NODE_ORBIT_WIDTH / 2} ${NODE_ORBIT_HEIGHT / 2})`}
+					/>
+				</Svg>
+			</Animated.View>
 		</Animated.View>
+	);
+}
+
+function LearningPathPuck({
+	iconKind,
+	state,
+}: {
+	iconKind: LearningPathNodeIconKind;
+	state: LearningPathNodeState;
+}) {
+	const { colors } = useDayovaTheme();
+	const locked = state === "locked";
+	const completed = state === "completed";
+	const NodeIcon = NODE_ICON[iconKind];
+	const faceColor = locked ? LOCKED_FACE_COLOR : colors.primary;
+	const baseColor = locked ? LOCKED_BASE_COLOR : colors.primaryStrong;
+	const iconColor = locked
+		? LOCKED_ICON_COLOR
+		: DAYOVA_DESIGN_SYSTEM.colors.light1;
+
+	return (
+		<View
+			pointerEvents="none"
+			style={{
+				position: "absolute",
+				left: (NODE_ORBIT_WIDTH - NODE_BUTTON_SIZE) / 2,
+				top: (NODE_ORBIT_HEIGHT - NODE_BUTTON_SIZE) / 2,
+				width: NODE_BUTTON_SIZE,
+				height: NODE_BUTTON_SIZE,
+			}}
+		>
+			{completed ? (
+				<View
+					style={{
+						position: "absolute",
+						left: (NODE_BUTTON_SIZE - COMPLETED_RIM_SIZE) / 2,
+						top: (NODE_BUTTON_SIZE - COMPLETED_RIM_SIZE) / 2 - 1,
+						width: COMPLETED_RIM_SIZE,
+						height: COMPLETED_RIM_SIZE,
+						borderRadius: COMPLETED_RIM_SIZE / 2,
+						backgroundColor: "#758091",
+					}}
+				/>
+			) : null}
+
+			<View
+				style={{
+					position: "absolute",
+					left: 0,
+					top: NODE_DEPTH,
+					width: NODE_BUTTON_SIZE,
+					height: NODE_FACE_HEIGHT,
+					borderRadius: NODE_BUTTON_SIZE / 2,
+					backgroundColor: baseColor,
+				}}
+			/>
+			<View
+				style={{
+					position: "absolute",
+					left: 0,
+					top: 0,
+					width: NODE_BUTTON_SIZE,
+					height: NODE_FACE_HEIGHT,
+					borderRadius: NODE_BUTTON_SIZE / 2,
+					borderWidth: completed ? 4 : 0,
+					borderColor: DAYOVA_DESIGN_SYSTEM.colors.light2,
+					backgroundColor: faceColor,
+					alignItems: "center",
+					justifyContent: "center",
+				}}
+			>
+				<View
+					style={{
+						position: "absolute",
+						left: 15,
+						top: completed ? 7 : 6,
+						width: 38,
+						height: 7,
+						borderRadius: 99,
+						backgroundColor: locked
+							? "rgba(255, 255, 255, 0.28)"
+							: "rgba(255, 255, 255, 0.18)",
+					}}
+				/>
+				<NodeIcon
+					size={completed ? 30 : 29}
+					color={iconColor}
+					weight={iconKind === "repeat" ? "bold" : completed ? "bold" : "fill"}
+				/>
+			</View>
+		</View>
 	);
 }
 
@@ -100,28 +245,47 @@ function LearningPathNode({
 	session: PlanSession;
 	state: LearningPathNodeState;
 }) {
-	const { colors, isDark } = useDayovaTheme();
-	const locked = state === "locked";
-	const completed = state === "completed";
-	const PhaseIcon = PHASE_ICON[session.phase];
-	const faceColor = locked
-		? isDark
-			? colors.path3
-			: colors.path1
-		: colors.primary;
-	const baseColor = locked
-		? isDark
-			? colors.path1
-			: colors.path3
-		: colors.primaryStrong;
-	const orbitColor = locked ? colors.secondaryText : colors.primary;
+	const { colors } = useDayovaTheme();
+	const reduceMotion = useReducedMotion();
+	const breathingScale = useSharedValue(1);
+	const current = state === "current";
+	const iconKind = getLearningPathNodeIconKind(session.phase, state);
 	const title = formatGermanUiText(session.title);
+
+	useEffect(() => {
+		if (!current || reduceMotion) {
+			cancelAnimation(breathingScale);
+			breathingScale.value = 1;
+			return;
+		}
+
+		breathingScale.value = withRepeat(
+			withSequence(
+				withTiming(1.055, {
+					duration: 900,
+					easing: Easing.inOut(Easing.quad),
+				}),
+				withTiming(0.965, {
+					duration: 900,
+					easing: Easing.inOut(Easing.quad),
+				}),
+			),
+			-1,
+			false,
+		);
+
+		return () => cancelAnimation(breathingScale);
+	}, [breathingScale, current, reduceMotion]);
+
+	const breathingStyle = useAnimatedStyle(() => ({
+		transform: [{ scale: breathingScale.value }],
+	}));
 
 	return (
 		<Pressable
 			accessible
 			accessibilityHint={
-				locked
+				state === "locked"
 					? "Wählt diesen gesperrten Lernblock aus und zeigt die Vorschau. Gesperrte Lernblöcke können noch nicht geöffnet werden."
 					: "Wählt diesen Lernblock aus und zeigt die Vorschau. Öffnen kannst du ihn danach über die Pfeiltaste in der Vorschau."
 			}
@@ -142,74 +306,19 @@ function LearningPathNode({
 				transform: [{ scale: pressed ? 0.96 : 1 }],
 			})}
 		>
-			{selected ? <SelectionOrbit color={orbitColor} /> : null}
-
-			<View
-				pointerEvents="none"
-				style={{
-					position: "absolute",
-					left: (frame.width - NODE_BUTTON_SIZE) / 2,
-					top: (frame.height - NODE_BUTTON_SIZE) / 2,
-					width: NODE_BUTTON_SIZE,
-					height: NODE_BUTTON_SIZE,
-				}}
+			<Animated.View
+				style={[
+					{
+						position: "relative",
+						width: NODE_ORBIT_WIDTH,
+						height: NODE_ORBIT_HEIGHT,
+					},
+					breathingStyle,
+				]}
 			>
-				<View
-					style={{
-						position: "absolute",
-						left: 0,
-						top: NODE_DEPTH,
-						width: NODE_BUTTON_SIZE,
-						height: NODE_FACE_HEIGHT,
-						borderRadius: NODE_BUTTON_SIZE / 2,
-						backgroundColor: baseColor,
-					}}
-				/>
-				<View
-					style={{
-						position: "absolute",
-						left: 0,
-						top: 0,
-						width: NODE_BUTTON_SIZE,
-						height: NODE_FACE_HEIGHT,
-						borderRadius: NODE_BUTTON_SIZE / 2,
-						backgroundColor: faceColor,
-						alignItems: "center",
-						justifyContent: "center",
-					}}
-				>
-					<View
-						style={{
-							position: "absolute",
-							left: 16,
-							top: 7,
-							width: 40,
-							height: 7,
-							borderRadius: 99,
-							backgroundColor: "rgba(255, 255, 255, 0.18)",
-						}}
-					/>
-					{locked ? (
-						<SquareLock
-							size={27}
-							color={DAYOVA_DESIGN_SYSTEM.colors.light1}
-							strokeWidth={2}
-						/>
-					) : completed ? (
-						<Check
-							size={29}
-							color={DAYOVA_DESIGN_SYSTEM.colors.light1}
-							strokeWidth={2.5}
-						/>
-					) : (
-						<PhaseIcon
-							size={28}
-							color={DAYOVA_DESIGN_SYSTEM.colors.light1}
-							strokeWidth={2.2}
-						/>
-					)}
-				</View>
-			</View>
+				{current ? <ActiveOrbit color={colors.primary} /> : null}
+				<LearningPathPuck iconKind={iconKind} state={state} />
+			</Animated.View>
 		</Pressable>
 	);
 }


### PR DESCRIPTION
## What changed

- rebuilt the dashboard header around a centered `Hi {firstName}.` greeting
- moved the seven-day selector into the header and added swipe-right/back, swipe-left/forward day navigation
- refactored the learning plan into a Duolingo-inspired winding path of consistently layered circular steps
- replaced generic grey locks with Phosphor session icons: paper for theory, wrench for practice, and repeat arrows for rehearsal sessions
- added a double-rim checkmark treatment for completed steps
- added a rotating segmented orbit and gentle scale breathing animation to the current step
- respects Reduced Motion by disabling continuous orbit and breathing motion
- preserved session previews, selection, completion state, and unlock rules
- kept the path free of mascots, people, reward boxes, chests, and decorative game objects

## User impact

Users can navigate dashboard days by tapping or swiping. Learning-plan steps now communicate their session type before unlocking, completed work is immediately recognizable, and the current step has a calm animated focus treatment.

## Validation

- `pnpm typecheck`
- `pnpm test` (31 files, 130 tests passed)
- `pnpm lint`
- Expo Go attempted, then verified in the iPhone 17 development build
- visual verification for completed, current, theory, practice, and repeat steps
- two simulator captures 950 ms apart verified orbit rotation and scale breathing
- locked-step selection verified: preview updates while opening remains disabled
- `pnpm exec expo export --platform ios --output-dir /tmp/dayova-path-icons-reviewed-20260715` (7,745 modules; 15 MB Hermes bundle)
- Matt Pocock two-axis standards/spec review completed with no remaining findings

## Notes

The dashboard swipe gesture remains scoped to the date header. Path icons are imported individually from `phosphor-react-native` to avoid pulling the full icon catalog into the bundle.
