### PR TITLE
DAY-253: Replace school-name text with bounded school types

### DIFF
--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -2,6 +2,7 @@
 
 import { convexTest } from "convex-test";
 import { expect, test } from "vitest";
+import { GERMAN_FEDERAL_STATES } from "../src/lib/federal-states";
 import { api, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import schema from "./schema";
@@ -451,7 +452,7 @@ test("bounded school types survive authenticated profile and onboarding writes",
 		"other",
 		"prefer_not_to_say",
 	] as const;
-	const t = convexTest(schema, modules).withIdentity(studentIdentity);
+	const t = convexTest(schema, modules).withIdentity(userIdentity);
 
 	const userId = await t.mutation(api.users.syncCurrentUser, {});
 	for (const schoolType of supportedSchoolTypes) {
@@ -463,7 +464,7 @@ test("bounded school types survive authenticated profile and onboarding writes",
 		});
 		await expect(
 			t.mutation(api.users.saveOnboardingAnswers, {
-				answers: { ...onboardingAnswers("9"), schoolType },
+				answers: { ...onboardingAnswers({ grade: "9" }), schoolType },
 			}),
 		).resolves.toEqual({ success: true });
 	}
@@ -522,6 +523,67 @@ test("grade 13 survives the authenticated Convex profile round trip", async () =
 	expect(savedGrade).toMatchObject({ answer: "13" });
 });
 
