### PR TITLE
Publish completed agent work by default

### DIFF
--- a/.agents/skills/ask-matt/SKILL.md
+++ b/.agents/skills/ask-matt/SKILL.md
@@ -22,7 +22,7 @@ The route most work travels. You have an idea and want it built.
    - **Yes** → **`/to-spec`** (turn the thread into a spec), then **`/to-tickets`** to split it into tracer-bullet tickets, each declaring its **blocking edges**. On a local tracker that's one file per ticket under `.scratch/<feature>/issues/`, worked blockers-first by hand; on a real tracker the edges become native blocking links, so any ticket whose blockers are done can be grabbed — kick off **`/implement`** per ticket, **clearing context between each one**.
    - **No** → **`/implement`** right here, in the same context window.
 
-   Either way, **`/implement`** builds each issue by driving **`/tdd`** internally — one red-green slice at a time — then closes out by running **`/code-review`**, a two-axis review (Standards + Spec) of the diff. Commit only when the user or issue workflow asks for a commit. Reach for **`/tdd`** on its own when you just want to build a concrete behaviour test-first without a full spec, and **`/code-review`** on its own whenever you want to review a branch or PR against a fixed point.
+   Either way, **`/implement`** builds each issue by driving **`/tdd`** internally — one red-green slice at a time — then closes out by running **`/code-review`**, a two-axis review (Standards + Spec) of the diff, before committing and publishing the feature or PR branch under the repository's delivery policy. Reach for **`/tdd`** on its own when you just want to build a concrete behaviour test-first without a full spec, and **`/code-review`** on its own whenever you want to review a branch or PR against a fixed point.
 
 ### Context hygiene
 

--- a/.agents/skills/ask-matt/SKILL.md
+++ b/.agents/skills/ask-matt/SKILL.md
@@ -22,7 +22,7 @@ The route most work travels. You have an idea and want it built.
    - **Yes** → **`/to-spec`** (turn the thread into a spec), then **`/to-tickets`** to split it into tracer-bullet tickets, each declaring its **blocking edges**. On a local tracker that's one file per ticket under `.scratch/<feature>/issues/`, worked blockers-first by hand; on a real tracker the edges become native blocking links, so any ticket whose blockers are done can be grabbed — kick off **`/implement`** per ticket, **clearing context between each one**.
    - **No** → **`/implement`** right here, in the same context window.
 
-   Either way, **`/implement`** builds each issue by driving **`/tdd`** internally — one red-green slice at a time — then closes out by running **`/code-review`**, a two-axis review (Standards + Spec) of the diff, before committing and publishing the feature or PR branch under the repository's delivery policy. Reach for **`/tdd`** on its own when you just want to build a concrete behaviour test-first without a full spec, and **`/code-review`** on its own whenever you want to review a branch or PR against a fixed point.
+   Either way, **`/implement`** builds each issue by driving **`/tdd`** internally — one red-green slice at a time — then closes out by running **`/code-review`**, a two-axis review (Standards + Spec) of the diff, before committing and publishing through the repository's branch-ownership and delivery policy. Reach for **`/tdd`** on its own when you just want to build a concrete behaviour test-first without a full spec, and **`/code-review`** on its own whenever you want to review a branch or PR against a fixed point.
 
 ### Context hygiene
 

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -11,4 +11,4 @@ Run typechecking regularly, single test files regularly, and the full test suite
 
 Once done, use /code-review to review the work.
 
-Follow the repository's delivery policy. For Dayova implementation work, validate the result, commit only the in-scope changes, and push the non-default feature or PR branch unless the user explicitly asks to keep the work local. Never push the default branch or stage unrelated changes. If safe delivery is blocked, report the blocker instead of silently leaving completed work unpublished.
+Follow the repository's delivery policy. For explicitly mutating Dayova repository work, validate and review the result, then commit only the coherent in-scope changes. Publish only to a branch that already represents the current work item or pull request, or a new branch intentionally created for this work from the correct integration base. Preserve an existing pull request and stack. Never treat “non-default” alone as authorization to push, push the default branch, or stage unrelated changes. If safe delivery is blocked, report the blocker instead of silently leaving completed work unpublished.

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -11,4 +11,4 @@ Run typechecking regularly, single test files regularly, and the full test suite
 
 Once done, use /code-review to review the work.
 
-Commit only when the user requested a commit or the issue workflow explicitly requires one. Otherwise leave the completed changes in the worktree and report the files changed plus the validation run.
+Follow the repository's delivery policy. For Dayova implementation work, validate the result, commit only the in-scope changes, and push the non-default feature or PR branch unless the user explicitly asks to keep the work local. Never push the default branch or stage unrelated changes. If safe delivery is blocked, report the blocker instead of silently leaving completed work unpublished.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ Convex agent skills for common tasks can be installed by running
 
 ## Agent skills
 
