### PR TITLE
DAY-52 Upgrade pnpm to 11.15.1

### DIFF
--- a/.eas/workflows/ci.yml
+++ b/.eas/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 defaults:
   tools:
     node: "24.18.0"
-    pnpm: "10.25.0"
+    pnpm: "11.15.1"
 
 jobs:
   checks:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-auto-install-peers=false

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ optional validation analytics integration.
 ### Prerequisites
 
 - Node.js 24 (the repository currently pins 24.18.0)
-- pnpm 10.25.0
+- pnpm 11.15.1
 - The native toolchain for the target platform: Xcode on macOS or the Android
   SDK and Android Studio
 - Access to Clerk and Convex development environments (if you are part of the team, we should give you access to our internal Convex and Clerk teams for various reasons, but you can theoretically build and develop the app without being in them)

--- a/docs/contexts/platform/CONTEXT.md
+++ b/docs/contexts/platform/CONTEXT.md
@@ -52,24 +52,39 @@ when the PostHog key is absent.
 
 ## Package Manager Toolchain
 
-Dayova uses pnpm 11.15.1 on Node 24.18.0. Keep the pnpm version pinned exactly
-and identical in `package.json`, the shared `eas.json` build profile, and
-`.eas/workflows/ci.yml`. These are separate install surfaces, so the repeated
-pin is intentional; `tests/pnpm-toolchain.test.ts` guards them against drift.
+Dayova uses pnpm 11.15.1 on Node 24.18.0. The pnpm version is repeated because
+each install surface selects its toolchain independently: `package.json`
+controls local Corepack, the shared `eas.json` profile controls native EAS
+Build workers, and `.eas/workflows/ci.yml` controls EAS Workflow jobs. Keep
+those pins exact and identical so no surface falls back to a different image
+default; `tests/pnpm-toolchain.test.ts` guards them against drift.
 
 The 2026 rollback from pnpm 11 to pnpm 10 was an EAS runtime compatibility
 measure, not an application compatibility requirement: the then-current EAS
 image ran Node 20.19.4, while pnpm 11 required a newer Node runtime. The project
 now pins Node 24 for local and EAS builds, so that constraint no longer applies.
 
-Keep non-auth pnpm settings in `pnpm-workspace.yaml`, where pnpm 11 reads them.
-An `.npmrc` may contain registry and authentication entries, but must not
-contain pnpm behavior settings such as `auto-install-peers` or
-`only-built-dependencies`.
-In particular, keep `autoInstallPeers: false`, preserve `patchedDependencies`,
-and use `allowBuilds` as the only dependency build-script policy. When changing
-the pnpm version, update all three pins together and verify a frozen install,
-the full checks, production exports, and native EAS builds.
+### Why this policy exists
+
+pnpm 11 changed where it reads configuration: `.npmrc` is now limited to
+registry and authentication entries, while behavioral settings belong in
+`pnpm-workspace.yaml`. Leaving `auto-install-peers=false` in `.npmrc` would
+silently restore pnpm's default of installing missing peer dependencies.
+Keeping `autoInstallPeers: false` in the workspace file instead preserves
+Dayova's policy that peer dependencies must be declared deliberately.
+
+pnpm 11 also replaced the legacy dependency-build settings, including
+`onlyBuiltDependencies`, with one `allowBuilds` map. Dayova keeps that map as
+the sole lifecycle-script policy so an unreviewed dependency cannot execute
+install scripts. Preserve `patchedDependencies` alongside it because those
+repository-owned fixes are applied during installation and must survive a
+package-manager change. An `.npmrc` may still exist for registry and
+authentication entries, but must not contain pnpm behavioral settings.
+
+A package-manager change can affect lockfile parsing, peer resolution, patch
+application, dependency lifecycle scripts, CI, and native builds. Therefore,
+update all three pins together and verify a frozen install, the full checks,
+production exports, and native EAS builds.
 
 ## iOS Privacy Purpose Strings
 

--- a/docs/contexts/platform/CONTEXT.md
+++ b/docs/contexts/platform/CONTEXT.md
@@ -50,6 +50,24 @@ Do not add optional public envs to the required release-key list unless the app
 cannot function without them. The analytics client must stay disabled gracefully
 when the PostHog key is absent.
 
