### PR TITLE
Make Notion the internal documentation source

### DIFF
--- a/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
+++ b/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
@@ -20,14 +20,22 @@ _Avoid_: Bill, payment request
 **Customer**:
 A person or organization that places orders.
 _Avoid_: Client, buyer, account
+
+## Contracts and Constraints
+
+- Capture concise, stable code-facing architecture, constraints, implementation contracts, and conventions that must evolve with the code.
+- Link significant technical decisions to the relevant ADR and shared internal decisions to their canonical knowledge-system record.
 ```
 
 ## Rules
 
 - **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
 - **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
-- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Only include language specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) do not belong in the glossary even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs under `Language`.
 - **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Keep other sections code-facing and durable.** Include architecture, constraints, contracts, conventions, and decision pointers only when an agent needs them to change the repository safely and they must evolve with the code.
+- **Do not create another source of truth.** Exclude task status, scratch notes, transient plans, and copied internal documentation. Link the canonical work or knowledge record and summarize only the implementation-critical detail.
+- **Use ADRs for significant trade-offs.** Keep the durable operational consequence in context documentation when useful, and link the ADR that explains the decision and rationale.
 
 ## Single vs multi-context repos
 

--- a/.agents/skills/domain-modeling/SKILL.md
+++ b/.agents/skills/domain-modeling/SKILL.md
@@ -59,7 +59,7 @@ When the user states how something works, check whether the code agrees. If you 
 
 ### Update context documentation inline
 
-When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+When a term, stable code-facing constraint, or implementation contract is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
 
 Follow the repository's documented scope for context files. In Dayova, `CONTEXT.md` may combine the domain glossary with concise, stable code-facing architecture, constraints, implementation contracts, and decision pointers that must evolve with the code. Keep shared product, business, research, and organizational knowledge in the canonical knowledge system and link to it instead of duplicating it. Do not treat `CONTEXT.md` as a task spec, scratch pad, status log, or implementation journal.
 

--- a/.agents/skills/domain-modeling/SKILL.md
+++ b/.agents/skills/domain-modeling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domain-modeling
-description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain the domain model.
+description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, capture stable code-facing constraints or contracts, record an architectural decision, or when another skill needs to maintain the domain model.
 ---
 
 # Domain Modeling
@@ -37,7 +37,7 @@ If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The ma
 │       └── docs/adr/
 ```
 
-Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term or stable code-facing constraint is resolved. If no `docs/adr/` exists, create it when the first ADR is needed. Follow repo-local domain-documentation guidance when it defines a narrower or broader role for context files.
 
 ## During the session
 
@@ -57,11 +57,11 @@ When domain relationships are being discussed, stress-test them with specific sc
 
 When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
 
-### Update CONTEXT.md inline
+### Update context documentation inline
 
 When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
 