+### Delivery workflow
+
+For requests to implement, fix, build, update, refactor, or address review feedback, completion includes validation, an intentional commit containing only the in-scope changes, and a push to the non-default feature or pull-request branch. The user does not need to repeat “commit and push.” Update an existing pull request when one exists; otherwise create a scoped `codex/` branch from the current default branch and open a draft pull request when the work is ready for review.
+
+Never push directly to the default branch, stage unrelated user changes, or mix a distinct follow-up into the current branch. Put unrelated follow-up work on a separate branch, commit, and pull request. Read-only review, diagnosis, explanation, research, and status requests remain non-mutating. Stop and surface the blocker when scope is ambiguous, unrelated changes cannot be separated safely, validation has a material failure, authentication is unavailable, or the remote changed unexpectedly.
+
 ### Issue tracker
 
 Linear is the source of truth for issues and PRDs: use workspace `dayova`, team `Dayova` (`DAY`). `Dayova/dayova-mvp` GitHub Issues remains a bidirectionally synced compatibility surface. See `docs/agents/issue-tracker.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,19 @@ Convex agent skills for common tasks can be installed by running
 
 ### Delivery workflow
 
-For requests to implement, fix, build, update, refactor, or address review feedback, completion includes validation, an intentional commit containing only the in-scope changes, and a push to the non-default feature or pull-request branch. The user does not need to repeat “commit and push.” Update an existing pull request when one exists; otherwise create a scoped `codex/` branch from the current default branch and open a draft pull request when the work is ready for review.
+For explicitly mutating repository work (for example implementation, fixes, refactors, or review-feedback changes), completion normally includes:
 
-Never push directly to the default branch, stage unrelated user changes, or mix a distinct follow-up into the current branch. Put unrelated follow-up work on a separate branch, commit, and pull request. Read-only review, diagnosis, explanation, research, and status requests remain non-mutating. Stop and surface the blocker when scope is ambiguous, unrelated changes cannot be separated safely, validation has a material failure, authentication is unavailable, or the remote changed unexpectedly.
+1. validate the result;
+2. review the change;
+3. commit only the coherent in-scope changes;
+4. publish them to a branch owned by the current work; and
+5. update the existing pull request, or open a draft pull request when appropriate.
+
+The user does not need to repeat “commit and push.” Preserve the existing branch, pull request, and stack when the task belongs to one. Push only a branch that already represents the current work item or pull request, or a new branch intentionally created for this work.
+
+For new work, determine the correct integration base from the task, current branch, stack, and repository workflow; create a scoped `codex/` branch from that base. Do not assume the default branch is always the correct base.
+
+Never push directly to the default branch, treat another developer's, release, shared integration, or stack-parent branch as safe merely because it is non-default, stage unrelated user changes, or mix a distinct follow-up into the current branch. Put unrelated follow-up work on a separate branch, commit, and pull request. Read-only review, diagnosis, explanation, research, and status requests remain non-mutating. Stop and surface the blocker when scope or branch ownership is ambiguous, unrelated changes cannot be separated safely, validation has a material failure, authentication is unavailable, or the remote changed unexpectedly.
 
 ### Issue tracker
 

--- a/patches/matt-pocock-skills/dayova.patch
+++ b/patches/matt-pocock-skills/dayova.patch
@@ -7,7 +7,7 @@ index b7e3378..4ebce34 100644
     - **No** → **`/implement`** right here, in the same context window.
  
 -   Either way, **`/implement`** builds each issue by driving **`/tdd`** internally — one red-green slice at a time — then closes out by running **`/code-review`**, a two-axis review (Standards + Spec) of the diff, before committing. Reach for **`/tdd`** on its own when you just want to build a concrete behaviour test-first without a full spec, and **`/code-review`** on its own whenever you want to review a branch or PR against a fixed point.
-+   Either way, **`/implement`** builds each issue by driving **`/tdd`** internally — one red-green slice at a time — then closes out by running **`/code-review`**, a two-axis review (Standards + Spec) of the diff. Commit only when the user or issue workflow asks for a commit. Reach for **`/tdd`** on its own when you just want to build a concrete behaviour test-first without a full spec, and **`/code-review`** on its own whenever you want to review a branch or PR against a fixed point.
++   Either way, **`/implement`** builds each issue by driving **`/tdd`** internally — one red-green slice at a time — then closes out by running **`/code-review`**, a two-axis review (Standards + Spec) of the diff, before committing and publishing the feature or PR branch under the repository's delivery policy. Reach for **`/tdd`** on its own when you just want to build a concrete behaviour test-first without a full spec, and **`/code-review`** on its own whenever you want to review a branch or PR against a fixed point.
  
  ### Context hygiene
  
@@ -88,7 +88,7 @@ index 3650c44..41ca947 100644
  Once done, use /code-review to review the work.
  
 -Commit your work to the current branch.
-+Commit only when the user requested a commit or the issue workflow explicitly requires one. Otherwise leave the completed changes in the worktree and report the files changed plus the validation run.
++Follow the repository's delivery policy. For Dayova implementation work, validate the result, commit only the in-scope changes, and push the non-default feature or PR branch unless the user explicitly asks to keep the work local. Never push the default branch or stage unrelated changes. If safe delivery is blocked, report the blocker instead of silently leaving completed work unpublished.
 diff --git a/.agents/skills/improve-codebase-architecture/SKILL.md b/.agents/skills/improve-codebase-architecture/SKILL.md
 index 3c116bb..6fd2e04 100644
 --- a/.agents/skills/improve-codebase-architecture/SKILL.md

--- a/patches/matt-pocock-skills/dayova.patch
+++ b/patches/matt-pocock-skills/dayova.patch
@@ -7,7 +7,7 @@ index b7e3378..4ebce34 100644
     - **No** → **`/implement`** right here, in the same context window.
  
 -   Either way, **`/implement`** builds each issue by driving **`/tdd`** internally — one red-green slice at a time — then closes out by running **`/code-review`**, a two-axis review (Standards + Spec) of the diff, before committing. Reach for **`/tdd`** on its own when you just want to build a concrete behaviour test-first without a full spec, and **`/code-review`** on its own whenever you want to review a branch or PR against a fixed point.
-+   Either way, **`/implement`** builds each issue by driving **`/tdd`** internally — one red-green slice at a time — then closes out by running **`/code-review`**, a two-axis review (Standards + Spec) of the diff, before committing and publishing the feature or PR branch under the repository's delivery policy. Reach for **`/tdd`** on its own when you just want to build a concrete behaviour test-first without a full spec, and **`/code-review`** on its own whenever you want to review a branch or PR against a fixed point.
++   Either way, **`/implement`** builds each issue by driving **`/tdd`** internally — one red-green slice at a time — then closes out by running **`/code-review`**, a two-axis review (Standards + Spec) of the diff, before committing and publishing through the repository's branch-ownership and delivery policy. Reach for **`/tdd`** on its own when you just want to build a concrete behaviour test-first without a full spec, and **`/code-review`** on its own whenever you want to review a branch or PR against a fixed point.
  
  ### Context hygiene
  
@@ -88,7 +88,7 @@ index 3650c44..41ca947 100644
  Once done, use /code-review to review the work.
  
 -Commit your work to the current branch.
-+Follow the repository's delivery policy. For Dayova implementation work, validate the result, commit only the in-scope changes, and push the non-default feature or PR branch unless the user explicitly asks to keep the work local. Never push the default branch or stage unrelated changes. If safe delivery is blocked, report the blocker instead of silently leaving completed work unpublished.
++Follow the repository's delivery policy. For explicitly mutating Dayova repository work, validate and review the result, then commit only the coherent in-scope changes. Publish only to a branch that already represents the current work item or pull request, or a new branch intentionally created for this work from the correct integration base. Preserve an existing pull request and stack. Never treat “non-default” alone as authorization to push, push the default branch, or stage unrelated changes. If safe delivery is blocked, report the blocker instead of silently leaving completed work unpublished.
 diff --git a/.agents/skills/improve-codebase-architecture/SKILL.md b/.agents/skills/improve-codebase-architecture/SKILL.md
 index 3c116bb..6fd2e04 100644
 --- a/.agents/skills/improve-codebase-architecture/SKILL.md


### PR DESCRIPTION
## Summary

- define Dayova's default delivery loop for explicitly mutating repository work
- require validation, review, a coherent in-scope commit, and publication to a branch owned by the current work
- preserve an existing branch, pull request, and stack when work belongs to one
- determine the correct integration base for new work instead of assuming the default branch
- keep read-only review, diagnosis, research, explanation, and status requests non-mutating
- align the `ask-matt` and `implement` skills with that policy and preserve the changes in the maintained Matt Pocock overlay

## Root cause

Dayova's skill overlay explicitly replaced upstream commit behavior with “commit only when requested” and instructed agents to leave completed work in the worktree. The repository had no standing delivery rule to say that normal mutating change requests include commit and publication, so agents conservatively stopped after validation.

## Safety boundaries

- push only the existing branch for the current work item or pull request, or a new branch intentionally created for that work
- preserve stacked-PR dependencies and determine the correct integration base from task and repository context
- never treat “non-default” alone as authorization to push
- never push directly to the default branch or assume another developer's, release, shared integration, or stack-parent branch is safe
- never stage unrelated user changes or mix distinct follow-up work
- stop when scope, branch ownership, validation, authentication, or remote state makes publishing unsafe

## Validation

- `pnpm format:check`
- `pnpm check`
- `pnpm test` — 33 files, 145 tests passed
- `pnpm skills:validate` — 21 Matt Pocock skills and 22 Expo skills validated
- standalone `skill-creator` validation for `ask-matt` and `implement`
- independent Standards and Spec review axes — no actionable findings
- fresh read-only `codex exec` task correctly preserved stacked work, rejected an unrelated shared non-default branch, and kept diagnosis non-mutating
- rebased onto current `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified repository delivery workflows, including validation, review, commits, branch selection, publishing, and pull request handling.
  * Added guidance for preserving existing work and reporting blockers when changes cannot be safely delivered.
  * Expanded issue-tracking support across GitHub, GitLab, Linear, and local Markdown workflows.
  * Updated research, triage, design, architecture, and context-documentation guidance for clearer and more consistent collaboration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->