+## Package Manager Toolchain
+
+Dayova uses pnpm 11.15.1 on Node 24.18.0. Keep the pnpm version pinned exactly
+and identical in `package.json`, the shared `eas.json` build profile, and
+`.eas/workflows/ci.yml`. These are separate install surfaces, so the repeated
+pin is intentional; `tests/pnpm-toolchain.test.ts` guards them against drift.
+
+The 2026 rollback from pnpm 11 to pnpm 10 was an EAS runtime compatibility
+measure, not an application compatibility requirement: the then-current EAS
+image ran Node 20.19.4, while pnpm 11 required a newer Node runtime. The project
+now pins Node 24 for local and EAS builds, so that constraint no longer applies.
+
+Keep non-auth pnpm settings in `pnpm-workspace.yaml`, where pnpm 11 reads them.
+In particular, keep `autoInstallPeers: false`, preserve `patchedDependencies`,
+and use `allowBuilds` as the only dependency build-script policy. When changing
+the pnpm version, update all three pins together and verify a frozen install,
+the full checks, production exports, and native EAS builds.
+
 ## iOS Privacy Purpose Strings
 
 Dayova uses camera/photo upload for learning material and microphone/speech

--- a/docs/contexts/platform/CONTEXT.md
+++ b/docs/contexts/platform/CONTEXT.md
@@ -57,7 +57,11 @@ each install surface selects its toolchain independently: `package.json`
 controls local Corepack, the shared `eas.json` profile controls native EAS
 Build workers, and `.eas/workflows/ci.yml` controls EAS Workflow jobs. Keep
 those pins exact and identical so no surface falls back to a different image
-default; `tests/pnpm-toolchain.test.ts` guards them against drift.
+default. Keep `pmOnFail: error` in `pnpm-workspace.yaml` so a mismatched pnpm
+binary fails immediately instead of downloading and running another version.
+The removed pnpm 10 setting `packageManagerStrictVersion` must not be restored;
+pnpm 11 replaced it with `pmOnFail`. `tests/pnpm-toolchain.test.ts` guards this
+policy against drift.
 
 The 2026 rollback from pnpm 11 to pnpm 10 was an EAS runtime compatibility
 measure, not an application compatibility requirement: the then-current EAS

--- a/docs/contexts/platform/CONTEXT.md
+++ b/docs/contexts/platform/CONTEXT.md
@@ -63,6 +63,9 @@ image ran Node 20.19.4, while pnpm 11 required a newer Node runtime. The project
 now pins Node 24 for local and EAS builds, so that constraint no longer applies.
 
 Keep non-auth pnpm settings in `pnpm-workspace.yaml`, where pnpm 11 reads them.
+An `.npmrc` may contain registry and authentication entries, but must not
+contain pnpm behavior settings such as `auto-install-peers` or
+`only-built-dependencies`.
 In particular, keep `autoInstallPeers: false`, preserve `patchedDependencies`,
 and use `allowBuilds` as the only dependency build-script policy. When changing
 the pnpm version, update all three pins together and verify a frozen install,

--- a/docs/contexts/platform/CONTEXT.md
+++ b/docs/contexts/platform/CONTEXT.md
@@ -76,7 +76,19 @@ Dayova's policy that peer dependencies must be declared deliberately.
 pnpm 11 also replaced the legacy dependency-build settings, including
 `onlyBuiltDependencies`, with one `allowBuilds` map. Dayova keeps that map as
 the sole lifecycle-script policy so an unreviewed dependency cannot execute
-install scripts. Preserve `patchedDependencies` alongside it because those
+install scripts. With pnpm 11's strict dependency-build handling, `true` means
+that a reviewed script may run, while `false` records a reviewed denial; an
+unlisted script fails installation and forces a new decision.
+
+Keep the map limited to scripts encountered by a clean install of the current
+lockfile. `esbuild` is allowed because its postinstall selects, validates, and
+prepares the platform binary. `browser-tabs-lock`, `core-js`, and
+`tesseract.js` remain explicitly denied because their postinstall scripts only
+emit promotional or funding messages. Remove entries that are no longer
+resolved or no longer expose lifecycle scripts so future dependency changes
+must be reviewed instead of inheriting stale policy.
+
+Preserve `patchedDependencies` alongside `allowBuilds` because those
 repository-owned fixes are applied during installation and must survive a
 package-manager change. An `.npmrc` may still exist for registry and
 authentication entries, but must not contain pnpm behavioral settings.