-`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+Follow the repository's documented scope for context files. In Dayova, `CONTEXT.md` may combine the domain glossary with concise, stable code-facing architecture, constraints, implementation contracts, and decision pointers that must evolve with the code. Keep shared product, business, research, and organizational knowledge in the canonical knowledge system and link to it instead of duplicating it. Do not treat `CONTEXT.md` as a task spec, scratch pad, status log, or implementation journal.
 
 ### Offer ADRs sparingly
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Map the `bug` and `enhancement` category roles plus the five triage disposition 
 
 ### Domain docs
 
-Use a multi-context documentation layout with `CONTEXT-MAP.md` at the repo root; Confluence is the current cross-functional documentation hub for the wider team, while repo-local context docs guide agents and technical work. See `docs/agents/domain.md`.
+Use a multi-context documentation layout with `CONTEXT-MAP.md` at the repo root. Notion is Dayova's main internal documentation and knowledge workspace; consult it when product, business, research, or decision context materially affects the task. Repo-local context docs and ADRs contain only the code-facing guidance that must evolve with this repository. Link to relevant Notion pages instead of duplicating shared internal documentation. See `docs/agents/domain.md`.
 
 ### Skill maintenance
 

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,8 +1,8 @@
 # Context Map
 
-This repo uses a multi-context documentation layout for agent-facing technical and domain guidance.
+This repo uses a multi-context documentation layout for agent-facing, code-adjacent technical and domain guidance.
 
-Confluence is the current cross-functional documentation hub for Dayova. The local context docs listed here should capture the implementation-facing terminology, architecture, and decisions that agents need while working in this repo.
+Notion is Dayova's main internal documentation and knowledge workspace. The local context docs listed here should contain only the implementation-facing terminology, architecture, constraints, and decision pointers that agents need to change this repository safely. Link to relevant Notion records instead of duplicating shared internal documentation.
 
 ## Contexts
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -10,7 +10,7 @@ Repo-local context docs and ADRs are code-adjacent technical guides. They captur
 
 ## Agent access
 
-Use the semantic Notion connector when a task depends on internal product, business, research, meeting, or decision context. Search Notion before claiming that internal guidance does not exist, and preserve the canonical Notion page URL when referencing it from Linear, GitHub, or repo-local docs. If Notion access is unavailable, state that limitation and continue from available repo context without inventing or silently reconstructing internal documentation.
+Use the semantic Notion connector when a task depends on internal product, business, research, meeting, or decision context. Search Notion before claiming that internal guidance does not exist, and preserve the canonical Notion page URL when referencing it from Linear, GitHub, or repo-local docs. If Notion access is unavailable, state that limitation. Continue only when the task can be completed safely from the available Linear and repository evidence. If missing Notion context could materially change the implementation or decision, stop and surface the blocker rather than guessing or reconstructing the missing documentation.
 
 Do not use browser automation as the default Notion API. Do not copy private internal material into the repository when a link and concise implementation-facing summary are sufficient.
 
@@ -18,11 +18,12 @@ Use this ownership rule consistently:
 
 - If it needs to be done, tracked, assigned, or moved through a workflow, it belongs in Linear.
 - If it needs to be known, understood, discussed, or remembered internally, it belongs in Notion.
-- If it changes code or defines a code-facing technical contract, it belongs in GitHub and the relevant repo-local context doc or ADR.
+- Code and implementation evidence belong in GitHub.
+- Durable code-facing contracts, architectural constraints, or significant technical decisions belong in the relevant repo-local context documentation or ADR.
 
-Do not create mirrored task databases or parallel execution workflows in Notion. Notion pages may link to or embed Linear issues, projects, and views; actionable follow-ups discovered in Notion must be created in Linear.
+Do not create mirrored task databases or parallel execution workflows in Notion. Notion pages may link to or embed Linear issues, projects, and views. Confirmed actionable follow-up work discovered in Notion must be reconciled into Linear as the canonical work system. Search existing Linear work first, then link, update, or create work as appropriate; do not create duplicate issues.
 
-When documentation disagrees, treat Notion as canonical for current internal product and business context. Treat the code, tests, and repo-local ADRs as canonical for implemented technical behavior. Surface the drift and reconcile both sources rather than silently choosing or copying stale content.
+When sources disagree, use their ownership boundaries rather than one global precedence rule. Linear is canonical for active work scope, ownership, status, dependencies, and approved acceptance criteria. Notion is canonical for current internal product, business, research, and organizational knowledge. Code and tests are canonical for actual implemented behavior, while repo-local ADRs govern accepted code-facing technical decisions. Surface meaningful drift and reconcile the owning systems rather than silently choosing or copying stale content.
 
 ## Layout
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -4,9 +4,25 @@ How engineering skills should consume this repo's domain documentation when expl
 
 ## Documentation sources
 
-Confluence is the current cross-functional documentation hub for Dayova. It is used by technical and non-technical team members and may later move to Notion.
+Notion is Dayova's main internal documentation and knowledge workspace. Technical and non-technical team members use it for product and business context, research, meeting notes, decisions, operating knowledge, and other information the team needs to know, understand, or remember.
 
-Repo-local context docs are agent-facing technical/domain guides. They should capture the terminology, architectural context, and implementation-facing decisions that agents need while working in this repo. They may summarize or link to Confluence where useful, but they are not a replacement for shared team documentation.
+Repo-local context docs and ADRs are code-adjacent technical guides. They capture the stable terminology, architectural constraints, implementation contracts, and decision pointers that must evolve with this repository. They should link to the relevant Notion page and summarize only the implementation-critical detail needed to work safely; they are not a second internal knowledge base.
+
+## Agent access
+
+Use the semantic Notion connector when a task depends on internal product, business, research, meeting, or decision context. Search Notion before claiming that internal guidance does not exist, and preserve the canonical Notion page URL when referencing it from Linear, GitHub, or repo-local docs. If Notion access is unavailable, state that limitation and continue from available repo context without inventing or silently reconstructing internal documentation.
+
+Do not use browser automation as the default Notion API. Do not copy private internal material into the repository when a link and concise implementation-facing summary are sufficient.
+
+Use this ownership rule consistently:
+
+- If it needs to be done, tracked, assigned, or moved through a workflow, it belongs in Linear.
+- If it needs to be known, understood, discussed, or remembered internally, it belongs in Notion.
+- If it changes code or defines a code-facing technical contract, it belongs in GitHub and the relevant repo-local context doc or ADR.
+
+Do not create mirrored task databases or parallel execution workflows in Notion. Notion pages may link to or embed Linear issues, projects, and views; actionable follow-ups discovered in Notion must be created in Linear.
+
+When documentation disagrees, treat Notion as canonical for current internal product and business context. Treat the code, tests, and repo-local ADRs as canonical for implemented technical behavior. Surface the drift and reconcile both sources rather than silently choosing or copying stale content.
 
 ## Layout
 
@@ -42,8 +58,9 @@ Context-specific decisions may live beside their context docs, for example:
 - The context docs listed there that are relevant to the task
 - `docs/adr/` for system-wide decisions
 - Context-specific ADRs for the area being changed
+- Relevant Notion pages when product, business, research, meeting, or decision context materially affects the task
 
-If these files do not exist yet, proceed silently. The producer skill `/grill-with-docs` can create them lazily when terminology or decisions are resolved.
+If these files do not exist yet, proceed silently. The `/domain-modeling` skill can create them lazily when terminology or code-facing decisions are resolved.
 
 ## Use project vocabulary
 
@@ -52,3 +69,10 @@ When output names a domain concept, use the term from the relevant context docs.
 ## Flag ADR conflicts
 
 If output contradicts an existing ADR, surface it explicitly instead of silently overriding it.
+
+## Writing and linking
+
+- Create shared internal documentation in Notion.
+- Add a canonical Notion link to a context doc or ADR when that shared decision materially affects implementation.
+- Keep repo-local summaries concise and durable; do not paste whole Notion pages into the repository.
+- Put actionable follow-up work in Linear and link it from Notion or the repo where useful.

--- a/docs/contexts/auth/CONTEXT.md
+++ b/docs/contexts/auth/CONTEXT.md
@@ -2,7 +2,7 @@
 
 This context covers authentication, identity, organizations, roles, permissions, and provider-specific integration decisions.
 
-Confluence is the current cross-functional documentation hub. Keep this file focused on implementation-facing terminology, conventions, and assumptions that agents need while working in this repo.
+Notion is Dayova's main internal documentation and knowledge workspace. Keep this file focused on implementation-facing terminology, conventions, and assumptions that must evolve with the code, and link to relevant Notion records instead of duplicating shared documentation.
 
 ## Notes
 

--- a/docs/contexts/backend-convex/CONTEXT.md
+++ b/docs/contexts/backend-convex/CONTEXT.md
@@ -4,7 +4,7 @@ This context covers Convex schema, functions, indexes, migrations, backend data 
 
 When working on Convex code, always read `convex/_generated/ai/guidelines.md` first.
 
-Confluence is the current cross-functional documentation hub. Keep this file focused on implementation-facing terminology, conventions, and assumptions that agents need while working in this repo.
+Notion is Dayova's main internal documentation and knowledge workspace. Keep this file focused on implementation-facing terminology, conventions, and assumptions that must evolve with the code, and link to relevant Notion records instead of duplicating shared documentation.
 
 ## Language
 

--- a/docs/contexts/design-system/CONTEXT.md
+++ b/docs/contexts/design-system/CONTEXT.md
@@ -2,7 +2,7 @@
 
 This context covers shared UI components, styling conventions, tokens, themes, visual language, and design implementation patterns.
 
-Confluence is the current cross-functional documentation hub. Keep this file focused on implementation-facing terminology, conventions, and assumptions that agents need while working in this repo.
+Notion is Dayova's main internal documentation and knowledge workspace. Keep this file focused on implementation-facing terminology, conventions, and assumptions that must evolve with the code, and link to relevant Notion records instead of duplicating shared documentation.
 
 ## Current Design Delivery Model
 

--- a/docs/contexts/integrations/CONTEXT.md
+++ b/docs/contexts/integrations/CONTEXT.md
@@ -2,22 +2,22 @@
 
 This context covers third-party services and external system boundaries, including documentation, issue tracking, analytics, AI services, payments, email, and future migrations.
 
-Confluence is the current cross-functional documentation hub and may later move to Notion.
+Notion is Dayova's main internal documentation and knowledge workspace. Linear owns actionable work and workflow state; GitHub owns code and pull requests. Link these systems rather than duplicating their records.
 
 Linear workspace `dayova`, team `Dayova` (`DAY`), is the source of truth for issues and PRDs. GitHub Issues for `Dayova/dayova-mvp` is a bidirectionally synced compatibility surface, and linked pull requests drive Linear workflow status automation. Agent-facing operation rules live in `docs/agents/issue-tracker.md`.
 
 ## Language
 
 **PostHog Student Profile**:
-An identifiable analytics profile for a validation-phase student, used to connect in-app behavior with the team's Confluence-based student table.
+An identifiable analytics profile for a validation-phase student, used to connect in-app behavior with the team's Notion validation-student database.
 _Avoid_: Treating PostHog as the source of record for full research notes or qualitative interview data.
 
 **Validation Student Table**:
-The Confluence-based table used by non-technical team members to manage test students, their real deadlines, check-ins, and qualitative observations.
+The Notion database used by non-technical team members to manage test students, their real deadlines, check-ins, and qualitative observations.
 _Avoid_: Splitting founder-facing validation notes across multiple unlinked tools.
 
 **Validation Student Code**:
-A short Dayova-owned code such as `S1` or `S2` that links a student in the Confluence validation table to their app user and PostHog profile.
+A short Dayova-owned code such as `S1` or `S2` that links a student in the Notion validation-student database to their app user and PostHog profile.
 _Avoid_: Using email address or full name as the stable join key between tools.
 
 ## PostHog Validation Analytics

--- a/docs/contexts/integrations/CONTEXT.md
+++ b/docs/contexts/integrations/CONTEXT.md
@@ -13,7 +13,7 @@ An identifiable analytics profile for a validation-phase student, used to connec
 _Avoid_: Treating PostHog as the source of record for full research notes or qualitative interview data.
 
 **Validation Student Table**:
-The Notion database used by non-technical team members to manage test students, their real deadlines, check-ins, and qualitative observations.
+The canonical [🎓 Students database](https://app.notion.com/p/cf81d5caf5944c349b76cfa532c94d5c) used by non-technical team members to manage test students, their real deadlines, check-ins, and qualitative observations.
 _Avoid_: Splitting founder-facing validation notes across multiple unlinked tools.
 
 **Validation Student Code**:

--- a/docs/contexts/mobile-app/CONTEXT.md
+++ b/docs/contexts/mobile-app/CONTEXT.md
@@ -2,7 +2,7 @@
 
 This context covers the Expo app, Expo Router, navigation, native UI, styling, client state, and mobile-specific behavior.
 
-Confluence is the current cross-functional documentation hub. Keep this file focused on implementation-facing terminology, conventions, and assumptions that agents need while working in this repo.
+Notion is Dayova's main internal documentation and knowledge workspace. Keep this file focused on implementation-facing terminology, conventions, and assumptions that must evolve with the code, and link to relevant Notion records instead of duplicating shared documentation.
 
 ## Language
 

--- a/docs/contexts/platform/CONTEXT.md
+++ b/docs/contexts/platform/CONTEXT.md
@@ -2,7 +2,7 @@
 
 This context covers environments, builds, releases, EAS, CI/CD, deployment, secrets, local development, and operational workflows.
 
-Confluence is the current cross-functional documentation hub. Keep this file focused on implementation-facing terminology, conventions, and assumptions that agents need while working in this repo.
+Notion is Dayova's main internal documentation and knowledge workspace. Keep this file focused on implementation-facing terminology, conventions, and assumptions that must evolve with the code, and link to relevant Notion records instead of duplicating shared documentation.
 
 ## Language
 

--- a/docs/contexts/product/CONTEXT.md
+++ b/docs/contexts/product/CONTEXT.md
@@ -2,7 +2,7 @@
 
 This context covers Dayova's product language, learning model, user journeys, content taxonomy, quizzes, study sessions, progress, and other domain concepts.
 
-Confluence is the current cross-functional documentation hub. Keep this file focused on implementation-facing terminology and assumptions that agents need while working in this repo.
+Notion is Dayova's main internal documentation and knowledge workspace. Keep this file focused on implementation-facing terminology and assumptions that must evolve with the code, and link to relevant Notion records instead of duplicating shared documentation.
 
 ## Language
 
@@ -68,7 +68,7 @@ _Avoid_: Treating Generalprobe as a fourth learner-facing phase separate from Pr
 
 ## Notes
 
-- Capture repo-relevant summaries or links to Confluence decisions here.
+- Capture concise implementation-relevant summaries and links to canonical Notion decisions here.
 - Put product/domain ADRs in `docs/contexts/product/adr/`.
 
 ## Example Dialogue

--- a/patches/matt-pocock-skills/dayova.patch
+++ b/patches/matt-pocock-skills/dayova.patch
@@ -416,4 +416,66 @@ index b414b58..90c627f 100644
  
  Pick model-invocation only when the agent must reach the skill on its own, or another skill must. If it only ever fires by hand, make it user-invoked and pay no context load.
  
-
+diff --git a/.agents/skills/domain-modeling/CONTEXT-FORMAT.md b/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
+index eaf2a18..ea6c61a 100644
+--- a/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
++++ b/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
+@@ -20,14 +20,22 @@ _Avoid_: Bill, payment request
+ **Customer**:
+ A person or organization that places orders.
+ _Avoid_: Client, buyer, account
++
++## Contracts and Constraints
++
++- Capture concise, stable code-facing architecture, constraints, implementation contracts, and conventions that must evolve with the code.
++- Link significant technical decisions to the relevant ADR and shared internal decisions to their canonical knowledge-system record.
+ ```
+ 
+ ## Rules
+ 
+ - **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+ - **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+-- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
++- **Only include language specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) do not belong in the glossary even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs under `Language`.
+ - **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
++- **Keep other sections code-facing and durable.** Include architecture, constraints, contracts, conventions, and decision pointers only when an agent needs them to change the repository safely and they must evolve with the code.
++- **Do not create another source of truth.** Exclude task status, scratch notes, transient plans, and copied internal documentation. Link the canonical work or knowledge record and summarize only the implementation-critical detail.
++- **Use ADRs for significant trade-offs.** Keep the durable operational consequence in context documentation when useful, and link the ADR that explains the decision and rationale.
+ 
+ ## Single vs multi-context repos
+ 
+diff --git a/.agents/skills/domain-modeling/SKILL.md b/.agents/skills/domain-modeling/SKILL.md
+index d0f7e1a..e535afd 100644
+--- a/.agents/skills/domain-modeling/SKILL.md
++++ b/.agents/skills/domain-modeling/SKILL.md
+@@ -1,6 +1,6 @@
+ ---
+ name: domain-modeling
+-description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain the domain model.
++description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, capture stable code-facing constraints or contracts, record an architectural decision, or when another skill needs to maintain the domain model.
+ ---
+ 
+ # Domain Modeling
+@@ -37,7 +37,7 @@ If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The ma
+ │       └── docs/adr/
+ ```
+ 
+-Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
++Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term or stable code-facing constraint is resolved. If no `docs/adr/` exists, create it when the first ADR is needed. Follow repo-local domain-documentation guidance when it defines a narrower or broader role for context files.
+ 
+ ## During the session
+ 
+@@ -57,11 +57,11 @@ When domain relationships are being discussed, stress-test them with specific sc
+ 
+ When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+ 
+-### Update CONTEXT.md inline
++### Update context documentation inline
+ 
+ When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+ 
+-`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
++Follow the repository's documented scope for context files. In Dayova, `CONTEXT.md` may combine the domain glossary with concise, stable code-facing architecture, constraints, implementation contracts, and decision pointers that must evolve with the code. Keep shared product, business, research, and organizational knowledge in the canonical knowledge system and link to it instead of duplicating it. Do not treat `CONTEXT.md` as a task spec, scratch pad, status log, or implementation journal.
+ 
+ ### Offer ADRs sparingly
+ 

