### PR TITLE
[HOTFIX][P0][DAY-158] Validate OTA baseline source SHA

### DIFF
--- a/scripts/ota-safety.mjs
+++ b/scripts/ota-safety.mjs
@@ -9,6 +9,8 @@ const baselinePath = resolve(
 	"release/production-ota-baseline.json",
 );
 const platforms = ["ios", "android"];
+const isNonEmptyString = (value) =>
+	typeof value === "string" && value.length > 0;
 
 const expectedProductionManifest = {
 	iosBundleIdentifier: "de.dayova.app",
@@ -130,6 +132,10 @@ export const evaluateProductionOta = ({
 			);
 		}
 
+		if (!isNonEmptyString(platformBaseline.sourceSha)) {
+			errors.push(`${platform} baseline sourceSha must be a non-empty string`);
+		}
+
 		if (currentRuntimeVersion !== baseline.runtimeVersion) {
 			errors.push(
 				`${platform} runtime ${currentRuntimeVersion ?? "missing"} does not match baseline runtime ${baseline.runtimeVersion}`,
@@ -146,8 +152,11 @@ export const evaluateProductionOta = ({
 	const baselineSummary = platforms
 		.map((platform) => {
 			const entry = baseline.platforms?.[platform];
+			const abbreviatedSourceSha = isNonEmptyString(entry?.sourceSha)
+				? entry.sourceSha.slice(0, 7)
+				: "invalid";
 			return entry
-				? `${platform} build ${entry.buildVersion} @ ${entry.sourceSha.slice(0, 7)} (${entry.distribution?.status ?? "unknown"})`
+				? `${platform} build ${entry.buildVersion} @ ${abbreviatedSourceSha} (${entry.distribution?.status ?? "unknown"})`
 				: `${platform} missing`;
 		})
 		.join(", ");

--- a/tests/ota-safety.test.ts
+++ b/tests/ota-safety.test.ts
@@ -130,4 +130,28 @@ describe("production OTA safety", () => {
 		expect(result.safe).toBe(false);
 		expect(result.reason).toContain("distribution is not verified");
 	});
+
+	it.each([undefined, 123])(
+		"rejects an invalid baseline sourceSha (%s) with a clear platform error",
+		(sourceSha) => {
+			const result = evaluate({
+				baseline: {
+					...baseline,
+					platforms: {
+						...baseline.platforms,
+						ios: {
+							...baseline.platforms.ios,
+							sourceSha,
+						},
+					},
+				},
+			});
+
+			expect(result.safe).toBe(false);
+			expect(result.reason).toContain(
+				"ios baseline sourceSha must be a non-empty string",
+			);
+			expect(result.baseline).toContain("ios build 49 @ invalid");
+		},
+	);
 });


### PR DESCRIPTION
## P0 hotfix summary

This is the minimal CodeRabbit follow-up to [PR #303](https://github.com/Dayova/dayova-mvp/pull/303) and [DAY-158](https://linear.app/dayova/issue/DAY-158).

It makes the production OTA baseline validator explicitly reject a missing or non-string platform `sourceSha`, and it keeps the baseline summary renderable when that field is malformed.

**Priority:** P0 / hotfix. The affected code is release control-plane code executed on every push to `main`. Its structured outputs feed both the OTA publication decision and the operator-facing skip report.

## Why this matters

`release/production-ota-baseline.json` is the persistent compatibility ledger introduced by DAY-158. Each platform entry records the distributed build, source commit, runtime, native fingerprint, and distribution verification state. Future release work—especially [DAY-114](https://linear.app/dayova/issue/DAY-114)—must update this ledger when a corrected binary is distributed.

Before this patch, `evaluateProductionOta()` called:

```js
entry.sourceSha.slice(0, 7)
```

without validating `sourceSha`.

That produces:

- `TypeError: Cannot read properties of undefined (reading 'slice')` when the field is missing
- `TypeError: entry.sourceSha.slice is not a function` when the field has a non-string value

The CLI's outer `createReport()` catch still converts that exception into `safe: false`, so this was **not an active unsafe-publish bypass**. It already failed closed.

The operational defect is that a malformed ledger entry collapses a precise platform validation failure into a generic “preflight could not be completed” result. That discards the usable baseline summary and obscures exactly which platform and field must be repaired.

## Release-workflow dependency

On a `main` push, `.eas/workflows/ci.yml` uses the preflight report to produce:

- `ota_safe`
- `ota_reason`
- `ota_baseline`
- `ota_current_fingerprints`

Those outputs control and explain two downstream branches:

1. `send_updates` runs only when `ota_safe == true`
2. `ota_skipped` publishes the reason, baseline, and current fingerprints when publication is blocked

A deterministic, field-specific report matters because this gate is the durable safety boundary for all later commits—not a one-off check for PR #303.

## Root cause

The initial DAY-158 implementation validated manifest identity, runtime compatibility, distribution verification, and native fingerprints, but treated baseline provenance metadata as structurally trusted while rendering the report.

CodeRabbit identified that trust boundary after PR #303 merged.

## What changed

### Validator

- Added a minimal non-empty-string predicate.
- Validates each platform's `sourceSha`.
- Emits a clear error such as:
  - `ios baseline sourceSha must be a non-empty string`
- Uses `invalid` in the human-readable baseline summary instead of throwing.
- Preserves the existing summary format for valid source SHAs.

### Regression coverage

A parameterized regression test covers both failure modes:

- missing `sourceSha`
- numeric/non-string `sourceSha`

The test asserts:

- the update remains blocked
- the reason identifies the iOS `sourceSha` field
- the baseline summary remains available and marks the value invalid

## User and developer impact

There is no app UI or end-user behavior change.

Release owners get:

- deterministic fail-closed behavior
- actionable platform-specific diagnostics
- an intact baseline summary
- regression protection before DAY-114 records replacement-binary provenance

This reduces the chance that urgent release work is delayed by an opaque preflight failure.

## Risk assessment

### Risk reduced

- Silent structural assumptions in the production release ledger
- Opaque errors during baseline maintenance
- Loss of useful EAS workflow diagnostics
- Regressions when DAY-114 records the corrected binary baseline

### What this does not change

- The active runtime 1.0.3 OTA remains unchanged.
- No OTA is published by this PR.
- Fingerprint matching and distribution verification rules are unchanged.
- The deliberate DAY-158 decision not to roll back the current OTA is unchanged.
- The gate already failed closed; this patch makes that failure precise and stable.

## Dependency chain

- Primary incident and gate: [DAY-158](https://linear.app/dayova/issue/DAY-158)
- Privacy prerequisite: [DAY-111](https://linear.app/dayova/issue/DAY-111)
- Corrected binary and verified baseline: [DAY-114](https://linear.app/dayova/issue/DAY-114)
- Production analytics verification after corrected distribution: [DAY-112](https://linear.app/dayova/issue/DAY-112)
- Analytics release provenance: [DAY-220](https://linear.app/dayova/issue/DAY-220)

This follow-up keeps DAY-158's release boundary reliable for the work that follows.

## Validation

### Regression proof before the fix

The new test failed in both malformed cases with the exact two `.slice()` exceptions described above.

### Passing validation after the fix

- `pnpm exec vitest run tests/ota-safety.test.ts` — 7 tests passed
- `pnpm exec biome check scripts/ota-safety.mjs tests/ota-safety.test.ts` — passed
- `pnpm check` — lint and typecheck passed
- `pnpm test` — 30 test files / 132 tests passed
- `git diff --check` — passed
- CodeRabbit re-review of both modified files — **0 issues**

Local commands ran on Node 24.17 and emitted the existing engine-range warning from current `main` (`>=22 <24`). The EAS PR workflow is configured for Node 22 and is the authoritative supported-runtime check.

## Review scope

Exactly two files:

- `scripts/ota-safety.mjs`
- `tests/ota-safety.test.ts`

34 insertions, 1 deletion. No dependency, workflow, app, backend, analytics, or baseline-data changes.

## Merge priority

Please treat this as a high-priority hotfix follow-up to DAY-158 and merge once the required Node 22 repository checks are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production OTA safety checks to detect missing or invalid platform baseline identifiers.
  * Added clearer error messages when baseline information is invalid.
  * Prevented malformed baseline data from causing failures during summary generation.

* **Tests**
  * Added coverage for invalid iOS baseline values and verified that unsafe OTA evaluations provide the expected details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->