### PR TITLE
Update README for current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,18 @@ and complete variable reference are documented in [`.env.example`](.env.example)
 Dayova currently supports native iOS and Android builds in portrait
 orientation. The Expo config intentionally excludes web; future web support is
 tracked in [DAY-45](https://linear.app/dayova/issue/DAY-45/track-future-web-support).
-The iOS app currently requires iOS 17 because of the native Clerk SDK.
+The current native build targets iOS 17 because
+[`@clerk/expo` 3.7.8's iOS pod](https://github.com/clerk/javascript/blob/%40clerk%2Fexpo%403.7.8/packages/expo/ios/ClerkExpo.podspec)
+links
+[Clerk iOS 1.3.2](https://github.com/clerk/clerk-ios/blob/1.3.2/Package.swift),
+and its
+[config plugin](https://github.com/clerk/javascript/blob/%40clerk%2Fexpo%403.7.8/packages/expo/app.plugin.js)
+enforces that dependency's iOS 17 minimum. Expo SDK 57 itself supports
+[iOS 16.4 and later](https://docs.expo.dev/versions/v57.0.0/). Dayova currently
+uses Clerk's JavaScript authentication path and
+[stubs the native iOS module](src/lib/patchClerkNativeEventEmitter.ts), so the
+native dependency and resulting support floor should be re-evaluated through a
+focused native experiment before changing the deployment target.
 
 ## Appearance and dark mode
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ optional validation analytics integration.
 - pnpm 10.25.0
 - The native toolchain for the target platform: Xcode on macOS or the Android
   SDK and Android Studio
-- Access to the Dayova Clerk and Convex development environments
+- Access to Clerk and Convex development environments (if you are part of the team, we should give you access to our internal Convex and Clerk teams for various reasons, but you can theoretically build and develop the app without being in them)
 
 This project contains native code and requires an Expo development build; it
 does not run in Expo Go.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Dayova MVP
 
-Dayova is a German-language learning app that helps learners turn upcoming
-exams and assignments into a `Persönlicher Lernplan`, work through guided
-`Theorie`, `Üben`, and `Praxis` sessions, and continue with their next learning
-step.
+Dayova is a German-language learning app that turns upcoming exams into a
+`Persönlicher Lernplan`, guides learners through `Theorie`, `Üben`, and
+`Praxis` sessions, and separately helps them schedule and manage homework.
 
 The app is built with Expo and React Native. Convex provides the backend, Clerk
 provides authentication, NativeWind provides styling, and PostHog provides the

--- a/README.md
+++ b/README.md
@@ -1,19 +1,121 @@
-# dayova-mvp
+# Dayova MVP
 
-`pnpm install` and then either `pnpm ios` or `pnpm android` to try out the app
+Dayova is a German-language learning app that helps learners turn upcoming
+exams and assignments into a `Persönlicher Lernplan`, work through guided
+`Theorie`, `Üben`, and `Praxis` sessions, and continue with their next learning
+step.
+
+The app is built with Expo and React Native. Convex provides the backend, Clerk
+provides authentication, NativeWind provides styling, and PostHog provides the
+optional validation analytics integration.
+
+## Local development
+
+### Prerequisites
+
+- Node.js 24 (the repository currently pins 24.18.0)
+- pnpm 10.25.0
+- The native toolchain for the target platform: Xcode on macOS or the Android
+  SDK and Android Studio
+- Access to the Dayova Clerk and Convex development environments
+
+This project contains native code and requires an Expo development build; it
+does not run in Expo Go.
+
+### Setup
+
+1. Install dependencies:
+
+   ```sh
+   pnpm install
+   ```
+
+2. Create `.env.local` using [`.env.example`](.env.example) as the reference.
+   `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` is required. The Convex CLI writes the
+   local `EXPO_PUBLIC_CONVEX_URL` when the development deployment starts.
+   PostHog variables are optional and analytics stays disabled when its API key
+   is absent.
+
+3. Build and start the app together with Convex:
+
+   ```sh
+   pnpm ios      # macOS only
+   pnpm android
+   ```
+
+   After a development build is installed, use `pnpm start` to start Metro and
+   Convex without rebuilding the native app.
+
+Backend-only secrets, including file-storage and Vertex AI credentials, belong
+in the Convex environment rather than in Expo public variables. The commands
+and complete variable reference are documented in [`.env.example`](.env.example).
 
 ## Platform support
 
-Dayova is currently native-only. Web support is intentionally not wired into local scripts or Expo config yet; track that work in https://github.com/Dayova/dayova-mvp/issues/32.
+Dayova currently supports native iOS and Android builds in portrait
+orientation. The Expo config intentionally excludes web; future web support is
+tracked in [DAY-45](https://linear.app/dayova/issue/DAY-45/track-future-web-support).
+The iOS app currently requires iOS 17 because of the native Clerk SDK.
 
-## Dark mode support
+## Appearance and dark mode
 
-Dayova currently implements the light-mode design system only. Dark mode is intentionally not wired into Tailwind, NativeWind, or shared component tokens yet; track that work in https://github.com/Dayova/dayova-mvp/issues/136.
+Light, dark, and system appearance modes are implemented. Learners can choose
+`Hell`, `System`, or `Dunkel` under **Settings → Design**, and the preference is
+persisted across app launches.
 
-## Styling
+The implementation includes:
 
-See [docs/styling.md](docs/styling.md) for NativeWind/Tailwind conventions, including the project-specific `tailwind-merge` configuration required for custom `text-*` size and color classes like `text-16 text-text`.
+- light and dark semantic color tokens for NativeWind;
+- matching runtime colors for React Navigation, native component props, the
+  root background, and status bars;
+- live system-appearance updates on Android and iOS; and
+- a local iOS appearance bridge that keeps system mode synchronized across
+  cold launch, foreground/background transitions, and OS appearance changes.
 
-# Windows
+Dark mode is functional but not considered complete. The remaining work is a
+cross-screen, real-device, and accessibility audit plus known visual cleanup.
+The current state is tracked in
+[DAY-44](https://linear.app/dayova/issue/DAY-44/dark-mode-support) and the
+completion audit in
+[DAY-101](https://linear.app/dayova/issue/DAY-101/audit-and-complete-dark-mode-design-system-support).
+Known open defects include notification styling
+([DAY-214](https://linear.app/dayova/issue/DAY-214/inconsistent-tab-icon-badge-and-typography-styling-in-light-and-dark))
+and dark-mode action spacing
+([DAY-215](https://linear.app/dayova/issue/DAY-215/inconsistent-spacing-in-dark-mode)).
 
-If you are on Windows you will need to download the ninja.exe from https://github.com/ninja-build/ninja/releases and put it into your `D:/ninja/ninja.exe` path or any other path set by the ´NINJA_PATH´ env variable. This is due to: https://github.com/expo/expo/issues/36274 see https://github.com/expo/expo/issues/36274#issuecomment-3521622624
+Theme tokens and runtime colors live in [`src/global.css`](src/global.css) and
+[`src/lib/theme.ts`](src/lib/theme.ts). Preference handling lives in
+[`src/lib/theme-preference.ts`](src/lib/theme-preference.ts). See the
+[design-system context](docs/contexts/design-system/CONTEXT.md) and the
+[iOS appearance module guide](modules/dayova-system-appearance/README.md) for
+the implementation rules and native validation matrix.
+
+## Project checks
+
+```sh
+pnpm check          # lint and TypeScript
+pnpm test           # Vitest suite
+pnpm format:check   # formatting and Tailwind class order
+pnpm check:unused   # unused files, dependencies, and exports
+```
+
+## Repository guidance
+
+- [Context map](CONTEXT-MAP.md): architecture and domain documentation
+- [Styling guide](docs/styling.md): NativeWind, typography, tokens, and class
+  merging conventions
+- [Bottom-sheet guide](docs/bottom-sheets.md): shared sheet behavior
+- [Release guide](release/README.md): production builds and OTA safety
+- [Issue-tracker guide](docs/agents/issue-tracker.md): Linear is the source of
+  truth for issues and PRDs; GitHub Issues is the synchronized compatibility
+  surface
+
+## Windows Android builds
+
+Windows Android builds require a standalone `ninja.exe` because of the native
+CMake path-length workaround in [`plugins/withNinjaLongPaths.js`](plugins/withNinjaLongPaths.js).
+Download Ninja from the
+[official releases](https://github.com/ninja-build/ninja/releases), then either
+place it at `D:\ninja\ninja.exe` or set `NINJA_PATH` to its absolute path. See
+the related [Expo issue](https://github.com/expo/expo/issues/36274) for the
+underlying limitation.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ pnpm check:unused   # unused files, dependencies, and exports
 - [Issue-tracker guide](docs/agents/issue-tracker.md): Linear is the source of
   truth for issues and PRDs; GitHub Issues is the synchronized compatibility
   surface
+- [Triage-label guide](docs/agents/triage-labels.md): follow its required label
+  mappings instead of substituting similarly named Linear labels
 
 ## Windows Android builds
 


### PR DESCRIPTION
## Summary

- expand the README with the current product, local-development, platform, validation, and repository guidance
- document light, dark, and system appearance as implemented while clearly separating the remaining device, accessibility, and visual QA
- replace stale GitHub issue references with the canonical Linear issues and link the current dark-mode follow-up defects
- clarify the Windows Android Ninja workaround and current Node/pnpm requirements

## Why

The README still described Dayova as light-mode-only even though semantic dark tokens, persisted Hell/System/Dunkel preferences, runtime theme integration, and the iOS appearance bridge are implemented. It also pointed contributors to GitHub Issues even though Linear is now the source of truth.

## Impact

Contributors get an accurate setup path and a concise view of supported platforms. The appearance section now reflects the actual implementation without presenting the remaining cross-screen and real-device audit as finished.

## Validation

- `pnpm format:check`
- `pnpm exec vitest run src/lib/theme-preference.test.ts src/lib/theme-css.test.ts src/lib/ios-appearance-module.test.ts` — 3 files, 9 tests passed
- `git diff --check`
- verified every repository-local README link resolves

The available shell used Node 22.22.3 and emitted the expected engine warning; the repository and updated README pin Node 24.18.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded onboarding instructions with prerequisites, environment setup, and platform-specific development guidance.
  * Clarified native iOS and Android support, portrait-only behavior, and the exclusion of web support.
  * Added details about appearance modes, persisted preferences, known dark-mode issues, project checks, repository guidance, and Windows Android build requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->