--- a/eas.json
+++ b/eas.json
@@ -5,7 +5,8 @@
   },
   "build": {
     "base": {
-      "node": "24.18.0"
+      "node": "24.18.0",
+      "pnpm": "11.15.1"
     },
     "development": {
       "extends": "base",

--- a/package.json
+++ b/package.json
@@ -120,5 +120,5 @@
 	"engines": {
 		"node": ">=24.3 <25"
 	},
-	"packageManager": "pnpm@10.25.0"
+	"packageManager": "pnpm@11.15.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+autoInstallPeers: false
+
 allowBuilds:
   '@clerk/shared': false
   browser-tabs-lock: false
@@ -8,9 +10,6 @@ allowBuilds:
   msgpackr-extract: false
   tesseract.js: false
   utf-8-validate: false
-
-onlyBuiltDependencies:
-  - esbuild
 
 patchedDependencies:
   '@react-native/gradle-plugin@0.86.0': patches/@react-native__gradle-plugin@0.86.0.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 autoInstallPeers: false
+pmOnFail: error
 
 allowBuilds:
   browser-tabs-lock: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,15 +1,10 @@
 autoInstallPeers: false
 
 allowBuilds:
-  '@clerk/shared': false
   browser-tabs-lock: false
-  bufferutil: false
   core-js: false
-  dtrace-provider: false
   esbuild: true
-  msgpackr-extract: false
   tesseract.js: false
-  utf-8-validate: false
 
 patchedDependencies:
   '@react-native/gradle-plugin@0.86.0': patches/@react-native__gradle-plugin@0.86.0.patch

--- a/tests/pnpm-toolchain.test.ts
+++ b/tests/pnpm-toolchain.test.ts
@@ -34,6 +34,7 @@ const workspace = parseYaml(
 	readFileSync(new URL("../pnpm-workspace.yaml", import.meta.url), "utf8"),
 ) as {
 	autoInstallPeers?: boolean;
+	allowBuilds?: Record<string, boolean>;
 	onlyBuiltDependencies?: string[];
 };
 
@@ -74,6 +75,12 @@ describe("pnpm toolchain", () => {
 
 	it("keeps pnpm 11 workspace settings out of .npmrc and removes legacy build settings", () => {
 		expect(workspace.autoInstallPeers).toBe(false);
+		expect(workspace.allowBuilds).toEqual({
+			"browser-tabs-lock": false,
+			"core-js": false,
+			esbuild: true,
+			"tesseract.js": false,
+		});
 		expect(workspace).not.toHaveProperty("onlyBuiltDependencies");
 
 		const npmrcPath = new URL("../.npmrc", import.meta.url);

--- a/tests/pnpm-toolchain.test.ts
+++ b/tests/pnpm-toolchain.test.ts
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+const packageJson = JSON.parse(
+	readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as {
+	packageManager: string;
+};
+
+const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+
+const easConfig = JSON.parse(
+	readFileSync(new URL("../eas.json", import.meta.url), "utf8"),
+) as {
+	build: {
+		base: {
+			pnpm: string;
+		};
+	};
+};
+
+const workflow = parseYaml(
+	readFileSync(new URL("../.eas/workflows/ci.yml", import.meta.url), "utf8"),
+) as {
+	defaults: {
+		tools: {
+			pnpm: string;
+		};
+	};
+};
+
+const workspace = parseYaml(
+	readFileSync(new URL("../pnpm-workspace.yaml", import.meta.url), "utf8"),
+) as {
+	autoInstallPeers?: boolean;
+	onlyBuiltDependencies?: string[];
+};
+
+describe("pnpm toolchain", () => {
+	it("pins and documents one exact pnpm 11 version across every toolchain surface", () => {
+		expect(packageJson.packageManager).toMatch(/^pnpm@11\.\d+\.\d+$/);
+
+		const pnpmVersion = packageJson.packageManager.slice("pnpm@".length);
+
+		expect(easConfig.build.base.pnpm).toBe(pnpmVersion);
+		expect(workflow.defaults.tools.pnpm).toBe(pnpmVersion);
+		expect(readme).toContain(`- pnpm ${pnpmVersion}`);
+	});
+
+	it("keeps pnpm 11 workspace settings out of .npmrc and removes legacy build settings", () => {
+		expect(workspace.autoInstallPeers).toBe(false);
+		expect(workspace).not.toHaveProperty("onlyBuiltDependencies");
+		expect(existsSync(new URL("../.npmrc", import.meta.url))).toBe(false);
+	});
+});

--- a/tests/pnpm-toolchain.test.ts
+++ b/tests/pnpm-toolchain.test.ts
@@ -36,6 +36,8 @@ const workspace = parseYaml(
 	autoInstallPeers?: boolean;
 	allowBuilds?: Record<string, boolean>;
 	onlyBuiltDependencies?: string[];
+	packageManagerStrictVersion?: boolean;
+	pmOnFail?: string;
 };
 
 function parseNpmrcSettingNames(content: string): Set<string> {
@@ -75,6 +77,7 @@ describe("pnpm toolchain", () => {
 
 	it("keeps pnpm 11 workspace settings out of .npmrc and removes legacy build settings", () => {
 		expect(workspace.autoInstallPeers).toBe(false);
+		expect(workspace.pmOnFail).toBe("error");
 		expect(workspace.allowBuilds).toEqual({
 			"browser-tabs-lock": false,
 			"core-js": false,
@@ -82,6 +85,7 @@ describe("pnpm toolchain", () => {
 			"tesseract.js": false,
 		});
 		expect(workspace).not.toHaveProperty("onlyBuiltDependencies");
+		expect(workspace).not.toHaveProperty("packageManagerStrictVersion");
 
 		const npmrcPath = new URL("../.npmrc", import.meta.url);
 		const npmrcSettingNames = existsSync(npmrcPath)
@@ -90,5 +94,7 @@ describe("pnpm toolchain", () => {
 
 		expect(npmrcSettingNames).not.toContain("autoinstallpeers");
 		expect(npmrcSettingNames).not.toContain("onlybuiltdependencies");
+		expect(npmrcSettingNames).not.toContain("packagemanagerstrictversion");
+		expect(npmrcSettingNames).not.toContain("pmonfail");
 	});
 });

--- a/tests/pnpm-toolchain.test.ts
+++ b/tests/pnpm-toolchain.test.ts
@@ -37,6 +37,30 @@ const workspace = parseYaml(
 	onlyBuiltDependencies?: string[];
 };
 
+function parseNpmrcSettingNames(content: string): Set<string> {
+	const settingNames = new Set<string>();
+
+	for (const rawLine of content.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (line === "" || line.startsWith("#") || line.startsWith(";")) {
+			continue;
+		}
+
+		const separatorIndex = line.indexOf("=");
+		const name = (
+			separatorIndex === -1 ? line : line.slice(0, separatorIndex)
+		)
+			.trim()
+			.replace(/\[\]$/, "")
+			.replaceAll("-", "")
+			.toLowerCase();
+
+		settingNames.add(name);
+	}
+
+	return settingNames;
+}
+
 describe("pnpm toolchain", () => {
 	it("pins and documents one exact pnpm 11 version across every toolchain surface", () => {
 		expect(packageJson.packageManager).toMatch(/^pnpm@11\.\d+\.\d+$/);
@@ -51,6 +75,13 @@ describe("pnpm toolchain", () => {
 	it("keeps pnpm 11 workspace settings out of .npmrc and removes legacy build settings", () => {
 		expect(workspace.autoInstallPeers).toBe(false);
 		expect(workspace).not.toHaveProperty("onlyBuiltDependencies");
-		expect(existsSync(new URL("../.npmrc", import.meta.url))).toBe(false);
+
+		const npmrcPath = new URL("../.npmrc", import.meta.url);
+		const npmrcSettingNames = existsSync(npmrcPath)
+			? parseNpmrcSettingNames(readFileSync(npmrcPath, "utf8"))
+			: new Set<string>();
+
+		expect(npmrcSettingNames).not.toContain("autoinstallpeers");
+		expect(npmrcSettingNames).not.toContain("onlybuiltdependencies");
 	});
 });


### PR DESCRIPTION
## What

- pin pnpm 11.15.1 exactly across local Corepack, EAS Build, and EAS Workflows, and fail fast on mismatched binaries
- move pnpm 11 workspace settings out of `.npmrc`, remove the legacy build-script setting, keep the reviewed four-package build policy, and preserve dependency patches
- document the historical Node/EAS compatibility rationale and add a regression test that prevents toolchain pin drift

## Why

The 2026 downgrade to pnpm 10 was a valid EAS recovery measure: the then-current EAS image used Node 20.19.4, which could not run pnpm 11. The app itself was compatible. Dayova now pins Node 24.18.0 and uses Expo SDK 57, so that constraint no longer applies.

Linear: [DAY-52](https://linear.app/dayova/issue/DAY-52/update-pnpm-to-v11)

Closes #41

## Validation

- clean frozen install with Node 24.18.0 and pnpm 11.15.1; lockfile unchanged
- `pnpm check`
- `pnpm test` — 33 files / 145 tests
- `APP_VARIANT=development pnpm check:unused`
- Expo Doctor — 20/20
- production iOS and Android exports
- iOS EAS production build 52: https://expo.dev/accounts/dayova/projects/dayova/builds/7a663489-619e-4369-a5a3-b2c416e58378
- Android EAS production build 14: https://expo.dev/accounts/dayova/projects/dayova/builds/cb992d61-2808-4ef3-824e-c013457f8efd
- repo-local Standards/Spec re-review: no actionable findings
- CodeRabbit CLI review: 0 findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup/prerequisites to require **pnpm 11.15.1** (and aligned Node.js guidance).
  * Added a “Package Manager Toolchain” policy to keep pnpm/Node/CI/install behavior consistent.

* **Configuration**
  * Pinned **pnpm 11.15.1** across development, builds, and CI.
  * Updated workspace install behavior (e.g., peer installation handling) and formalized allowed dependency build execution.

* **Tests**
  * Added automated checks to ensure the pnpm toolchain and workspace settings stay in sync across repository files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