--- a/patches/matt-pocock-skills/dayova.patch
+++ b/patches/matt-pocock-skills/dayova.patch
@@ -472,7 +472,8 @@ index d0f7e1a..e535afd 100644
 -### Update CONTEXT.md inline
 +### Update context documentation inline
  
- When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+-When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
++When a term, stable code-facing constraint, or implementation contract is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
  
 -`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
 +Follow the repository's documented scope for context files. In Dayova, `CONTEXT.md` may combine the domain glossary with concise, stable code-facing architecture, constraints, implementation contracts, and decision pointers that must evolve with the code. Keep shared product, business, research, and organizational knowledge in the canonical knowledge system and link to it instead of duplicating it. Do not treat `CONTEXT.md` as a task spec, scratch pad, status log, or implementation journal.


### PR DESCRIPTION
## Summary

- replace current-facing Confluence guidance with Notion across `AGENTS.md`, the context map, and every affected domain context
- define the ownership boundary: Notion for internal knowledge and documentation, Linear for actionable work, and GitHub/repo ADRs for code-facing contracts
- require agents to consult the semantic Notion connector when internal context materially affects a task
- update validation-student integration terminology and link the canonical Notion `🎓 Students` database
- replace the stale `/grill-with-docs` producer reference with the installed `/domain-modeling` skill
- align `/domain-modeling` and Dayova's persistent Matt-skills patch overlay with the repository's broader context-document semantics

## Why

The repository guidance still described the pre-migration documentation model, so agents could treat the former documentation system as canonical or duplicate internal knowledge and task tracking in the wrong place.

## Impact

Agents now have one consistent documentation policy and explicit instructions for linking Notion, Linear, and GitHub without creating parallel sources of truth. The tracked repository contains no remaining references to the former documentation platform.

## Validation

- `git grep -ni confluence` — no matches
- `pnpm format:check`
- `pnpm check`
- `pnpm test` — 33 files, 145 tests passed
- `pnpm skills:validate` — 21 Matt Pocock skills and 22 Expo skills validated
- standalone `skill-creator/scripts/quick_validate.py .agents/skills/domain-modeling` — `Skill is valid!`
- verified semantic Notion access to the `Dayova` workspace and the canonical `🎓 Students` database


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation guidance to use Notion as the primary cross-functional knowledge workspace.
  * Clarified when to consult and how to link Notion records without duplicating shared content.
  * Refreshed context documentation across multiple areas (auth, backend, design, integrations, mobile, platform, and product).

* **Agent Skills & Workflow**
  * Revised domain-modeling templates and rules to emphasize stable code-facing contracts/constraints and canonical decision links.
  * Updated skill behaviors to favor inline answers and more independent, conditional subagent execution.
  * Expanded issue-tracker configuration guidance with improved Linear workflow semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->