+test("bounded federal states stay selectable and survive profile and onboarding writes", async () => {
+	const t = convexTest(schema, modules).withIdentity(userIdentity);
+
+	const userId = await t.mutation(api.users.syncCurrentUser, {
+		state: "Mecklenburg-Vorpommern",
+	});
+	await expect(t.query(api.users.getMe, {})).resolves.toMatchObject({
+		state: "Mecklenburg-Vorpommern",
+	});
+
+	await expect(
+		t.mutation(api.users.saveOnboardingAnswers, {
+			answers: {
+				...onboardingAnswers({ grade: "13" }),
+				state: "Baden-Württemberg",
+			},
+		}),
+	).resolves.toEqual({ success: true });
+
+	const stateQuestion = await t.run(async (ctx) =>
+		ctx.db
+			.query("onboardingQuestions")
+			.withIndex("by_key", (q) => q.eq("key", "state"))
+			.unique(),
+	);
+	expect(stateQuestion).toMatchObject({
+		prompt: "Aus welchem Bundesland kommst du?",
+		kind: "select",
+		options: GERMAN_FEDERAL_STATES,
+	});
+	if (!stateQuestion) throw new Error("Missing state question.");
+	await expect(
+		t.run(async (ctx) =>
+			ctx.db
+				.query("userOnboardingAnswers")
+				.withIndex("by_userId_and_questionId", (q) =>
+					q.eq("userId", userId).eq("questionId", stateQuestion._id),
+				)
+				.unique(),
+		),
+	).resolves.toMatchObject({ answer: "Baden-Württemberg" });
+});
+
+test("profile and onboarding writes reject values outside the federal-state vocabulary", async () => {
+	const t = convexTest(schema, modules).withIdentity(userIdentity);
+
+	await expect(
+		t.mutation(api.users.syncCurrentUser, { state: "private state" }),
+	).rejects.toThrow("Bundesland");
+
+	await t.mutation(api.users.syncCurrentUser, { state: "Bayern" });
+	await expect(
+		t.mutation(api.users.updateProfile, { state: "Atlantis" }),
+	).rejects.toThrow("Bundesland");
+	await expect(
+		t.mutation(api.users.saveOnboardingAnswers, {
+			answers: { ...onboardingAnswers({ grade: "9" }), state: "Saxony" },
+		}),
+	).rejects.toThrow("Bundesland");
+});
+
 test("profile and onboarding writes reject grades outside the product vocabulary", async () => {
 	const t = convexTest(schema, modules).withIdentity(userIdentity);
 
@@ -541,7 +603,7 @@ test("profile and onboarding writes reject grades outside the product vocabulary
 });
 
 test("profile and onboarding writes reject free-text school names", async () => {
-	const t = convexTest(schema, modules).withIdentity(studentIdentity);
+	const t = convexTest(schema, modules).withIdentity(userIdentity);
 
 	await expect(
 		t.mutation(api.users.syncCurrentUser, {
@@ -558,7 +620,7 @@ test("profile and onboarding writes reject free-text school names", async () => 
 	await expect(
 		t.mutation(api.users.saveOnboardingAnswers, {
 			answers: {
-				...onboardingAnswers("9"),
+				...onboardingAnswers({ grade: "9" }),
 				schoolType: "Goethe-Gymnasium Dresden",
 			},
 		}),
@@ -566,12 +628,12 @@ test("profile and onboarding writes reject free-text school names", async () => 
 });
 
 test("profile sync maps generic legacy values and clears school names", async () => {
-	const t = convexTest(schema, modules).withIdentity(studentIdentity);
+	const t = convexTest(schema, modules).withIdentity(userIdentity);
 	const { userId, schoolTypeQuestionId } = await t.run(async (ctx) => {
 		const insertedUserId = await ctx.db.insert("users", {
-			tokenIdentifier: studentIdentity.tokenIdentifier,
-			clerkId: studentIdentity.subject,
-			email: studentIdentity.email,
+			tokenIdentifier: userIdentity.tokenIdentifier,
+			clerkId: userIdentity.subject,
+			email: userIdentity.email,
 			schoolType: "Goethe-Gymnasium Dresden",
 		});
 		const insertedQuestionId = await ctx.db.insert("onboardingQuestions", {

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -40,7 +40,7 @@ const onboardingAnswers = (
 	challenge: "Zeitmanagement",
 	goal: "Bessere Noten",
 	state: "Sachsen",
-	schoolType: "Gymnasium",
+	schoolType: "gymnasium",
 	grade: "9",
 	dailySchoolTime: "45 min",
 	studyDays: "Montag, Mittwoch",
@@ -441,6 +441,57 @@ test("legacy recovery leaves manual settings authoritative and skips unsafe answ
 	);
 });
 
+test("bounded school types survive authenticated profile and onboarding writes", async () => {
+	const supportedSchoolTypes = [
+		"gymnasium",
+		"secondary_general",
+		"comprehensive",
+		"hauptschule",
+		"vocational",
+		"other",
+		"prefer_not_to_say",
+	] as const;
+	const t = convexTest(schema, modules).withIdentity(studentIdentity);
+
+	const userId = await t.mutation(api.users.syncCurrentUser, {});
+	for (const schoolType of supportedSchoolTypes) {
+		await expect(
+			t.mutation(api.users.updateProfile, { schoolType }),
+		).resolves.toEqual({ success: true });
+		await expect(t.query(api.users.getMe, {})).resolves.toMatchObject({
+			schoolType,
+		});
+		await expect(
+			t.mutation(api.users.saveOnboardingAnswers, {
+				answers: { ...onboardingAnswers("9"), schoolType },
+			}),
+		).resolves.toEqual({ success: true });
+	}
+
+	const storedQuestion = await t.run(async (ctx) =>
+		ctx.db
+			.query("onboardingQuestions")
+			.withIndex("by_key", (q) => q.eq("key", "schoolType"))
+			.unique(),
+	);
+	expect(storedQuestion).toMatchObject({
+		prompt: "Welche Schulart besuchst du?",
+		kind: "select",
+		options: supportedSchoolTypes,
+	});
+	if (!storedQuestion) throw new Error("Missing school type question.");
+	await expect(
+		t.run(async (ctx) =>
+			ctx.db
+				.query("userOnboardingAnswers")
+				.withIndex("by_userId_and_questionId", (q) =>
+					q.eq("userId", userId).eq("questionId", storedQuestion._id),
+				)
+				.unique(),
+		),
+	).resolves.toMatchObject({ answer: "prefer_not_to_say" });
+});
+
 test("grade 13 survives the authenticated Convex profile round trip", async () => {
 	const t = convexTest(schema, modules).withIdentity(userIdentity);
 
@@ -487,4 +538,92 @@ test("profile and onboarding writes reject grades outside the product vocabulary
 			answers: onboardingAnswers({ grade: "14" }),
 		}),
 	).rejects.toThrow("Klassenstufe");
+});
+
+test("profile and onboarding writes reject free-text school names", async () => {
+	const t = convexTest(schema, modules).withIdentity(studentIdentity);
+
+	await expect(
+		t.mutation(api.users.syncCurrentUser, {
+			schoolType: "Goethe-Gymnasium Dresden",
+		}),
+	).rejects.toThrow("Schulart");
+
+	await t.mutation(api.users.syncCurrentUser, { schoolType: "gymnasium" });
+	await expect(
+		t.mutation(api.users.updateProfile, {
+			schoolType: "Realschule am Stadtpark",
+		}),
+	).rejects.toThrow("Schulart");
+	await expect(
+		t.mutation(api.users.saveOnboardingAnswers, {
+			answers: {
+				...onboardingAnswers("9"),
+				schoolType: "Goethe-Gymnasium Dresden",
+			},
+		}),
+	).rejects.toThrow("Schulart");
+});
+
+test("profile sync maps generic legacy values and clears school names", async () => {
+	const t = convexTest(schema, modules).withIdentity(studentIdentity);
+	const { userId, schoolTypeQuestionId } = await t.run(async (ctx) => {
+		const insertedUserId = await ctx.db.insert("users", {
+			tokenIdentifier: studentIdentity.tokenIdentifier,
+			clerkId: studentIdentity.subject,
+			email: studentIdentity.email,
+			schoolType: "Goethe-Gymnasium Dresden",
+		});
+		const insertedQuestionId = await ctx.db.insert("onboardingQuestions", {
+			key: "schoolType",
+			prompt: "Welche Schule besuchst du?",
+			kind: "input",
+			order: 5,
+		});
+		await ctx.db.insert("userOnboardingAnswers", {
+			userId: insertedUserId,
+			questionId: insertedQuestionId,
+			answer: "Goethe-Gymnasium Dresden",
+		});
+		return {
+			userId: insertedUserId,
+			schoolTypeQuestionId: insertedQuestionId,
+		};
+	});
+
+	await t.mutation(api.users.syncCurrentUser, {});
+	expect(await t.query(api.users.getMe, {})).not.toHaveProperty("schoolType");
+	await expect(
+		t.run(async (ctx) =>
+			ctx.db
+				.query("userOnboardingAnswers")
+				.withIndex("by_userId_and_questionId", (q) =>
+					q.eq("userId", userId).eq("questionId", schoolTypeQuestionId),
+				)
+				.unique(),
+		),
+	).resolves.toBeNull();
+
+	await t.run(async (ctx) => {
+		await ctx.db.patch("users", userId, { schoolType: "Gymnasium" });
+		await ctx.db.insert("userOnboardingAnswers", {
+			userId,
+			questionId: schoolTypeQuestionId,
+			answer: "Gymnasium",
+		});
+	});
+	await t.mutation(api.users.syncCurrentUser, {});
+	await expect(t.query(api.users.getMe, {})).resolves.toMatchObject({
+		schoolType: "gymnasium",
+	});
+	await expect(
+		t.run(async (ctx) =>
+			ctx.db
+				.query("userOnboardingAnswers")
+				.withIndex("by_userId_and_questionId", (q) =>
+					q.eq("userId", userId).eq("questionId", schoolTypeQuestionId),
+				)
+				.unique(),
+		),
+	).resolves.toMatchObject({ answer: "gymnasium" });
 });

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -466,7 +466,7 @@ test("bounded school types survive authenticated profile and onboarding writes",
 			t.mutation(api.users.saveOnboardingAnswers, {
 				answers: { ...onboardingAnswers({ grade: "9" }), schoolType },
 			}),
-		).resolves.toEqual({ success: true });
+		).resolves.toMatchObject({ success: true });
 	}
 
 	const storedQuestion = await t.run(async (ctx) =>
@@ -540,7 +540,7 @@ test("bounded federal states stay selectable and survive profile and onboarding 
 				state: "Baden-Württemberg",
 			},
 		}),
-	).resolves.toEqual({ success: true });
+	).resolves.toMatchObject({ success: true });
 
 	const stateQuestion = await t.run(async (ctx) =>
 		ctx.db

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,6 +1,11 @@
 import { v } from "convex/values";
 import { GERMAN_FEDERAL_STATES } from "../src/lib/federal-states";
 import { GRADE_OPTIONS, isSupportedGrade } from "../src/lib/grades";
+import {
+	isSupportedSchoolType,
+	normalizeLegacySchoolType,
+	SCHOOL_TYPE_VALUES,
+} from "../src/lib/school-types";
 import type { Id } from "./_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { mutation, query } from "./_generated/server";
@@ -116,9 +121,10 @@ const DEFAULT_ONBOARDING_QUESTIONS: Array<{
 	},
 	{
 		key: "schoolType",
-		prompt: "Welche Schule besuchst du?",
-		kind: "input" as const,
+		prompt: "Welche Schulart besuchst du?",
+		kind: "select" as const,
 		order: 5,
+		options: [...SCHOOL_TYPE_VALUES],
 	},
 	{
 		key: "grade",
@@ -292,6 +298,15 @@ const normalizeOptionalGrade = (grade?: string) => {
 	return normalizedGrade;
 };
 
+const normalizeOptionalSchoolType = (schoolType?: string) => {
+	const normalizedSchoolType = schoolType?.trim();
+	if (!normalizedSchoolType) return undefined;
+	if (!isSupportedSchoolType(normalizedSchoolType)) {
+		throwUserFacingError("Bitte wähle eine gültige Schulart aus.");
+	}
+	return normalizedSchoolType;
+};
+
 const profileFields = (args: {
 	email?: string;
 	name?: string;
@@ -304,19 +319,50 @@ const profileFields = (args: {
 	validationStudentCode?: string;
 }) => {
 	const grade = normalizeOptionalGrade(args.grade);
+	const schoolType = normalizeOptionalSchoolType(args.schoolType);
 	return {
 		...(args.email !== undefined ? { email: normalizeEmail(args.email) } : {}),
 		...(args.name !== undefined ? { name: args.name } : {}),
 		...(args.phone !== undefined ? { phone: args.phone } : {}),
 		...(args.birthDate !== undefined ? { birthDate: args.birthDate } : {}),
 		...(grade !== undefined ? { grade } : {}),
-		...(args.schoolType !== undefined ? { schoolType: args.schoolType } : {}),
+		...(schoolType !== undefined ? { schoolType } : {}),
 		...(args.state !== undefined ? { state: args.state } : {}),
 		...(args.avatarUrl !== undefined ? { avatarUrl: args.avatarUrl } : {}),
 		...(args.validationStudentCode !== undefined
 			? { validationStudentCode: args.validationStudentCode }
 			: {}),
 	};
+};
+
+const sanitizeLegacyOnboardingSchoolType = async (
+	ctx: MutationCtx,
+	userId: Id<"users">,
+) => {
+	const question = await ctx.db
+		.query("onboardingQuestions")
+		.withIndex("by_key", (q) => q.eq("key", "schoolType"))
+		.unique();
+	if (!question) return;
+
+	const answer = await ctx.db
+		.query("userOnboardingAnswers")
+		.withIndex("by_userId_and_questionId", (q) =>
+			q.eq("userId", userId).eq("questionId", question._id),
+		)
+		.unique();
+	if (!answer) return;
+
+	const schoolType = normalizeLegacySchoolType(answer.answer);
+	if (!schoolType) {
+		await ctx.db.delete("userOnboardingAnswers", answer._id);
+		return;
+	}
+	if (schoolType !== answer.answer) {
+		await ctx.db.patch("userOnboardingAnswers", answer._id, {
+			answer: schoolType,
+		});
+	}
 };
 
 export const syncCurrentUser = mutation({
@@ -356,7 +402,15 @@ export const syncCurrentUser = mutation({
 
 		let userId: Id<"users">;
 		if (existingUser) {
-			await ctx.db.patch("users", existingUser._id, user);
+			const schoolType =
+				args.schoolType === undefined
+					? normalizeLegacySchoolType(existingUser.schoolType)
+					: normalizeOptionalSchoolType(args.schoolType);
+			await ctx.db.patch("users", existingUser._id, {
+				...user,
+				schoolType,
+			});
+			await sanitizeLegacyOnboardingSchoolType(ctx, existingUser._id);
 			userId = existingUser._id;
 		} else {
 			userId = await ctx.db.insert("users", user);
@@ -443,6 +497,12 @@ export const saveOnboardingAnswers = mutation({
 		if (!normalizedGrade) {
 			throwUserFacingError("Bitte wähle eine gültige Klassenstufe aus.");
 		}
+		const normalizedSchoolType = normalizeOptionalSchoolType(
+			args.answers.schoolType,
+		);
+		if (!normalizedSchoolType) {
+			throwUserFacingError("Bitte wähle eine gültige Schulart aus.");
+		}
 
 		const learningTimes = await insertLearningTimesWhenAbsent(ctx, {
 			ownerTokenIdentifier: identity.tokenIdentifier,
@@ -493,7 +553,11 @@ export const saveOnboardingAnswers = mutation({
 			[keyof typeof args.answers, string]
 		>) {
 			const normalizedAnswer =
-				key === "grade" ? normalizedGrade : answer.trim();
+				key === "grade"
+					? normalizedGrade
+					: key === "schoolType"
+						? normalizedSchoolType
+						: answer.trim();
 			if (!normalizedAnswer) continue;
 
 			const questionId = questionIdsByKey[key];

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,5 +1,8 @@
 import { v } from "convex/values";
-import { GERMAN_FEDERAL_STATES } from "../src/lib/federal-states";
+import {
+	GERMAN_FEDERAL_STATES,
+	isGermanFederalState,
+} from "../src/lib/federal-states";
 import { GRADE_OPTIONS, isSupportedGrade } from "../src/lib/grades";
 import {
 	isSupportedSchoolType,
@@ -298,6 +301,15 @@ const normalizeOptionalGrade = (grade?: string) => {
 	return normalizedGrade;
 };
 
+const normalizeOptionalFederalState = (state?: string) => {
+	const normalizedState = state?.trim();
+	if (!normalizedState) return undefined;
+	if (!isGermanFederalState(normalizedState)) {
+		throwUserFacingError("Bitte wähle ein gültiges Bundesland aus.");
+	}
+	return normalizedState;
+};
+
 const normalizeOptionalSchoolType = (schoolType?: string) => {
 	const normalizedSchoolType = schoolType?.trim();
 	if (!normalizedSchoolType) return undefined;
@@ -320,6 +332,7 @@ const profileFields = (args: {
 }) => {
 	const grade = normalizeOptionalGrade(args.grade);
 	const schoolType = normalizeOptionalSchoolType(args.schoolType);
+	const state = normalizeOptionalFederalState(args.state);
 	return {
 		...(args.email !== undefined ? { email: normalizeEmail(args.email) } : {}),
 		...(args.name !== undefined ? { name: args.name } : {}),
@@ -327,7 +340,7 @@ const profileFields = (args: {
 		...(args.birthDate !== undefined ? { birthDate: args.birthDate } : {}),
 		...(grade !== undefined ? { grade } : {}),
 		...(schoolType !== undefined ? { schoolType } : {}),
-		...(args.state !== undefined ? { state: args.state } : {}),
+		...(state !== undefined ? { state } : {}),
 		...(args.avatarUrl !== undefined ? { avatarUrl: args.avatarUrl } : {}),
 		...(args.validationStudentCode !== undefined
 			? { validationStudentCode: args.validationStudentCode }
@@ -503,6 +516,10 @@ export const saveOnboardingAnswers = mutation({
 		if (!normalizedSchoolType) {
 			throwUserFacingError("Bitte wähle eine gültige Schulart aus.");
 		}
+		const normalizedState = normalizeOptionalFederalState(args.answers.state);
+		if (!normalizedState) {
+			throwUserFacingError("Bitte wähle ein gültiges Bundesland aus.");
+		}
 
 		const learningTimes = await insertLearningTimesWhenAbsent(ctx, {
 			ownerTokenIdentifier: identity.tokenIdentifier,
@@ -555,9 +572,11 @@ export const saveOnboardingAnswers = mutation({
 			const normalizedAnswer =
 				key === "grade"
 					? normalizedGrade
-					: key === "schoolType"
-						? normalizedSchoolType
-						: answer.trim();
+					: key === "state"
+						? normalizedState
+						: key === "schoolType"
+							? normalizedSchoolType
+							: answer.trim();
 			if (!normalizedAnswer) continue;
 
 			const questionId = questionIdsByKey[key];

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -418,7 +418,7 @@ export const syncCurrentUser = mutation({
 			const schoolType =
 				args.schoolType === undefined
 					? normalizeLegacySchoolType(existingUser.schoolType)
-					: normalizeOptionalSchoolType(args.schoolType);
+					: user.schoolType;
 			await ctx.db.patch("users", existingUser._id, {
 				...user,
 				schoolType,

--- a/docs/contexts/auth/CONTEXT.md
+++ b/docs/contexts/auth/CONTEXT.md
@@ -8,6 +8,10 @@ Notion is Dayova's main internal documentation and knowledge workspace. Keep thi
 
 - Registration is password-based: the learner enters an E-Mail address, sets a
   password, then confirms the account with a 6-digit E-Mail code.
+- Clerk `unsafeMetadata.schoolType` stores only the stable bounded `Schulart`
+  key. Exact generic legacy labels are normalized on authentication; ambiguous
+  values such as school names are removed without including the raw value in
+  diagnostics.
 - Native session lifetime, per-device logout, compromise response, app-lock,
   and step-up decisions are recorded in
   [ADR 0001](adr/0001-native-session-policy.md).

--- a/docs/contexts/backend-convex/CONTEXT.md
+++ b/docs/contexts/backend-convex/CONTEXT.md
@@ -18,5 +18,9 @@ _Avoid_: User-facing message, learner error text
 
 ## Notes
 
+- Convex keeps `users.schoolType` schema-compatible with legacy strings while
+  every current write boundary accepts only the seven stable `Schulart` keys.
+  Authenticated profile sync lazily maps exact generic legacy values and
+  removes ambiguous user/profile-answer values without logging them.
 - Capture backend data model, function boundaries, and migration decisions here.
 - Put backend ADRs in `docs/contexts/backend-convex/adr/`.

--- a/docs/contexts/integrations/CONTEXT.md
+++ b/docs/contexts/integrations/CONTEXT.md
@@ -41,8 +41,10 @@ The Clerk user ID is the PostHog `distinctId` and is not duplicated as a
 - `grade`, only one of `6`, `7`, `8`, `9`, `10`, `11`, `12`, or `13`
 - `state`, only one of the 16 German federal-state names used by onboarding
 
-`school_type` is intentionally excluded until DAY-253 supplies a bounded
-product field and a reviewed follow-up changes this contract.
+The product `Schulart` field is bounded by DAY-253, but `school_type` remains
+intentionally excluded from PostHog. Adding it requires a separate, reviewed
+change to this analytics contract; the product field alone does not authorize
+collection.
 
 Every custom event receives `analytics_schema_version` centrally. It may also
 receive `validation_student_code`, `eas_update_id`, `eas_channel`,

--- a/docs/contexts/mobile-app/CONTEXT.md
+++ b/docs/contexts/mobile-app/CONTEXT.md
@@ -34,9 +34,10 @@ _Avoid_: Called by client, Server Error, raw stack trace
 
 ## Notes
 
-- Onboarding asks “Welche Schulart besuchst du?” through the native bounded
-  picker. “Keine Angabe” is the privacy-safe default; there is no school-name
-  input or free-text “other” follow-up.
+- Onboarding asks “Welche Schulart besuchst du?” through the shared
+  `OnboardingSelect` / `SelectSheet` bottom-sheet contract. “Keine Angabe” is
+  the privacy-safe default; there is no school-name input or free-text “other”
+  follow-up.
 - Capture app architecture, routing, UI, and native behavior decisions here.
 - Put mobile-app ADRs in `docs/contexts/mobile-app/adr/`.
 - NativeWind is part of the build pipeline, not only runtime styling. Release

--- a/docs/contexts/mobile-app/CONTEXT.md
+++ b/docs/contexts/mobile-app/CONTEXT.md
@@ -34,6 +34,9 @@ _Avoid_: Called by client, Server Error, raw stack trace
 
 ## Notes
 
+- Onboarding asks “Welche Schulart besuchst du?” through the native bounded
+  picker. “Keine Angabe” is the privacy-safe default; there is no school-name
+  input or free-text “other” follow-up.
 - Capture app architecture, routing, UI, and native behavior decisions here.
 - Put mobile-app ADRs in `docs/contexts/mobile-app/adr/`.
 - NativeWind is part of the build pipeline, not only runtime styling. Release

--- a/docs/contexts/platform/CONTEXT.md
+++ b/docs/contexts/platform/CONTEXT.md
@@ -16,7 +16,7 @@ _Avoid_: User-facing message, learner error text
 - `EXPO_PUBLIC_POSTHOG_API_KEY` enables PostHog analytics in the Expo app. Leave it empty to disable analytics locally.
 - `EXPO_PUBLIC_POSTHOG_HOST` defaults to `https://eu.i.posthog.com`; use a Dayova-owned reverse proxy only if event delivery or privacy requirements justify the extra infrastructure.
 - Analytics events must go through `src/lib/analytics.ts`. PostHog autocapture, lifecycle events, anonymous pre-auth tracking, and session replay are intentionally disabled for the validation phase.
-- Clerk user ID is the PostHog `distinctId`, never a `clerk_id` property. Custom identity is exactly optional `convex_user_id`, optional `validation_student_code`, bounded `grade` (`6` through `13`), and bounded German federal `state`; `school_type` is excluded pending DAY-253.
+- Clerk user ID is the PostHog `distinctId`, never a `clerk_id` property. Custom identity is exactly optional `convex_user_id`, optional `validation_student_code`, bounded `grade` (`6` through `13`), and bounded German federal `state`; the bounded product `Schulart` remains excluded as `school_type` until a separate reviewed analytics-contract change.
 - Names, email addresses, birth dates, avatar URLs, school names, raw notes, filenames, uploaded content, learner answers, transcripts, and diagnostic error detail are never custom PostHog person or event properties.
 - Capture platform conventions, release processes, and environment decisions here.
 - Put platform ADRs in `docs/contexts/platform/adr/`.

--- a/docs/contexts/product/CONTEXT.md
+++ b/docs/contexts/product/CONTEXT.md
@@ -70,6 +70,10 @@ _Avoid_: Treating Praxis as a fourth phase separate from rehearsal, requiring on
 A focused learning period where Dayova is tested with a small number of students who have real school deadlines, to learn whether the product causes earlier and more committed action.
 _Avoid_: Treating generic app usage, polite feedback, or TestFlight downloads as validation.
 
+**Schulart**:
+The optional, coarse category a learner selects during onboarding. Store one stable key (`gymnasium`, `secondary_general`, `comprehensive`, `hauptschule`, `vocational`, `other`, or `prefer_not_to_say`) and show its German label; `prefer_not_to_say` is the ordinary “Keine Angabe” choice.
+_Avoid_: School name, free-text school field, inferring a category from an identifiable name
+
 **First Real Block**:
 The first genuine learning or work block a student starts for a real exam, assignment, presentation, or graded task before the last possible moment.
 _Avoid_: Counting planning-only activity or artificial test tasks as this signal.

--- a/src/app/profile.tsx
+++ b/src/app/profile.tsx
@@ -87,7 +87,7 @@ export default function ProfileScreen() {
 				name: normalizedName,
 				birthDate: user?.birthDate ?? "",
 				grade: user?.grade ?? "",
-				schoolType: user?.schoolType ?? "",
+				schoolType: user?.schoolType,
 				state: user?.state ?? "",
 			});
 

--- a/src/components/onboarding/onboarding-flow.test.ts
+++ b/src/components/onboarding/onboarding-flow.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 import type { OnboardingAnswers } from "~/context/OnboardingContext";
-import { prepareClerkRegistration } from "~/lib/clerk-registration";
+import {
+	type ClerkRegistrationInput,
+	prepareClerkRegistration,
+} from "~/lib/clerk-registration";
 import {
 	getNextOnboardingStepIndex,
 	getOnboardingRegistrationPayload,
@@ -15,7 +18,7 @@ const answers = (
 	challenge: "Organisation",
 	goal: "Mehr Struktur im Lernen",
 	state: "Sachsen",
-	schoolType: "Gymnasium",
+	schoolType: "gymnasium",
 	grade: "9",
 	dailySchoolTime: "60 min",
 	studyDays: "Montag, Mittwoch",
@@ -85,7 +88,7 @@ describe("onboarding flow decisions", () => {
 			password: "supersecret",
 			birthDate: "09.09.2012",
 			grade: "13",
-			schoolType: "Gymnasium",
+			schoolType: "gymnasium",
 			state: "Sachsen",
 		});
 
@@ -95,6 +98,32 @@ describe("onboarding flow decisions", () => {
 				unsafeMetadata: { grade: "13" },
 			},
 		});
+	});
+
+	test("keeps the bounded school type through the Clerk registration boundary", () => {
+		const registrationPayload = getOnboardingRegistrationPayload(
+			answers({ schoolType: "prefer_not_to_say" }),
+		);
+
+		expect(prepareClerkRegistration(registrationPayload)).toMatchObject({
+			profile: { schoolType: "prefer_not_to_say" },
+			signUp: {
+				unsafeMetadata: { schoolType: "prefer_not_to_say" },
+			},
+		});
+	});
+
+	test("rejects unsupported school types at the Clerk registration boundary", () => {
+		const invalidPayload = {
+			...getOnboardingRegistrationPayload(answers()),
+			schoolType: "Goethe-Gymnasium Dresden",
+		};
+
+		expect(() =>
+			prepareClerkRegistration(
+				invalidPayload as unknown as ClerkRegistrationInput,
+			),
+		).toThrow("Bitte wähle eine gültige Schulart aus.");
 	});
 
 	test("rejects unsupported states at the Clerk registration boundary", () => {

--- a/src/components/onboarding/onboarding-flow.ts
+++ b/src/components/onboarding/onboarding-flow.ts
@@ -6,7 +6,7 @@ type AnswerStepKind = "chips" | "goals" | "range" | "wheel";
 export type OnboardingDecisionStep =
 	| {
 			kind: "text";
-			field: "email" | "name" | "password" | "schoolType";
+			field: "email" | "name" | "password";
 	  }
 	| { kind: AnswerStepKind; field: keyof OnboardingAnswers }
 	| { kind: "fact" | "infoStack" | "intro" };
@@ -30,9 +30,6 @@ export function getOnboardingStepDecision(
 		const value = answers[step.field];
 		if (step.field === "name" && !isValidName(value)) {
 			return { action: "advance", error: "Bitte gib deinen Namen ein." };
-		}
-		if (step.field === "schoolType" && value.trim().length < 2) {
-			return { action: "advance", error: "Bitte gib deine Schulform ein." };
 		}
 		if (step.field === "email" && !isValidEmail(value)) {
 			return {
@@ -79,6 +76,6 @@ export const getOnboardingRegistrationPayload = (
 	password: answers.password,
 	birthDate: answers.birthDate,
 	grade: answers.grade,
-	schoolType: answers.schoolType,
+	schoolType: answers.schoolType || undefined,
 	state: answers.state,
 });

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -55,6 +55,11 @@ import {
 } from "~/lib/password-reverification";
 import { signOutAndResetState } from "~/lib/logout-state";
 import { isSupportedGrade } from "~/lib/grades";
+import {
+	isSupportedSchoolType,
+	normalizeLegacySchoolType,
+	type SupportedSchoolType,
+} from "~/lib/school-types";
 
 type LoginInput = {
 	email: string;
@@ -66,7 +71,7 @@ type UpdateProfileInput = {
 	name: string;
 	birthDate: string;
 	grade: string;
-	schoolType: string;
+	schoolType?: SupportedSchoolType;
 	state: string;
 };
 
@@ -77,7 +82,7 @@ type AuthUser = {
 	phone?: string;
 	birthDate?: string;
 	grade?: string;
-	schoolType?: string;
+	schoolType?: SupportedSchoolType;
 	state?: string;
 	avatarUrl?: string;
 	validationStudentCode?: string;
@@ -153,6 +158,17 @@ const AccountActionsContext = createContext<
 
 const getMetadataString = (metadata: Record<string, unknown>, key: string) =>
 	typeof metadata[key] === "string" ? metadata[key] : undefined;
+
+const normalizeOptionalSchoolTypeInput = (
+	value: unknown,
+): SupportedSchoolType | undefined => {
+	if (typeof value !== "string" || value.trim().length === 0) return undefined;
+	const normalizedValue = value.trim();
+	if (!isSupportedSchoolType(normalizedValue)) {
+		throw new Error("Bitte wähle eine gültige Schulart aus.");
+	}
+	return normalizedValue;
+};
 
 const getGermanClerkErrorByCode = (code?: string) => {
 	switch (code) {
@@ -405,6 +421,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 			clerkName.trim().length > 0
 				? clerkName
 				: getMetadataString(unsafeMetadata, "name");
+		const schoolType = normalizeLegacySchoolType(
+			getMetadataString(unsafeMetadata, "schoolType"),
+		);
 
 		return {
 			clerkId: clerkUser.id,
@@ -415,7 +434,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 				clerkUser.primaryPhoneNumber?.phoneNumber,
 			birthDate: getMetadataString(unsafeMetadata, "birthDate"),
 			grade: getMetadataString(unsafeMetadata, "grade"),
-			schoolType: getMetadataString(unsafeMetadata, "schoolType"),
+			schoolType,
 			state: getMetadataString(unsafeMetadata, "state"),
 			avatarUrl: clerkUser.imageUrl,
 			validationStudentCode: getMetadataString(
@@ -423,6 +442,29 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 				"validationStudentCode",
 			),
 		};
+	}, [clerkUser]);
+
+	useEffect(() => {
+		if (!clerkUser) return;
+		const rawSchoolType = getMetadataString(
+			clerkUser.unsafeMetadata ?? {},
+			"schoolType",
+		);
+		if (!rawSchoolType) return;
+		const schoolType = normalizeLegacySchoolType(rawSchoolType);
+		if (schoolType === rawSchoolType) return;
+
+		void clerkUser
+			.updateMetadata({
+				unsafeMetadata: { schoolType: schoolType ?? null },
+			})
+			.catch(() => {
+				logDiagnosticError(
+					"Failed to sanitize legacy school type metadata.",
+					new Error("Clerk metadata cleanup failed."),
+					{ source: "auth.sanitizeSchoolType", level: "warn" },
+				);
+			});
 	}, [clerkUser]);
 
 	const activateSession = useCallback(
@@ -781,7 +823,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 				name: input.name.trim(),
 				birthDate: input.birthDate.trim(),
 				grade: input.grade.trim(),
-				schoolType: input.schoolType.trim(),
+				schoolType: normalizeOptionalSchoolTypeInput(input.schoolType),
 				state: input.state.trim(),
 			};
 			if (
@@ -791,13 +833,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 				throw new Error("Bitte wähle eine gültige Klassenstufe aus.");
 			}
 			const { firstName, lastName } = splitName(normalizedProfile.name);
-			const unsafeMetadata = {
+			const unsafeMetadata: Record<string, unknown> = {
 				...(clerkUser.unsafeMetadata ?? {}),
 				birthDate: normalizedProfile.birthDate,
 				grade: normalizedProfile.grade,
-				schoolType: normalizedProfile.schoolType,
 				state: normalizedProfile.state,
 			};
+			delete unsafeMetadata.schoolType;
+			if (normalizedProfile.schoolType) {
+				unsafeMetadata.schoolType = normalizedProfile.schoolType;
+			}
 
 			try {
 				await clerkUser.update({

--- a/src/context/OnboardingContext.tsx
+++ b/src/context/OnboardingContext.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { createContext, useContext, useMemo, useState } from "react";
+import type { SupportedSchoolType } from "~/lib/school-types";
 
 export type OnboardingAnswers = {
 	studyTime: string;
@@ -7,7 +8,7 @@ export type OnboardingAnswers = {
 	challenge: string;
 	goal: string;
 	state: string;
-	schoolType: string;
+	schoolType: SupportedSchoolType | "";
 	grade: string;
 	dailySchoolTime: string;
 	studyDays: string;
@@ -37,7 +38,10 @@ const emptyAnswers: OnboardingAnswers = {
 
 type OnboardingContextValue = {
 	answers: OnboardingAnswers;
-	setAnswer: (field: keyof OnboardingAnswers, value: string) => void;
+	setAnswer: <Field extends keyof OnboardingAnswers>(
+		field: Field,
+		value: OnboardingAnswers[Field],
+	) => void;
 	clearAnswers: () => void;
 	hasAnswers: boolean;
 };

--- a/src/features/auth/dayova-auth-flow.tsx
+++ b/src/features/auth/dayova-auth-flow.tsx
@@ -118,6 +118,7 @@ import {
 	type RegistrationStage,
 	shouldHandleRegistrationBack,
 } from "~/lib/registration-navigation";
+import { SCHOOL_TYPE_OPTIONS, SCHOOL_TYPE_VALUES } from "~/lib/school-types";
 import { useDayovaTheme } from "~/lib/theme";
 import { cn } from "~/lib/utils";
 import IntroPathSvg from "../../../assets/onboarding/intro-path.svg";
@@ -209,9 +210,9 @@ type InfoStackStep = {
 
 type TextStep = {
 	kind: "text";
-	id: "name" | "schoolType" | "email" | "password";
+	id: "name" | "email" | "password";
 	title: string;
-	field: "name" | "schoolType" | "email" | "password";
+	field: "name" | "email" | "password";
 	placeholder: string;
 	secure?: boolean;
 	keyboardType?: TextInputProps["keyboardType"];
@@ -221,9 +222,9 @@ type TextStep = {
 
 type WheelStep = {
 	kind: "wheel";
-	id: "state" | "grade" | "birthDate" | "learningTime";
+	id: "state" | "schoolType" | "grade" | "birthDate" | "learningTime";
 	title: string;
-	field: "state" | "grade" | "birthDate" | "learningTime";
+	field: "state" | "schoolType" | "grade" | "birthDate" | "learningTime";
 };
 
 type OnboardingStep =
@@ -446,12 +447,10 @@ const FLOW_STEPS: readonly OnboardingStep[] = [
 		field: "state",
 	},
 	{
-		kind: "text",
+		kind: "wheel",
 		id: "schoolType",
-		title: "Welche Schule\nbesuchst du?",
+		title: "Welche Schulart besuchst du?",
 		field: "schoolType",
-		placeholder: "Gymnasium",
-		autoComplete: "off",
 	},
 	{
 		kind: "wheel",
@@ -550,6 +549,7 @@ const defaultAnswerForStep = (step: OnboardingStep) => {
 	if (step.kind === "range") return "30 min";
 	if (step.kind === "wheel") {
 		if (step.field === "state") return "Sachsen";
+		if (step.field === "schoolType") return "prefer_not_to_say";
 		if (step.field === "grade") return "9";
 		if (step.field === "birthDate") return DEFAULT_BIRTH_DATE;
 		if (step.field === "learningTime") return DEFAULT_LEARNING_TIME;
@@ -3109,6 +3109,23 @@ function WheelAnswer({ step }: { step: WheelStep }) {
 				testID="onboarding-grade-picker"
 				title="Klassenstufe auswählen"
 				onChange={(value) => setAnswer("grade", value)}
+			/>
+		);
+	}
+
+	if (step.field === "schoolType") {
+		return (
+			<OnboardingSelect
+				accessibilityLabel="Schulart auswählen"
+				value={answers.schoolType || "prefer_not_to_say"}
+				options={SCHOOL_TYPE_VALUES}
+				formatLabel={(schoolType) =>
+					SCHOOL_TYPE_OPTIONS.find((option) => option.value === schoolType)
+						?.label ?? schoolType
+				}
+				testID="onboarding-school-type-picker"
+				title="Schulart auswählen"
+				onChange={(value) => setAnswer("schoolType", value)}
 			/>
 		);
 	}

--- a/src/features/auth/login-screen.ui.test.tsx
+++ b/src/features/auth/login-screen.ui.test.tsx
@@ -53,7 +53,7 @@ const mockOnboarding = {
 		challenge: "Organisation",
 		goal: "Mehr Struktur im Lernen",
 		state: "Sachsen",
-		schoolType: "Gymnasium",
+		schoolType: "prefer_not_to_say",
 		grade: "9",
 		dailySchoolTime: "60 min",
 		studyDays: "Montag",
@@ -517,5 +517,19 @@ describe("OnboardingScreen", () => {
 				"Keine Sorge, du\nkannst deine\nLernzeiten später\nanpassen.",
 			),
 		).toBeNull();
+	});
+
+	test("renders school type through the shared bottom-sheet select trigger", async () => {
+		const screen = await render(
+			<OnboardingScreen initialStepId="schoolType" />,
+		);
+
+		expect(screen.getByText("Welche Schulart besuchst du?")).toBeOnTheScreen();
+		expect(
+			screen.getByRole("button", { name: "Schulart auswählen" }),
+		).toHaveAccessibilityValue({ text: "Keine Angabe" });
+		expect(
+			screen.getByTestId("onboarding-school-type-picker"),
+		).toBeOnTheScreen();
 	});
 });

--- a/src/lib/clerk-registration.ts
+++ b/src/lib/clerk-registration.ts
@@ -1,5 +1,9 @@
 import { isGermanFederalState } from "./federal-states";
 import { isSupportedGrade } from "./grades";
+import {
+	isSupportedSchoolType,
+	type SupportedSchoolType,
+} from "./school-types";
 
 export type ClerkRegistrationInput = {
 	email: string;
@@ -8,7 +12,7 @@ export type ClerkRegistrationInput = {
 	phone?: string;
 	birthDate?: string;
 	grade?: string;
-	schoolType?: string;
+	schoolType?: SupportedSchoolType;
 	state?: string;
 };
 
@@ -17,7 +21,7 @@ export type ClerkProfile = {
 	phone?: string;
 	birthDate?: string;
 	grade?: string;
-	schoolType?: string;
+	schoolType?: SupportedSchoolType;
 	state?: string;
 };
 
@@ -50,13 +54,21 @@ export const prepareClerkRegistration = (input: ClerkRegistrationInput) => {
 	if (state && !isGermanFederalState(state)) {
 		throw new Error("Bitte wähle ein gültiges Bundesland aus.");
 	}
+	const schoolTypeCandidate = input.schoolType?.trim();
+	let schoolType: SupportedSchoolType | undefined;
+	if (schoolTypeCandidate) {
+		if (!isSupportedSchoolType(schoolTypeCandidate)) {
+			throw new Error("Bitte wähle eine gültige Schulart aus.");
+		}
+		schoolType = schoolTypeCandidate;
+	}
 
 	const profile = {
 		name: input.name?.trim(),
 		phone: input.phone?.trim(),
 		birthDate: input.birthDate,
 		grade,
-		schoolType: input.schoolType?.trim(),
+		schoolType,
 		state,
 	};
 	const { firstName, lastName } = splitClerkName(profile.name);

--- a/src/lib/federal-states.test.ts
+++ b/src/lib/federal-states.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, test } from "vitest";
-import {
-	GERMAN_FEDERAL_STATES,
-	isGermanFederalState,
-} from "./federal-states";
+import { GERMAN_FEDERAL_STATES, isGermanFederalState } from "./federal-states";
 
 describe("federal state contract", () => {
 	test("publishes every German federal state exactly once", () => {

--- a/src/lib/federal-states.test.ts
+++ b/src/lib/federal-states.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import {
+	GERMAN_FEDERAL_STATES,
+	isGermanFederalState,
+} from "./federal-states";
+
+describe("federal state contract", () => {
+	test("publishes every German federal state exactly once", () => {
+		expect(GERMAN_FEDERAL_STATES).toEqual([
+			"Bremen",
+			"Hamburg",
+			"Baden-Württemberg",
+			"Sachsen",
+			"Sachsen-Anhalt",
+			"Brandenburg",
+			"Bayern",
+			"Berlin",
+			"Hessen",
+			"Niedersachsen",
+			"Nordrhein-Westfalen",
+			"Rheinland-Pfalz",
+			"Saarland",
+			"Schleswig-Holstein",
+			"Thüringen",
+			"Mecklenburg-Vorpommern",
+		]);
+		expect(new Set(GERMAN_FEDERAL_STATES).size).toBe(16);
+	});
+
+	test("accepts only published federal states", () => {
+		for (const state of GERMAN_FEDERAL_STATES) {
+			expect(isGermanFederalState(state)).toBe(true);
+		}
+
+		expect(isGermanFederalState("private state")).toBe(false);
+		expect(isGermanFederalState(" Bayern ")).toBe(false);
+		expect(isGermanFederalState(13)).toBe(false);
+	});
+});

--- a/src/lib/school-types.test.ts
+++ b/src/lib/school-types.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import {
+	isSupportedSchoolType,
+	normalizeLegacySchoolType,
+	SCHOOL_TYPE_OPTIONS,
+} from "./school-types";
+
+describe("school type contract", () => {
+	test("publishes only the approved stable keys and German labels", () => {
+		expect(SCHOOL_TYPE_OPTIONS).toEqual([
+			{ value: "gymnasium", label: "Gymnasium" },
+			{
+				value: "secondary_general",
+				label: "Oberschule / Realschule / Sekundarschule",
+			},
+			{
+				value: "comprehensive",
+				label: "Gesamt- / Gemeinschaftsschule",
+			},
+			{ value: "hauptschule", label: "Hauptschule" },
+			{ value: "vocational", label: "Berufliche Schule" },
+			{ value: "other", label: "Andere Schulart" },
+			{ value: "prefer_not_to_say", label: "Keine Angabe" },
+		]);
+	});
+
+	test("accepts every stable key and rejects free-text school names", () => {
+		for (const option of SCHOOL_TYPE_OPTIONS) {
+			expect(isSupportedSchoolType(option.value)).toBe(true);
+		}
+
+		expect(isSupportedSchoolType("Goethe-Gymnasium Dresden")).toBe(false);
+		expect(isSupportedSchoolType("Gymnasium")).toBe(false);
+		expect(isSupportedSchoolType(13)).toBe(false);
+	});
+
+	test("maps only exact generic legacy values and drops identifiable text", () => {
+		const genericLegacyValues = [
+			["Gymnasium", "gymnasium"],
+			["Oberschule", "secondary_general"],
+			["Realschule", "secondary_general"],
+			["Sekundarschule", "secondary_general"],
+			["Gesamtschule", "comprehensive"],
+			["Gemeinschaftsschule", "comprehensive"],
+			["Hauptschule", "hauptschule"],
+			["Berufsschule", "vocational"],
+			["Berufliche Schule", "vocational"],
+			["Andere Schulart", "other"],
+			["Keine Angabe", "prefer_not_to_say"],
+		] as const;
+
+		for (const [legacyValue, expected] of genericLegacyValues) {
+			expect(normalizeLegacySchoolType(legacyValue)).toBe(expected);
+		}
+
+		expect(normalizeLegacySchoolType("  GYMNASIUM  ")).toBe("gymnasium");
+		expect(normalizeLegacySchoolType("Goethe-Gymnasium Dresden")).toBe(
+			undefined,
+		);
+		expect(normalizeLegacySchoolType("Realschule am Stadtpark")).toBe(
+			undefined,
+		);
+		expect(normalizeLegacySchoolType("")).toBe(undefined);
+		expect(normalizeLegacySchoolType(null)).toBe(undefined);
+	});
+});

--- a/src/lib/school-types.ts
+++ b/src/lib/school-types.ts
@@ -1,0 +1,55 @@
+export const SCHOOL_TYPE_OPTIONS = [
+	{ value: "gymnasium", label: "Gymnasium" },
+	{
+		value: "secondary_general",
+		label: "Oberschule / Realschule / Sekundarschule",
+	},
+	{
+		value: "comprehensive",
+		label: "Gesamt- / Gemeinschaftsschule",
+	},
+	{ value: "hauptschule", label: "Hauptschule" },
+	{ value: "vocational", label: "Berufliche Schule" },
+	{ value: "other", label: "Andere Schulart" },
+	{ value: "prefer_not_to_say", label: "Keine Angabe" },
+] as const;
+
+export type SupportedSchoolType = (typeof SCHOOL_TYPE_OPTIONS)[number]["value"];
+
+export const SCHOOL_TYPE_VALUES = SCHOOL_TYPE_OPTIONS.map(
+	(option) => option.value,
+) as readonly SupportedSchoolType[];
+
+const SCHOOL_TYPE_VALUE_SET = new Set<string>(SCHOOL_TYPE_VALUES);
+
+export const isSupportedSchoolType = (
+	value: unknown,
+): value is SupportedSchoolType =>
+	typeof value === "string" && SCHOOL_TYPE_VALUE_SET.has(value);
+
+const GENERIC_LEGACY_SCHOOL_TYPES: Readonly<
+	Record<string, SupportedSchoolType>
+> = {
+	gymnasium: "gymnasium",
+	oberschule: "secondary_general",
+	realschule: "secondary_general",
+	sekundarschule: "secondary_general",
+	"oberschule / realschule / sekundarschule": "secondary_general",
+	gesamtschule: "comprehensive",
+	gemeinschaftsschule: "comprehensive",
+	"gesamt- / gemeinschaftsschule": "comprehensive",
+	hauptschule: "hauptschule",
+	berufsschule: "vocational",
+	"berufliche schule": "vocational",
+	"andere schulart": "other",
+	"keine angabe": "prefer_not_to_say",
+};
+
+export const normalizeLegacySchoolType = (
+	value: unknown,
+): SupportedSchoolType | undefined => {
+	if (typeof value !== "string") return undefined;
+	const normalizedValue = value.trim();
+	if (isSupportedSchoolType(normalizedValue)) return normalizedValue;
+	return GENERIC_LEGACY_SCHOOL_TYPES[normalizedValue.toLowerCase()];
+};


### PR DESCRIPTION
## Summary

- rebuild the DAY-253 change on current `main`, including the merged DAY-109 sheet system from #316 and the DAY-111 / Grade 13 work from #322
- replace free-text school-name collection with seven stable school-type keys and the privacy-safe `Keine Angabe` default
- present the choice through the shared `OnboardingSelect` → `SelectSheet` bottom-sheet contract, with accessible trigger and radio semantics
- enforce the bounded vocabulary at Clerk and Convex write boundaries; normalize exact generic legacy labels and remove identifiable school-name values without logging them
- preserve the current federal-state, learning-time, and analytics contracts; `school_type` remains intentionally excluded from PostHog pending a separate reviewed contract change
- update product, auth, mobile, backend, platform, and integration documentation

## Integration status

- standalone on current `main`; no remaining stack dependency
- adapted to the post-DAY-109 Bottom Sheet API and current registration/onboarding flow
- conflict-free and mergeable; all GitHub checks pass and all review threads are resolved
- final review cleanup reuses the already-validated Convex value; CodeRabbit withdrew its diagnostic-detail finding after confirming the privacy boundary

## Visual evidence

### Screen recording

https://github.com/user-attachments/assets/fd6aba22-035c-439d-92a5-6a007b131227

- `00:00–00:00.5` — privacy-safe `Keine Angabe` default is visible
- `00:00.5–00:01` — the trigger opens the shared DAY-109 bottom sheet
- `00:01–00:04.5` — the sheet title and all seven bounded school-type options are visible
- `00:04.5–00:05` — selecting `Gymnasium` closes the sheet
- `00:05–00:07.32` — the trigger persists the selected `Gymnasium` value
- evidence inspection covered the complete 7.32-second timeline at 2 fps (16 frames at 0.5-second intervals) plus one contact sheet; the recording has no audio stream

### Screenshots

<table>
  <tr>
    <th>Privacy-safe default</th>
    <th>DAY-109 shared sheet</th>
    <th>Selected value</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/23ddc636-24fa-4f5c-9993-a1ca51184372" width="260" alt="School type onboarding screen with Keine Angabe selected"></td>
    <td><img src="https://github.com/user-attachments/assets/f84261a6-ae32-4354-99d4-5625a3cc9825" width="260" alt="Shared Schulart auswählen bottom sheet with seven bounded options"></td>
    <td><img src="https://github.com/user-attachments/assets/e1dca1fb-46e6-4e2f-ace3-16f643946b30" width="260" alt="School type onboarding screen with Gymnasium selected"></td>
  </tr>
</table>

## Verification

- `pnpm test`: 509 tests passed (440 Vitest, 52 Jest UI, 17 Node checks)
- `pnpm check`: Biome, ESLint, and TypeScript passed
- `pnpm format:check`, `pnpm check:unused`, and `git diff --check` passed
- isolated anonymous Convex deployment validated with `convex dev --once`
- Android debug development build succeeded; the onboarding screen and shared selection sheet were exercised and visually inspected on `DAY_169_Pixel_9`
- verified the default, all seven accessible options, selection lifecycle, and updated trigger value; restored the emulator's original signed-in session afterward

[DAY-253](https://linear.app/dayova/issue/DAY-253/replace-free-text-school-name-collection-with-bounded-school-type)

## Decision record

- [Decision record — use Dayova select sheets for bounded onboarding choices](https://app.notion.com/p/3a42e87228bf8170bff8e0dd429be88e)
