### PR TITLE
DAY-291 Add student-facing Analyse dashboard

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -29,12 +29,15 @@ import type * as learningSessionContentConstraints from "../learningSessionConte
 import type * as learningSessionDurationText from "../learningSessionDurationText.js";
 import type * as learningSessionScheduleFormatting from "../learningSessionScheduleFormatting.js";
 import type * as learningSessionSegmentation from "../learningSessionSegmentation.js";
+import type * as learningTimeAvailability from "../learningTimeAvailability.js";
 import type * as learningTimes from "../learningTimes.js";
+import type * as learningTimesBackfill from "../learningTimesBackfill.js";
 import type * as learningTopicMap from "../learningTopicMap.js";
 import type * as notifications from "../notifications.js";
 import type * as scheduleConflicts from "../scheduleConflicts.js";
 import type * as theoryContent from "../theoryContent.js";
 import type * as topicDescriptionValidation from "../topicDescriptionValidation.js";
+import type * as userAnalytics from "../userAnalytics.js";
 import type * as users from "../users.js";
 import type * as validationAnalytics from "../validationAnalytics.js";
 
@@ -66,12 +69,15 @@ declare const fullApi: ApiFromModules<{
   learningSessionDurationText: typeof learningSessionDurationText;
   learningSessionScheduleFormatting: typeof learningSessionScheduleFormatting;
   learningSessionSegmentation: typeof learningSessionSegmentation;
+  learningTimeAvailability: typeof learningTimeAvailability;
   learningTimes: typeof learningTimes;
+  learningTimesBackfill: typeof learningTimesBackfill;
   learningTopicMap: typeof learningTopicMap;
   notifications: typeof notifications;
   scheduleConflicts: typeof scheduleConflicts;
   theoryContent: typeof theoryContent;
   topicDescriptionValidation: typeof topicDescriptionValidation;
+  userAnalytics: typeof userAnalytics;
   users: typeof users;
   validationAnalytics: typeof validationAnalytics;
 }>;

--- a/convex/userAnalytics.test.ts
+++ b/convex/userAnalytics.test.ts
@@ -190,6 +190,48 @@ test("does not expose another learner's analytics", async () => {
 	});
 });
 
+test("keeps future outcomes out of the selected reporting period", async () => {
+	const { t, learningPlanId } = await seedAnalyticsData();
+	await t.run(async (ctx) => {
+		await ctx.db.insert("learningPlanSessions", {
+			ownerTokenIdentifier: identity.tokenIdentifier,
+			learningPlanId,
+			phase: "practice",
+			title: "Zukünftige Einheit",
+			dateKey: "2026-07-30",
+			dateLabel: "30. Juli 2026",
+			startTime: "16:00",
+			durationMinutes: 15,
+			goal: "Später üben.",
+			tasks: ["Aufgabe lösen"],
+			expectedOutcome: "Du bist sicherer.",
+			completed: true,
+			executionStatus: "completed",
+			outcomeAt: Date.UTC(2026, 6, 30, 14),
+			activeStudySeconds: 900,
+			sortOrder: 4,
+			createdAt: Date.UTC(2026, 6, 30, 14),
+			updatedAt: Date.UTC(2026, 6, 30, 14),
+		});
+	});
+
+	const overview = await t.query(api.userAnalytics.getOverview, {
+		period: "week",
+		todayKey: "2026-07-28",
+		timezoneOffsetMinutes: 0,
+	});
+
+	expect(overview.overall).toMatchObject({
+		completedSessions: 3,
+		totalSessions: 4,
+	});
+	expect(overview.period).toEqual({
+		completedSessions: 2,
+		activeStudyMinutes: 30,
+		recoveredSessions: 1,
+	});
+});
+
 test("rejects malformed calendar and timezone inputs", async () => {
 	const t = convexTest(schema, modules).withIdentity(identity);
 

--- a/convex/userAnalytics.test.ts
+++ b/convex/userAnalytics.test.ts
@@ -1,0 +1,210 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+const identity = { tokenIdentifier: "test:analytics-user" };
+
+const seedAnalyticsData = async () => {
+	const backend = convexTest(schema, modules);
+	const t = backend.withIdentity(identity);
+	const learningPlanId = await t.run(async (ctx) => {
+		const now = Date.UTC(2026, 6, 28, 12);
+		return await ctx.db.insert("learningPlans", {
+			ownerTokenIdentifier: identity.tokenIdentifier,
+			subject: "Mathe",
+			examTypeLabel: "Klausur",
+			examDateKey: "2026-08-05",
+			examDateLabel: "5. August 2026",
+			durationMinutes: 90,
+			topicDescription: "Lineare Funktionen",
+			status: "accepted",
+			createdAt: now,
+			updatedAt: now,
+		});
+	});
+	const ids = await t.run(async (ctx) => {
+		const base = {
+			ownerTokenIdentifier: identity.tokenIdentifier,
+			learningPlanId,
+			dateLabel: "28. Juli 2026",
+			startTime: "16:00",
+			durationMinutes: 30,
+			goal: "Sicher anwenden.",
+			tasks: ["Aufgaben lösen"],
+			expectedOutcome: "Du kannst die Aufgabe lösen.",
+			createdAt: Date.UTC(2026, 6, 27, 10),
+			updatedAt: Date.UTC(2026, 6, 28, 14),
+		};
+		const firstSessionId = await ctx.db.insert("learningPlanSessions", {
+			...base,
+			phase: "practice",
+			title: "Gleichungen üben",
+			dateKey: "2026-07-27",
+			completed: true,
+			executionStatus: "completed",
+			outcomeAt: Date.UTC(2026, 6, 27, 14),
+			activeStudySeconds: 1_200,
+			sortOrder: 0,
+		});
+		const missedSessionId = await ctx.db.insert("learningPlanSessions", {
+			...base,
+			phase: "theory",
+			title: "Grundlagen wiederholen",
+			dateKey: "2026-07-27",
+			completed: false,
+			executionStatus: "adjusted",
+			outcomeAt: Date.UTC(2026, 6, 27, 15),
+			sortOrder: 1,
+		});
+		const recoverySessionId = await ctx.db.insert("learningPlanSessions", {
+			...base,
+			phase: "theory",
+			title: "Kleiner Neustart",
+			dateKey: "2026-07-28",
+			completed: true,
+			executionStatus: "completed",
+			outcomeAt: Date.UTC(2026, 6, 28, 14),
+			activeStudySeconds: 600,
+			adjustedFromSessionId: missedSessionId,
+			sortOrder: 2,
+		});
+		const openSessionId = await ctx.db.insert("learningPlanSessions", {
+			...base,
+			phase: "rehearsal",
+			title: "Generalprobe",
+			dateKey: "2026-07-30",
+			completed: false,
+			executionStatus: "notStarted",
+			sortOrder: 3,
+		});
+		const itemId = await ctx.db.insert("learningSessionContentItems", {
+			ownerTokenIdentifier: identity.tokenIdentifier,
+			learningPlanId,
+			sessionId: recoverySessionId,
+			phase: "theory",
+			kind: "written",
+			title: "Steigung",
+			prompt: "Erkläre die Steigung.",
+			explanation: "Die Steigung beschreibt die Änderung.",
+			idealAnswer: "Änderung von y pro Änderung von x.",
+			evaluationKeywords: ["Änderung"],
+			sortOrder: 0,
+			createdAt: Date.UTC(2026, 6, 28, 13),
+			updatedAt: Date.UTC(2026, 6, 28, 13),
+		});
+		await ctx.db.insert("learningSessionAnswerAttempts", {
+			ownerTokenIdentifier: identity.tokenIdentifier,
+			learningPlanId,
+			sessionId: recoverySessionId,
+			itemId,
+			answerText: "Änderung von y.",
+			rating: "partiallyCorrect",
+			feedback: "Fast richtig.",
+			perfectAnswer: "Änderung von y pro Änderung von x.",
+			timeSpentSeconds: 45,
+			createdAt: Date.UTC(2026, 6, 28, 13, 30),
+		});
+		await ctx.db.insert("learningSessionAnalyses", {
+			ownerTokenIdentifier: identity.tokenIdentifier,
+			learningPlanId,
+			sessionId: recoverySessionId,
+			strengths: ["Du erkennst lineare Zusammenhänge."],
+			gaps: ["Steigung noch präziser erklären."],
+			recommendation: "Übe eine weitere Steigungsaufgabe.",
+			createdAt: Date.UTC(2026, 6, 28, 14),
+			updatedAt: Date.UTC(2026, 6, 28, 14),
+		});
+		return { firstSessionId, openSessionId };
+	});
+	return { backend, t, learningPlanId, ...ids };
+};
+
+test("returns private, actionable learning analytics for the selected period", async () => {
+	const { t, learningPlanId, openSessionId } = await seedAnalyticsData();
+
+	const overview = await t.query(api.userAnalytics.getOverview, {
+		period: "week",
+		todayKey: "2026-07-28",
+		timezoneOffsetMinutes: 0,
+	});
+
+	expect(overview.overall).toEqual({
+		acceptedPlans: 1,
+		finishedPlans: 0,
+		completedSessions: 2,
+		totalSessions: 3,
+		progressPercent: 67,
+	});
+	expect(overview.period).toEqual({
+		completedSessions: 2,
+		activeStudyMinutes: 30,
+		recoveredSessions: 1,
+	});
+	expect(overview.currentStreakDays).toBe(2);
+	expect(overview.nextSession).toMatchObject({
+		id: openSessionId,
+		learningPlanId,
+		subject: "Mathe",
+		title: "Generalprobe",
+	});
+	expect(overview.knowledge).toMatchObject({
+		answeredItems: 1,
+		correct: 0,
+		partiallyCorrect: 1,
+		notCorrect: 0,
+		scorePercent: 50,
+		strengths: ["Du erkennst lineare Zusammenhänge."],
+		gaps: ["Steigung noch präziser erklären."],
+		recommendation: "Übe eine weitere Steigungsaufgabe.",
+	});
+	expect(overview.activity.at(-1)).toEqual({
+		dayKey: "2026-07-28",
+		completedSessions: 1,
+		activeStudyMinutes: 10,
+	});
+});
+
+test("does not expose another learner's analytics", async () => {
+	const { backend } = await seedAnalyticsData();
+	const otherUser = backend.withIdentity({
+		tokenIdentifier: "test:other-user",
+	});
+
+	await expect(
+		otherUser.query(api.userAnalytics.getOverview, {
+			period: "all",
+			todayKey: "2026-07-28",
+			timezoneOffsetMinutes: 0,
+		}),
+	).resolves.toMatchObject({
+		hasData: false,
+		overall: {
+			acceptedPlans: 0,
+			completedSessions: 0,
+			totalSessions: 0,
+		},
+	});
+});
+
+test("rejects malformed calendar and timezone inputs", async () => {
+	const t = convexTest(schema, modules).withIdentity(identity);
+
+	await expect(
+		t.query(api.userAnalytics.getOverview, {
+			period: "week",
+			todayKey: "2026-02-31",
+			timezoneOffsetMinutes: 0,
+		}),
+	).rejects.toThrow("Ungültiger Kalendertag.");
+	await expect(
+		t.query(api.userAnalytics.getOverview, {
+			period: "week",
+			todayKey: "2026-07-28",
+			timezoneOffsetMinutes: 841,
+		}),
+	).rejects.toThrow("Ungültige Zeitzone.");
+});

--- a/convex/userAnalytics.ts
+++ b/convex/userAnalytics.ts
@@ -1,0 +1,445 @@
+import { v } from "convex/values";
+import type { Doc, Id } from "./_generated/dataModel";
+import { query } from "./_generated/server";
+import { throwUserFacingError } from "./errors";
+
+const analyticsPeriodValidator = v.union(
+	v.literal("week"),
+	v.literal("month"),
+	v.literal("all"),
+);
+
+const activityPointValidator = v.object({
+	dayKey: v.string(),
+	completedSessions: v.number(),
+	activeStudyMinutes: v.number(),
+});
+
+const planProgressValidator = v.object({
+	id: v.id("learningPlans"),
+	subject: v.string(),
+	examTypeLabel: v.string(),
+	examDateKey: v.string(),
+	examDateLabel: v.string(),
+	progressPercent: v.number(),
+	completedSessions: v.number(),
+	totalSessions: v.number(),
+});
+
+const nextSessionValidator = v.object({
+	id: v.id("learningPlanSessions"),
+	learningPlanId: v.id("learningPlans"),
+	subject: v.string(),
+	title: v.string(),
+	dateKey: v.string(),
+});
+
+const overviewValidator = v.object({
+	hasData: v.boolean(),
+	historyLimited: v.boolean(),
+	overall: v.object({
+		acceptedPlans: v.number(),
+		finishedPlans: v.number(),
+		completedSessions: v.number(),
+		totalSessions: v.number(),
+		progressPercent: v.number(),
+	}),
+	period: v.object({
+		completedSessions: v.number(),
+		activeStudyMinutes: v.number(),
+		recoveredSessions: v.number(),
+	}),
+	currentStreakDays: v.number(),
+	activity: v.array(activityPointValidator),
+	plans: v.array(planProgressValidator),
+	nextSession: v.union(nextSessionValidator, v.null()),
+	knowledge: v.object({
+		answeredItems: v.number(),
+		correct: v.number(),
+		partiallyCorrect: v.number(),
+		notCorrect: v.number(),
+		scorePercent: v.union(v.number(), v.null()),
+		strengths: v.array(v.string()),
+		gaps: v.array(v.string()),
+		recommendation: v.union(v.string(), v.null()),
+	}),
+});
+
+type AnalyticsPeriod = "week" | "month" | "all";
+type SessionStatus =
+	| "notStarted"
+	| "started"
+	| "completed"
+	| "partiallyCompleted"
+	| "missed"
+	| "adjusted";
+
+const DAY_KEY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MAX_PLANS = 50;
+const MAX_SESSIONS_PER_PLAN = 75;
+const MAX_ATTEMPTS = 5_000;
+const MAX_ANALYSES = 500;
+
+const parseDayKey = (dayKey: string) => {
+	const match = DAY_KEY_PATTERN.exec(dayKey);
+	if (!match) return null;
+
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const timestamp = Date.UTC(year, month - 1, day);
+	const parsed = new Date(timestamp);
+	if (
+		parsed.getUTCFullYear() !== year ||
+		parsed.getUTCMonth() !== month - 1 ||
+		parsed.getUTCDate() !== day
+	) {
+		return null;
+	}
+	return timestamp;
+};
+
+const formatDayKey = (timestamp: number) => {
+	const date = new Date(timestamp);
+	return [
+		date.getUTCFullYear(),
+		(date.getUTCMonth() + 1).toString().padStart(2, "0"),
+		date.getUTCDate().toString().padStart(2, "0"),
+	].join("-");
+};
+
+const addDays = (dayKey: string, days: number) => {
+	const timestamp = parseDayKey(dayKey);
+	if (timestamp === null) return null;
+	return formatDayKey(timestamp + days * 86_400_000);
+};
+
+const timestampToDayKey = (timestamp: number, timezoneOffsetMinutes: number) =>
+	formatDayKey(timestamp - timezoneOffsetMinutes * 60_000);
+
+const getSessionStatus = (
+	session: Doc<"learningPlanSessions">,
+): SessionStatus =>
+	session.executionStatus ?? (session.completed ? "completed" : "notStarted");
+
+const isWithinPeriod = (
+	timestamp: number,
+	startDayKey: string | null,
+	timezoneOffsetMinutes: number,
+) =>
+	startDayKey === null ||
+	timestampToDayKey(timestamp, timezoneOffsetMinutes) >= startDayKey;
+
+const getPeriodStartDayKey = (period: AnalyticsPeriod, todayKey: string) => {
+	if (period === "all") return null;
+	return addDays(todayKey, period === "week" ? -6 : -29);
+};
+
+const getCurrentStreak = (completedDayKeys: Set<string>, todayKey: string) => {
+	const yesterdayKey = addDays(todayKey, -1);
+	let cursor = completedDayKeys.has(todayKey)
+		? todayKey
+		: yesterdayKey && completedDayKeys.has(yesterdayKey)
+			? yesterdayKey
+			: null;
+	let streak = 0;
+
+	while (cursor && completedDayKeys.has(cursor)) {
+		streak += 1;
+		cursor = addDays(cursor, -1);
+	}
+	return streak;
+};
+
+const uniqueRecentStrings = (values: string[], limit: number) => {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const rawValue of values) {
+		const value = rawValue.trim();
+		const key = value.toLocaleLowerCase("de-DE");
+		if (!value || seen.has(key)) continue;
+		seen.add(key);
+		result.push(value);
+		if (result.length >= limit) break;
+	}
+	return result;
+};
+
+export const getOverview = query({
+	args: {
+		period: analyticsPeriodValidator,
+		todayKey: v.string(),
+		timezoneOffsetMinutes: v.number(),
+	},
+	returns: overviewValidator,
+	handler: async (ctx, args) => {
+		const identity = await ctx.auth.getUserIdentity();
+		if (!identity) {
+			throwUserFacingError("Nicht authentifiziert.");
+		}
+		if (parseDayKey(args.todayKey) === null) {
+			throwUserFacingError("Ungültiger Kalendertag.");
+		}
+		if (
+			!Number.isInteger(args.timezoneOffsetMinutes) ||
+			Math.abs(args.timezoneOffsetMinutes) > 14 * 60
+		) {
+			throwUserFacingError("Ungültige Zeitzone.");
+		}
+
+		const ownerTokenIdentifier = identity.tokenIdentifier;
+		const plans = await ctx.db
+			.query("learningPlans")
+			.withIndex("by_ownerTokenIdentifier_and_status", (q) =>
+				q
+					.eq("ownerTokenIdentifier", ownerTokenIdentifier)
+					.eq("status", "accepted"),
+			)
+			.order("desc")
+			.take(MAX_PLANS);
+
+		const sessionsByPlan = await Promise.all(
+			plans.map((plan) =>
+				ctx.db
+					.query("learningPlanSessions")
+					.withIndex("by_learningPlanId_and_sortOrder", (q) =>
+						q.eq("learningPlanId", plan._id),
+					)
+					.order("asc")
+					.take(MAX_SESSIONS_PER_PLAN),
+			),
+		);
+		const sessions = sessionsByPlan.flat();
+		const planById = new Map(plans.map((plan) => [plan._id, plan]));
+		const periodStartDayKey = getPeriodStartDayKey(args.period, args.todayKey);
+		const activityStartDayKey =
+			periodStartDayKey ?? addDays(args.todayKey, -29);
+		if (!activityStartDayKey) {
+			throwUserFacingError("Ungültiger Analysezeitraum.");
+		}
+
+		const effectiveSessions = sessions.filter(
+			(session) => getSessionStatus(session) !== "adjusted",
+		);
+		const completedSessions = effectiveSessions.filter(
+			(session) => getSessionStatus(session) === "completed",
+		);
+		const completedDayKeys = new Set(
+			completedSessions.flatMap((session) =>
+				session.outcomeAt
+					? [timestampToDayKey(session.outcomeAt, args.timezoneOffsetMinutes)]
+					: [],
+			),
+		);
+		const periodSessions = effectiveSessions.filter(
+			(session) =>
+				session.outcomeAt !== undefined &&
+				isWithinPeriod(
+					session.outcomeAt,
+					periodStartDayKey,
+					args.timezoneOffsetMinutes,
+				),
+		);
+		const periodCompletedSessions = periodSessions.filter(
+			(session) => getSessionStatus(session) === "completed",
+		);
+
+		const activityByDay = new Map<
+			string,
+			{ completedSessions: number; activeStudySeconds: number }
+		>();
+		for (let cursor: string | null = activityStartDayKey; cursor; ) {
+			activityByDay.set(cursor, {
+				completedSessions: 0,
+				activeStudySeconds: 0,
+			});
+			if (cursor === args.todayKey) break;
+			cursor = addDays(cursor, 1);
+		}
+		for (const session of effectiveSessions) {
+			if (!session.outcomeAt) continue;
+			const dayKey = timestampToDayKey(
+				session.outcomeAt,
+				args.timezoneOffsetMinutes,
+			);
+			const point = activityByDay.get(dayKey);
+			if (!point) continue;
+			if (getSessionStatus(session) === "completed") {
+				point.completedSessions += 1;
+			}
+			point.activeStudySeconds += session.activeStudySeconds ?? 0;
+		}
+
+		const planProgress = plans.map((plan, index) => {
+			const planSessions = sessionsByPlan[index].filter(
+				(session) => getSessionStatus(session) !== "adjusted",
+			);
+			const planCompletedSessions = planSessions.filter(
+				(session) => getSessionStatus(session) === "completed",
+			).length;
+			return {
+				id: plan._id,
+				subject: plan.subject,
+				examTypeLabel: plan.examTypeLabel,
+				examDateKey: plan.examDateKey,
+				examDateLabel: plan.examDateLabel,
+				progressPercent:
+					planSessions.length > 0
+						? Math.round((planCompletedSessions / planSessions.length) * 100)
+						: 0,
+				completedSessions: planCompletedSessions,
+				totalSessions: planSessions.length,
+			};
+		});
+		planProgress.sort((left, right) =>
+			left.examDateKey.localeCompare(right.examDateKey),
+		);
+
+		const openSessions = effectiveSessions
+			.filter((session) => getSessionStatus(session) !== "completed")
+			.filter((session) => planById.has(session.learningPlanId))
+			.sort((left, right) =>
+				`${left.dateKey}-${left.startTime}`.localeCompare(
+					`${right.dateKey}-${right.startTime}`,
+				),
+			);
+		const nextSession =
+			openSessions.find((session) => session.dateKey >= args.todayKey) ??
+			openSessions.at(-1) ??
+			null;
+		const nextSessionPlan = nextSession
+			? planById.get(nextSession.learningPlanId)
+			: null;
+
+		const attempts = await ctx.db
+			.query("learningSessionAnswerAttempts")
+			.withIndex("by_ownerTokenIdentifier", (q) =>
+				q.eq("ownerTokenIdentifier", ownerTokenIdentifier),
+			)
+			.order("desc")
+			.take(MAX_ATTEMPTS);
+		const latestAttemptsByItem = new Map<
+			Id<"learningSessionContentItems">,
+			Doc<"learningSessionAnswerAttempts">
+		>();
+		for (const attempt of attempts) {
+			if (
+				!planById.has(attempt.learningPlanId) ||
+				!isWithinPeriod(
+					attempt.createdAt,
+					periodStartDayKey,
+					args.timezoneOffsetMinutes,
+				) ||
+				latestAttemptsByItem.has(attempt.itemId)
+			) {
+				continue;
+			}
+			latestAttemptsByItem.set(attempt.itemId, attempt);
+		}
+		const latestAttempts = [...latestAttemptsByItem.values()];
+		const correct = latestAttempts.filter(
+			(attempt) => attempt.rating === "correct",
+		).length;
+		const partiallyCorrect = latestAttempts.filter(
+			(attempt) => attempt.rating === "partiallyCorrect",
+		).length;
+		const notCorrect = latestAttempts.filter(
+			(attempt) => attempt.rating === "notCorrect",
+		).length;
+
+		const analyses = await ctx.db
+			.query("learningSessionAnalyses")
+			.withIndex("by_ownerTokenIdentifier", (q) =>
+				q.eq("ownerTokenIdentifier", ownerTokenIdentifier),
+			)
+			.order("desc")
+			.take(MAX_ANALYSES);
+		const periodAnalyses = analyses.filter(
+			(analysis) =>
+				planById.has(analysis.learningPlanId) &&
+				isWithinPeriod(
+					analysis.updatedAt,
+					periodStartDayKey,
+					args.timezoneOffsetMinutes,
+				),
+		);
+
+		const totalSessions = effectiveSessions.length;
+		const completedSessionCount = completedSessions.length;
+		const finishedPlans = planProgress.filter(
+			(plan) => plan.totalSessions > 0 && plan.progressPercent === 100,
+		).length;
+		const recoveredSessions = periodCompletedSessions.filter(
+			(session) => session.adjustedFromSessionId !== undefined,
+		).length;
+		const activeStudySeconds = periodSessions.reduce(
+			(total, session) => total + (session.activeStudySeconds ?? 0),
+			0,
+		);
+		const answeredItems = latestAttempts.length;
+
+		return {
+			hasData: plans.length > 0,
+			historyLimited:
+				plans.length === MAX_PLANS ||
+				sessionsByPlan.some(
+					(planSessions) => planSessions.length === MAX_SESSIONS_PER_PLAN,
+				) ||
+				attempts.length === MAX_ATTEMPTS ||
+				analyses.length === MAX_ANALYSES,
+			overall: {
+				acceptedPlans: plans.length,
+				finishedPlans,
+				completedSessions: completedSessionCount,
+				totalSessions,
+				progressPercent:
+					totalSessions > 0
+						? Math.round((completedSessionCount / totalSessions) * 100)
+						: 0,
+			},
+			period: {
+				completedSessions: periodCompletedSessions.length,
+				activeStudyMinutes: Math.round(activeStudySeconds / 60),
+				recoveredSessions,
+			},
+			currentStreakDays: getCurrentStreak(completedDayKeys, args.todayKey),
+			activity: [...activityByDay.entries()].map(([dayKey, point]) => ({
+				dayKey,
+				completedSessions: point.completedSessions,
+				activeStudyMinutes: Math.round(point.activeStudySeconds / 60),
+			})),
+			plans: planProgress,
+			nextSession:
+				nextSession && nextSessionPlan
+					? {
+							id: nextSession._id,
+							learningPlanId: nextSession.learningPlanId,
+							subject: nextSessionPlan.subject,
+							title: nextSession.title,
+							dateKey: nextSession.dateKey,
+						}
+					: null,
+			knowledge: {
+				answeredItems,
+				correct,
+				partiallyCorrect,
+				notCorrect,
+				scorePercent:
+					answeredItems > 0
+						? Math.round(
+								((correct + partiallyCorrect * 0.5) / answeredItems) * 100,
+							)
+						: null,
+				strengths: uniqueRecentStrings(
+					periodAnalyses.flatMap((analysis) => analysis.strengths),
+					3,
+				),
+				gaps: uniqueRecentStrings(
+					periodAnalyses.flatMap((analysis) => analysis.gaps),
+					3,
+				),
+				recommendation: periodAnalyses[0]?.recommendation.trim() || null,
+			},
+		};
+	},
+});

--- a/convex/userAnalytics.ts
+++ b/convex/userAnalytics.ts
@@ -125,10 +125,12 @@ const getSessionStatus = (
 const isWithinPeriod = (
 	timestamp: number,
 	startDayKey: string | null,
+	endDayKey: string,
 	timezoneOffsetMinutes: number,
-) =>
-	startDayKey === null ||
-	timestampToDayKey(timestamp, timezoneOffsetMinutes) >= startDayKey;
+) => {
+	const dayKey = timestampToDayKey(timestamp, timezoneOffsetMinutes);
+	return (startDayKey === null || dayKey >= startDayKey) && dayKey <= endDayKey;
+};
 
 const getPeriodStartDayKey = (period: AnalyticsPeriod, todayKey: string) => {
 	if (period === "all") return null;
@@ -237,6 +239,7 @@ export const getOverview = query({
 				isWithinPeriod(
 					session.outcomeAt,
 					periodStartDayKey,
+					args.todayKey,
 					args.timezoneOffsetMinutes,
 				),
 		);
@@ -328,6 +331,7 @@ export const getOverview = query({
 				!isWithinPeriod(
 					attempt.createdAt,
 					periodStartDayKey,
+					args.todayKey,
 					args.timezoneOffsetMinutes,
 				) ||
 				latestAttemptsByItem.has(attempt.itemId)
@@ -354,15 +358,18 @@ export const getOverview = query({
 			)
 			.order("desc")
 			.take(MAX_ANALYSES);
-		const periodAnalyses = analyses.filter(
-			(analysis) =>
-				planById.has(analysis.learningPlanId) &&
-				isWithinPeriod(
-					analysis.updatedAt,
-					periodStartDayKey,
-					args.timezoneOffsetMinutes,
-				),
-		);
+		const periodAnalyses = analyses
+			.filter(
+				(analysis) =>
+					planById.has(analysis.learningPlanId) &&
+					isWithinPeriod(
+						analysis.updatedAt,
+						periodStartDayKey,
+						args.todayKey,
+						args.timezoneOffsetMinutes,
+					),
+			)
+			.sort((left, right) => right.updatedAt - left.updatedAt);
 
 		const totalSessions = effectiveSessions.length;
 		const completedSessionCount = completedSessions.length;

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -11,6 +11,7 @@ export default function AppLayout() {
 		>
 			<Tabs.Screen name="home" options={{ title: "Startseite" }} />
 			<Tabs.Screen name="learning-plans" options={{ title: "Lernpläne" }} />
+			<Tabs.Screen name="analyse" options={{ title: "Analyse" }} />
 			<Tabs.Screen name="settings" options={{ title: "Einstellungen" }} />
 		</Tabs>
 	);

--- a/src/app/(app)/analyse.tsx
+++ b/src/app/(app)/analyse.tsx
@@ -1,0 +1,1 @@
+export { AnalyticsScreen as default } from "~/features/analytics/analytics-screen";

--- a/src/components/bottom-nav.tsx
+++ b/src/components/bottom-nav.tsx
@@ -7,12 +7,12 @@ import Animated, {
 	withSpring,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Home, Route2, Settings } from "~/components/ui/icon";
+import { Analytics, Home, Route2, Settings } from "~/components/ui/icon";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 import { useDayovaTheme } from "~/lib/theme";
 
-type BottomNavKey = "home" | "learningPath" | "settings";
-type AppTabRouteName = "home" | "learning-plans" | "settings";
+type BottomNavKey = "home" | "learningPath" | "analytics" | "settings";
+type AppTabRouteName = "home" | "learning-plans" | "analyse" | "settings";
 type BottomNavIcon = typeof Home;
 type AppTabRoute = {
 	key: string;
@@ -46,6 +46,12 @@ const NAV_ITEMS: Array<{
 		icon: Route2,
 		routeName: "learning-plans",
 		label: "Lernpläne",
+	},
+	{
+		key: "analytics",
+		icon: Analytics,
+		routeName: "analyse",
+		label: "Analyse",
 	},
 	{
 		key: "settings",

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -1,5 +1,6 @@
 import {
 	AlertCircleIcon,
+	Analytics01Icon,
 	ArrowDown01Icon,
 	ArrowLeft01Icon,
 	ArrowRight01Icon,
@@ -73,6 +74,7 @@ const createIcon = (icon: HugeiconsProps["icon"]) => (props: IconProps) => (
 );
 
 export const Attachment = createIcon(Attachment01Icon);
+export const Analytics = createIcon(Analytics01Icon);
 export const Atom = createIcon(Atom02Icon);
 export const ArrowLeft = createIcon(ArrowLeft01Icon);
 export const ArrowRight = createIcon(ArrowRight01Icon);

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -1,0 +1,823 @@
+import { useConvexAuth, useQuery } from "convex/react";
+import { useRouter } from "expo-router";
+import { useMemo, useState } from "react";
+import {
+	Pressable,
+	useWindowDimensions,
+	View,
+	type ViewProps,
+} from "react-native";
+import Svg, { Circle } from "react-native-svg";
+import { api } from "#convex/_generated/api";
+import { NotificationButton } from "~/components/notification-button";
+import { AnimatedFlowerLoader } from "~/components/ui/animated-flower-loader";
+import { Button } from "~/components/ui/button";
+import {
+	ArrowUpRight,
+	Check,
+	CircleAlert,
+	Fire,
+	Route2,
+	Sparkles,
+	Time04,
+} from "~/components/ui/icon";
+import { Screen, ScreenScroll } from "~/components/ui/screen";
+import { ActionSurface, Surface } from "~/components/ui/surface";
+import { Text } from "~/components/ui/text";
+import { ThemedStatusBar } from "~/components/ui/themed-status-bar";
+import { useAuthSession } from "~/context/AuthContext";
+import { getDayKey, parseDayKey, useCurrentLocalDay } from "~/lib/day-key";
+import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
+import { formatGermanUiText } from "~/lib/german-ui-text";
+import { ROUTES } from "~/lib/routes";
+import { useDayovaTheme } from "~/lib/theme";
+import { cn } from "~/lib/utils";
+
+type AnalyticsPeriod = "week" | "month" | "all";
+type AnalyticsOverview = NonNullable<
+	ReturnType<typeof useQuery<typeof api.userAnalytics.getOverview>>
+>;
+
+const PERIOD_OPTIONS: Array<{
+	value: AnalyticsPeriod;
+	label: string;
+}> = [
+	{ value: "week", label: "7 Tage" },
+	{ value: "month", label: "30 Tage" },
+	{ value: "all", label: "Gesamt" },
+];
+
+const formatMinutes = (minutes: number) => {
+	if (minutes < 60) return `${minutes} min`;
+	const hours = Math.floor(minutes / 60);
+	const remainder = minutes % 60;
+	return remainder > 0 ? `${hours} h ${remainder} min` : `${hours} h`;
+};
+
+const formatCompactDay = (dayKey: string) => {
+	const date = parseDayKey(dayKey);
+	if (!date) return dayKey;
+	return new Intl.DateTimeFormat("de-DE", {
+		day: "2-digit",
+		month: "2-digit",
+	}).format(date);
+};
+
+function PeriodSelector({
+	period,
+	onChange,
+}: {
+	period: AnalyticsPeriod;
+	onChange: (period: AnalyticsPeriod) => void;
+}) {
+	return (
+		<View
+			accessibilityRole="tablist"
+			className="flex-row rounded-full border border-border bg-card p-1"
+		>
+			{PERIOD_OPTIONS.map((option) => {
+				const selected = option.value === period;
+				return (
+					<Pressable
+						key={option.value}
+						accessibilityRole="tab"
+						accessibilityState={{ selected }}
+						className={cn(
+							"h-11 flex-1 items-center justify-center rounded-full",
+							selected ? "bg-button-neutral" : "bg-transparent",
+						)}
+						onPress={() => onChange(option.value)}
+					>
+						<Text
+							className={cn(
+								"font-poppins font-semibold text-body-4",
+								selected ? "text-background" : "text-secondary-text",
+							)}
+						>
+							{option.label}
+						</Text>
+					</Pressable>
+				);
+			})}
+		</View>
+	);
+}
+
+function ProgressRing({
+	progressPercent,
+	size = 112,
+}: {
+	progressPercent: number;
+	size?: number;
+}) {
+	const { colors } = useDayovaTheme();
+	const strokeWidth = 9;
+	const radius = (size - strokeWidth) / 2;
+	const circumference = 2 * Math.PI * radius;
+	const progress = Math.max(0, Math.min(progressPercent, 100));
+
+	return (
+		<View
+			accessible
+			accessibilityLabel="Fortschritt deiner Lernpläne"
+			accessibilityRole="progressbar"
+			accessibilityValue={{
+				min: 0,
+				max: 100,
+				now: progress,
+				text: `${progress} Prozent`,
+			}}
+			className="items-center justify-center"
+			style={{ height: size, width: size }}
+		>
+			<Svg
+				accessible={false}
+				accessibilityElementsHidden
+				width={size}
+				height={size}
+				style={{ position: "absolute" }}
+			>
+				<Circle
+					cx={size / 2}
+					cy={size / 2}
+					r={radius}
+					stroke={colors.light2}
+					strokeWidth={strokeWidth}
+					fill="none"
+				/>
+				<Circle
+					cx={size / 2}
+					cy={size / 2}
+					r={radius}
+					stroke={colors.primaryStrong}
+					strokeWidth={strokeWidth}
+					fill="none"
+					strokeLinecap="round"
+					strokeDasharray={`${circumference} ${circumference}`}
+					strokeDashoffset={circumference - (progress / 100) * circumference}
+					transform={`rotate(-90 ${size / 2} ${size / 2})`}
+				/>
+			</Svg>
+			<Text
+				selectable
+				className="font-poppins font-semibold text-heading-2 text-text"
+				style={{ fontVariant: ["tabular-nums"] }}
+			>
+				{`${progress}%`}
+			</Text>
+		</View>
+	);
+}
+
+function SectionHeading({
+	title,
+	description,
+}: {
+	title: string;
+	description?: string;
+}) {
+	return (
+		<View className="gap-1">
+			<Text className="font-poppins font-semibold text-body-1 text-text">
+				{title}
+			</Text>
+			{description ? (
+				<Text
+					selectable
+					className="font-poppins text-body-4 text-secondary-text"
+				>
+					{description}
+				</Text>
+			) : null}
+		</View>
+	);
+}
+
+function MetricCard({
+	icon,
+	label,
+	value,
+}: {
+	icon: React.JSX.Element;
+	label: string;
+	value: string;
+}) {
+	return (
+		<Surface
+			accessible
+			accessibilityLabel={`${label}: ${value}`}
+			className="min-w-0 flex-1 gap-3 px-3 py-4"
+			variant="flat"
+		>
+			<View className="h-9 w-9 items-center justify-center rounded-full bg-system-subtle">
+				{icon}
+			</View>
+			<View className="gap-0.5">
+				<Text
+					selectable
+					className="font-poppins font-semibold text-body-2 text-text"
+					numberOfLines={1}
+					adjustsFontSizeToFit
+					style={{ fontVariant: ["tabular-nums"] }}
+				>
+					{value}
+				</Text>
+				<Text
+					className="font-poppins text-body-5 text-secondary-text"
+					numberOfLines={1}
+				>
+					{label}
+				</Text>
+			</View>
+		</Surface>
+	);
+}
+
+function ActivityChart({
+	activity,
+	period,
+}: {
+	activity: AnalyticsOverview["activity"];
+	period: AnalyticsPeriod;
+}) {
+	const { width } = useWindowDimensions();
+	const { colors } = useDayovaTheme();
+	const maxValue = Math.max(
+		1,
+		...activity.map((point) =>
+			Math.max(point.activeStudyMinutes, point.completedSessions * 5),
+		),
+	);
+	const chartWidth = Math.max(width - 88, 220);
+	const gap = activity.length <= 7 ? 8 : 3;
+	const barWidth = Math.max(
+		4,
+		(chartWidth - gap * Math.max(activity.length - 1, 0)) /
+			Math.max(activity.length, 1),
+	);
+	const totalMinutes = activity.reduce(
+		(total, point) => total + point.activeStudyMinutes,
+		0,
+	);
+	const totalSessions = activity.reduce(
+		(total, point) => total + point.completedSessions,
+		0,
+	);
+
+	if (activity.length === 0) return null;
+
+	return (
+		<Surface className="gap-5 p-5" variant="flat">
+			<View
+				accessible
+				accessibilityLabel={`Lernaktivität: ${formatMinutes(totalMinutes)} aktive Lernzeit und ${totalSessions} abgeschlossene Einheiten im Diagrammzeitraum.`}
+				className="h-32 flex-row items-end"
+				style={{ columnGap: gap }}
+			>
+				{activity.map((point) => {
+					const value = Math.max(
+						point.activeStudyMinutes,
+						point.completedSessions * 5,
+					);
+					const height = value > 0 ? Math.max(10, (value / maxValue) * 112) : 4;
+					return (
+						<View
+							key={point.dayKey}
+							accessible={false}
+							className="rounded-full bg-progress-track"
+							style={{
+								width: barWidth,
+								height,
+								backgroundColor:
+									value > 0 ? colors.primaryStrong : colors.light2,
+							}}
+						/>
+					);
+				})}
+			</View>
+			<View className="flex-row justify-between">
+				<Text className="font-poppins text-body-5 text-secondary-text">
+					{formatCompactDay(activity[0].dayKey)}
+				</Text>
+				<Text className="font-poppins text-body-5 text-secondary-text">
+					{period === "all" ? "Letzte 30 Tage" : "Lernaktivität"}
+				</Text>
+				<Text className="font-poppins text-body-5 text-secondary-text">
+					{formatCompactDay(activity.at(-1)?.dayKey ?? "")}
+				</Text>
+			</View>
+		</Surface>
+	);
+}
+
+function PlanProgressCard({
+	plan,
+	onPress,
+}: {
+	plan: AnalyticsOverview["plans"][number];
+	onPress: () => void;
+}) {
+	const { colors } = useDayovaTheme();
+	const title = formatGermanUiText(
+		`${plan.subject} ${plan.examTypeLabel}`.trim(),
+	);
+
+	return (
+		<ActionSurface
+			accessibilityLabel={`${title}, ${plan.progressPercent} Prozent abgeschlossen`}
+			accessibilityHint="Öffnet den Lernplan."
+			className="gap-4 p-5"
+			onPress={onPress}
+			variant="flat"
+		>
+			<View className="flex-row items-center gap-4">
+				<View className="h-11 w-11 items-center justify-center rounded-full bg-system-subtle">
+					<Route2 size={21} color={colors.primaryStrong} strokeWidth={2} />
+				</View>
+				<View className="min-w-0 flex-1">
+					<Text
+						className="font-poppins font-semibold text-body-2 text-text"
+						numberOfLines={2}
+					>
+						{title}
+					</Text>
+					<Text
+						selectable
+						className="font-poppins text-body-4 text-secondary-text"
+					>
+						{plan.examDateLabel}
+					</Text>
+				</View>
+				<Text
+					selectable
+					className="font-poppins font-semibold text-body-2 text-text"
+					style={{ fontVariant: ["tabular-nums"] }}
+				>
+					{`${plan.progressPercent}%`}
+				</Text>
+			</View>
+			<View
+				accessible
+				accessibilityRole="progressbar"
+				accessibilityValue={{
+					min: 0,
+					max: plan.totalSessions,
+					now: plan.completedSessions,
+					text: `${plan.completedSessions} von ${plan.totalSessions} Einheiten`,
+				}}
+				className="h-2 overflow-hidden rounded-full bg-progress-track"
+			>
+				<View
+					className="h-full rounded-full bg-primary-strong"
+					style={{ width: `${plan.progressPercent}%` }}
+				/>
+			</View>
+			<Text
+				selectable
+				className="font-poppins text-body-5 text-secondary-text"
+				style={{ fontVariant: ["tabular-nums"] }}
+			>
+				{`${plan.completedSessions} von ${plan.totalSessions} Einheiten abgeschlossen`}
+			</Text>
+		</ActionSurface>
+	);
+}
+
+function KnowledgeLegendItem({
+	color,
+	label,
+	value,
+}: {
+	color: string;
+	label: string;
+	value: number;
+}) {
+	return (
+		<View className="flex-row items-center gap-2">
+			<View
+				accessible={false}
+				className="h-2.5 w-2.5 rounded-full"
+				style={{ backgroundColor: color }}
+			/>
+			<Text className="font-poppins text-body-5 text-secondary-text">
+				{`${label} ${value}`}
+			</Text>
+		</View>
+	);
+}
+
+function InsightList({
+	icon,
+	items,
+	title,
+}: {
+	icon: (props: {
+		size?: number;
+		color?: string;
+		strokeWidth?: number;
+	}) => React.JSX.Element;
+	items: string[];
+	title: string;
+}) {
+	const Icon = icon;
+	const { colors } = useDayovaTheme();
+	if (items.length === 0) return null;
+
+	return (
+		<View className="gap-3">
+			<Text className="font-poppins font-semibold text-body-3 text-text">
+				{title}
+			</Text>
+			{items.map((item) => (
+				<View key={item} className="flex-row items-start gap-3">
+					<View className="pt-0.5">
+						<Icon
+							size={18}
+							color={
+								title === "Das sitzt schon" ? colors.success : colors.wrong
+							}
+							strokeWidth={2}
+						/>
+					</View>
+					<Text
+						selectable
+						className="min-w-0 flex-1 font-poppins text-body-4 text-text"
+					>
+						{item}
+					</Text>
+				</View>
+			))}
+		</View>
+	);
+}
+
+function KnowledgeCard({
+	knowledge,
+}: {
+	knowledge: AnalyticsOverview["knowledge"];
+}) {
+	const { colors } = useDayovaTheme();
+	const score = knowledge.scorePercent ?? 0;
+	const correctWidth =
+		knowledge.answeredItems > 0
+			? (knowledge.correct / knowledge.answeredItems) * 100
+			: 0;
+	const partialWidth =
+		knowledge.answeredItems > 0
+			? (knowledge.partiallyCorrect / knowledge.answeredItems) * 100
+			: 0;
+	const incorrectWidth = Math.max(0, 100 - correctWidth - partialWidth);
+
+	if (
+		knowledge.answeredItems === 0 &&
+		knowledge.strengths.length === 0 &&
+		knowledge.gaps.length === 0
+	) {
+		return (
+			<Surface className="gap-2 p-5" variant="flat">
+				<Text className="font-poppins font-semibold text-body-3 text-text">
+					Noch kein Wissensbild
+				</Text>
+				<Text
+					selectable
+					className="font-poppins text-body-4 text-secondary-text"
+				>
+					Nach deiner ersten Übungs- oder Praxiseinheit siehst du hier, was
+					schon sitzt und was du als Nächstes festigen kannst.
+				</Text>
+			</Surface>
+		);
+	}
+
+	return (
+		<Surface className="gap-6 p-5" variant="flat">
+			{knowledge.answeredItems > 0 ? (
+				<View className="gap-4">
+					<View className="flex-row items-end justify-between">
+						<View className="gap-1">
+							<Text className="font-poppins text-body-4 text-secondary-text">
+								Antwortqualität
+							</Text>
+							<Text
+								selectable
+								className="font-poppins font-semibold text-heading-2 text-text"
+								style={{ fontVariant: ["tabular-nums"] }}
+							>
+								{`${score}%`}
+							</Text>
+						</View>
+						<Text
+							selectable
+							className="font-poppins text-body-5 text-secondary-text"
+						>
+							{`${knowledge.answeredItems} ausgewertete Antworten`}
+						</Text>
+					</View>
+					<View
+						accessible
+						accessibilityLabel={`${knowledge.correct} richtig, ${knowledge.partiallyCorrect} teilweise richtig, ${knowledge.notCorrect} noch offen`}
+						className="h-3 flex-row overflow-hidden rounded-full bg-progress-track"
+					>
+						<View
+							className="h-full"
+							style={{
+								width: `${correctWidth}%`,
+								backgroundColor: colors.success,
+							}}
+						/>
+						<View
+							className="h-full"
+							style={{
+								width: `${partialWidth}%`,
+								backgroundColor: colors.info,
+							}}
+						/>
+						<View
+							className="h-full"
+							style={{
+								width: `${incorrectWidth}%`,
+								backgroundColor: colors.wrong,
+							}}
+						/>
+					</View>
+					<View className="flex-row flex-wrap gap-x-4 gap-y-2">
+						<KnowledgeLegendItem
+							color={colors.success}
+							label="Richtig"
+							value={knowledge.correct}
+						/>
+						<KnowledgeLegendItem
+							color={colors.info}
+							label="Teilweise"
+							value={knowledge.partiallyCorrect}
+						/>
+						<KnowledgeLegendItem
+							color={colors.wrong}
+							label="Offen"
+							value={knowledge.notCorrect}
+						/>
+					</View>
+				</View>
+			) : null}
+			<InsightList
+				icon={Check}
+				items={knowledge.strengths}
+				title="Das sitzt schon"
+			/>
+			<InsightList
+				icon={CircleAlert}
+				items={knowledge.gaps}
+				title="Als Nächstes festigen"
+			/>
+			{knowledge.recommendation ? (
+				<View className="flex-row items-start gap-3 rounded-info bg-system-subtle p-4">
+					<Sparkles size={19} color={colors.primaryStrong} strokeWidth={2} />
+					<Text
+						selectable
+						className="min-w-0 flex-1 font-poppins text-body-4 text-text"
+					>
+						{knowledge.recommendation}
+					</Text>
+				</View>
+			) : null}
+		</Surface>
+	);
+}
+
+function LoadingState() {
+	return (
+		<View
+			accessibilityLabel="Analyse wird geladen"
+			accessibilityLiveRegion="polite"
+			className="items-center gap-4 py-24"
+		>
+			<AnimatedFlowerLoader size={104} />
+			<Text className="font-poppins text-body-4 text-secondary-text">
+				Deine Analyse wird geladen …
+			</Text>
+		</View>
+	);
+}
+
+function EmptyState({ onCreatePlan }: { onCreatePlan: () => void }) {
+	return (
+		<Surface className="items-center gap-5 px-6 py-10" variant="flat">
+			<View className="h-16 w-16 items-center justify-center rounded-full bg-system-subtle">
+				<Sparkles
+					size={30}
+					color={DAYOVA_DESIGN_SYSTEM.colors.primaryStrong}
+					strokeWidth={2}
+				/>
+			</View>
+			<View className="items-center gap-2">
+				<Text className="text-center font-poppins font-semibold text-body-1 text-text">
+					Hier wächst deine Analyse
+				</Text>
+				<Text
+					selectable
+					className="text-center font-poppins text-body-4 text-secondary-text"
+				>
+					Erstelle deinen ersten Lernplan. Sobald du lernst, siehst du hier
+					deinen Fortschritt, deine Lernzeit und dein Wissensbild.
+				</Text>
+			</View>
+			<Button
+				accessibilityLabel="Ersten Lernplan erstellen"
+				onPress={onCreatePlan}
+			>
+				<Text>Ersten Lernplan erstellen</Text>
+			</Button>
+		</Surface>
+	);
+}
+
+function AnalyticsContent({
+	data,
+	period,
+	onOpenPlan,
+	onOpenNextSession,
+}: {
+	data: AnalyticsOverview;
+	period: AnalyticsPeriod;
+	onOpenPlan: (planId: string) => void;
+	onOpenNextSession: (planId: string, sessionId: string) => void;
+}) {
+	const { colors } = useDayovaTheme();
+	const periodLabel =
+		period === "week"
+			? "in den letzten 7 Tagen"
+			: period === "month"
+				? "in den letzten 30 Tagen"
+				: "insgesamt";
+
+	return (
+		<View className="gap-9">
+			<Surface className="gap-6 p-6">
+				<View className="flex-row items-center gap-5">
+					<ProgressRing progressPercent={data.overall.progressPercent} />
+					<View className="min-w-0 flex-1 gap-2">
+						<Text className="font-poppins font-semibold text-body-1 text-text">
+							Dein Lernfortschritt
+						</Text>
+						<Text
+							selectable
+							className="font-poppins text-body-4 text-secondary-text"
+						>
+							{data.overall.totalSessions > 0
+								? `${data.overall.completedSessions} von ${data.overall.totalSessions} geplanten Einheiten sind geschafft.`
+								: "Deine geplanten Einheiten erscheinen hier, sobald dein Lernplan bereit ist."}
+						</Text>
+					</View>
+				</View>
+				{data.nextSession ? (
+					<Button
+						accessibilityHint="Öffnet die nächste relevante Lerneinheit."
+						onPress={() =>
+							onOpenNextSession(
+								data.nextSession?.learningPlanId ?? "",
+								data.nextSession?.id ?? "",
+							)
+						}
+					>
+						<Text numberOfLines={1}>
+							{`${formatGermanUiText(data.nextSession.subject)} weiterlernen`}
+						</Text>
+						<ArrowUpRight size={20} color="#FFFFFF" strokeWidth={2} />
+					</Button>
+				) : null}
+			</Surface>
+
+			<View className="gap-4">
+				<SectionHeading
+					title="Dein Einsatz"
+					description={`Was du ${periodLabel} umgesetzt hast.`}
+				/>
+				<View className="flex-row gap-3">
+					<MetricCard
+						icon={
+							<Time04 size={19} color={colors.primaryStrong} strokeWidth={2} />
+						}
+						label="Lernzeit"
+						value={formatMinutes(data.period.activeStudyMinutes)}
+					/>
+					<MetricCard
+						icon={
+							<Check size={19} color={colors.primaryStrong} strokeWidth={2} />
+						}
+						label="Einheiten"
+						value={data.period.completedSessions.toString()}
+					/>
+					<MetricCard
+						icon={
+							<Fire size={19} color={colors.primaryStrong} strokeWidth={2} />
+						}
+						label="Lernserie"
+						value={`${data.currentStreakDays} T`}
+					/>
+				</View>
+				{data.period.recoveredSessions > 0 ? (
+					<View className="flex-row items-start gap-3 rounded-info bg-success-subtle p-4">
+						<Check size={19} color={colors.success} strokeWidth={2.2} />
+						<Text
+							selectable
+							className="min-w-0 flex-1 font-poppins text-body-4 text-text"
+						>
+							{data.period.recoveredSessions === 1
+								? "Du hast einen verschobenen Lernblock erfolgreich nachgeholt."
+								: `Du hast ${data.period.recoveredSessions} verschobene Lernblöcke erfolgreich nachgeholt.`}
+						</Text>
+					</View>
+				) : null}
+				<ActivityChart activity={data.activity} period={period} />
+			</View>
+
+			<View className="gap-4">
+				<SectionHeading
+					title="Deine Lernpläne"
+					description={`${data.overall.finishedPlans} von ${data.overall.acceptedPlans} Plänen vollständig abgeschlossen.`}
+				/>
+				<View className="gap-3">
+					{data.plans.map((plan) => (
+						<PlanProgressCard
+							key={plan.id}
+							plan={plan}
+							onPress={() => onOpenPlan(plan.id)}
+						/>
+					))}
+				</View>
+			</View>
+
+			<View className="gap-4">
+				<SectionHeading
+					title="Dein Wissensbild"
+					description={`Aus deinen ausgewerteten Antworten ${periodLabel}.`}
+				/>
+				<KnowledgeCard knowledge={data.knowledge} />
+			</View>
+
+			{data.historyLimited ? (
+				<Text
+					selectable
+					className="text-center font-poppins text-body-5 text-secondary-text"
+				>
+					Bei sehr umfangreichen Verläufen zeigt Dayova die neuesten Aktivitäten
+					und Analysen.
+				</Text>
+			) : null}
+		</View>
+	);
+}
+
+export function AnalyticsScreen(_props: ViewProps) {
+	const router = useRouter();
+	const { user } = useAuthSession();
+	const { isAuthenticated: isConvexAuthenticated } = useConvexAuth();
+	const today = useCurrentLocalDay();
+	const [period, setPeriod] = useState<AnalyticsPeriod>("week");
+	const queryArgs = useMemo(
+		() => ({
+			period,
+			todayKey: getDayKey(today),
+			timezoneOffsetMinutes: today.getTimezoneOffset(),
+		}),
+		[period, today],
+	);
+	const data = useQuery(
+		api.userAnalytics.getOverview,
+		user && isConvexAuthenticated ? queryArgs : "skip",
+	);
+
+	return (
+		<Screen>
+			<ThemedStatusBar />
+			<ScreenScroll topPadding={84} bottomPadding={150} horizontalPadding={24}>
+				<View className="flex-row items-center justify-between">
+					<Text className="font-poppins font-semibold text-heading-2 text-text">
+						Analyse
+					</Text>
+					<NotificationButton />
+				</View>
+
+				<View className="mt-7 gap-7">
+					<PeriodSelector period={period} onChange={setPeriod} />
+					{data === undefined ? (
+						<LoadingState />
+					) : data.hasData ? (
+						<AnalyticsContent
+							data={data}
+							period={period}
+							onOpenPlan={(planId) => router.push(`/learning-plans/${planId}`)}
+							onOpenNextSession={(planId, sessionId) =>
+								router.push(`/learning-plans/${planId}/sessions/${sessionId}`)
+							}
+						/>
+					) : (
+						<EmptyState
+							onCreatePlan={() => router.push(ROUTES.createLearningPlan)}
+						/>
+					)}
+				</View>
+			</ScreenScroll>
+		</Screen>
+	);
+}

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -649,6 +649,7 @@ function AnalyticsContent({
 			: period === "month"
 				? "in den letzten 30 Tagen"
 				: "insgesamt";
+	const nextSession = data.nextSession;
 
 	return (
 		<View className="gap-9">
@@ -669,18 +670,15 @@ function AnalyticsContent({
 						</Text>
 					</View>
 				</View>
-				{data.nextSession ? (
+				{nextSession ? (
 					<Button
 						accessibilityHint="Öffnet die nächste relevante Lerneinheit."
 						onPress={() =>
-							onOpenNextSession(
-								data.nextSession?.learningPlanId ?? "",
-								data.nextSession?.id ?? "",
-							)
+							onOpenNextSession(nextSession.learningPlanId, nextSession.id)
 						}
 					>
 						<Text numberOfLines={1}>
-							{`${formatGermanUiText(data.nextSession.subject)} weiterlernen`}
+							{`${formatGermanUiText(nextSession.subject)} weiterlernen`}
 						</Text>
 						<ArrowUpRight size={20} color="#FFFFFF" strokeWidth={2} />
 					</Button>

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -1,0 +1,220 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { fireEvent, render } from "@testing-library/react-native";
+import { AnalyticsScreen } from "./analytics-screen";
+
+const mockPush = jest.fn();
+const mockUseQuery = jest.fn();
+let mockIsConvexAuthenticated = true;
+let mockUser: { clerkId: string } | null = { clerkId: "user_123" };
+
+jest.mock("expo-router", () => ({
+	useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("convex/react", () => ({
+	useConvexAuth: () => ({ isAuthenticated: mockIsConvexAuthenticated }),
+	useQuery: (...args: unknown[]) => mockUseQuery(...args),
+}));
+
+jest.mock("#convex/_generated/api", () => ({
+	api: { userAnalytics: { getOverview: "getOverview" } },
+}));
+
+jest.mock("~/context/AuthContext", () => ({
+	useAuthSession: () => ({ user: mockUser }),
+}));
+
+jest.mock("~/components/notification-button", () => ({
+	NotificationButton: () => null,
+}));
+
+jest.mock("~/components/ui/animated-flower-loader", () => {
+	const React = jest.requireActual<typeof import("react")>("react");
+	return {
+		AnimatedFlowerLoader: () =>
+			React.createElement("AnimatedFlowerLoader", null),
+	};
+});
+
+jest.mock("~/components/ui/icon", () => {
+	const React = jest.requireActual<typeof import("react")>("react");
+	const Icon = (props: Record<string, unknown>) =>
+		React.createElement("Icon", props);
+	return new Proxy(
+		{ __esModule: true },
+		{
+			get: (target, property) =>
+				property in target ? target[property as keyof typeof target] : Icon,
+		},
+	);
+});
+
+jest.mock("~/components/ui/screen", () => {
+	const React = jest.requireActual<typeof import("react")>("react");
+	const Native =
+		jest.requireActual<typeof import("react-native")>("react-native");
+	return {
+		Screen: ({ children }: { children: ReactNode }) =>
+			React.createElement(Native.View, null, children),
+		ScreenScroll: ({ children }: { children: ReactNode }) =>
+			React.createElement(Native.View, null, children),
+	};
+});
+
+jest.mock("~/components/ui/themed-status-bar", () => ({
+	ThemedStatusBar: () => null,
+}));
+
+jest.mock("~/lib/theme", () => ({
+	useDayovaTheme: () => ({
+		colors: {
+			border: "#DCE6EE",
+			info: "#C9A100",
+			light2: "#F3F6FA",
+			primaryStrong: "#00A0E6",
+			success: "#34C759",
+			text: "#1A1A1A",
+			wrong: "#FF9500",
+		},
+	}),
+}));
+
+const emptyOverview = {
+	hasData: false,
+	historyLimited: false,
+	overall: {
+		acceptedPlans: 0,
+		finishedPlans: 0,
+		completedSessions: 0,
+		totalSessions: 0,
+		progressPercent: 0,
+	},
+	period: {
+		completedSessions: 0,
+		activeStudyMinutes: 0,
+		recoveredSessions: 0,
+	},
+	currentStreakDays: 0,
+	activity: [],
+	plans: [],
+	nextSession: null,
+	knowledge: {
+		answeredItems: 0,
+		correct: 0,
+		partiallyCorrect: 0,
+		notCorrect: 0,
+		scorePercent: null,
+		strengths: [],
+		gaps: [],
+		recommendation: null,
+	},
+};
+
+const populatedOverview = {
+	...emptyOverview,
+	hasData: true,
+	overall: {
+		acceptedPlans: 1,
+		finishedPlans: 0,
+		completedSessions: 2,
+		totalSessions: 3,
+		progressPercent: 67,
+	},
+	period: {
+		completedSessions: 2,
+		activeStudyMinutes: 30,
+		recoveredSessions: 1,
+	},
+	currentStreakDays: 2,
+	activity: [
+		{
+			dayKey: "2026-07-28",
+			completedSessions: 1,
+			activeStudyMinutes: 10,
+		},
+	],
+	plans: [
+		{
+			id: "plan_1",
+			subject: "Mathe",
+			examTypeLabel: "Klausur",
+			examDateKey: "2026-08-05",
+			examDateLabel: "5. August 2026",
+			progressPercent: 67,
+			completedSessions: 2,
+			totalSessions: 3,
+		},
+	],
+	nextSession: {
+		id: "session_1",
+		learningPlanId: "plan_1",
+		subject: "Mathe",
+		title: "Generalprobe",
+		dateKey: "2026-07-30",
+	},
+	knowledge: {
+		answeredItems: 1,
+		correct: 0,
+		partiallyCorrect: 1,
+		notCorrect: 0,
+		scorePercent: 50,
+		strengths: ["Du erkennst lineare Zusammenhänge."],
+		gaps: ["Steigung noch präziser erklären."],
+		recommendation: "Übe eine weitere Steigungsaufgabe.",
+	},
+};
+
+describe("AnalyticsScreen", () => {
+	beforeEach(() => {
+		mockPush.mockReset();
+		mockUseQuery.mockReset();
+		mockUseQuery.mockReturnValue(emptyOverview);
+		mockIsConvexAuthenticated = true;
+		mockUser = { clerkId: "user_123" };
+	});
+
+	test("skips private analytics until both auth layers are ready", async () => {
+		mockIsConvexAuthenticated = false;
+		await render(<AnalyticsScreen />);
+		expect(mockUseQuery).toHaveBeenCalledWith("getOverview", "skip");
+	});
+
+	test("guides a new learner to create the first plan", async () => {
+		const screen = await render(<AnalyticsScreen />);
+		fireEvent.press(
+			screen.getByRole("button", { name: "Ersten Lernplan erstellen" }),
+		);
+		expect(mockPush).toHaveBeenCalledWith("/learning-plans/new");
+	});
+
+	test("shows real progress and refreshes period-sensitive data", async () => {
+		mockUseQuery.mockReturnValue(populatedOverview);
+		const screen = await render(<AnalyticsScreen />);
+
+		expect(screen.getAllByText("67%")).toHaveLength(2);
+		expect(screen.getByText("30 min")).toBeOnTheScreen();
+		expect(screen.getByText("Antwortqualität")).toBeOnTheScreen();
+		expect(
+			screen.getByText(
+				"Du hast einen verschobenen Lernblock erfolgreich nachgeholt.",
+			),
+		).toBeOnTheScreen();
+
+		await fireEvent.press(screen.getByRole("tab", { name: "30 Tage" }));
+		expect(mockUseQuery).toHaveBeenLastCalledWith(
+			"getOverview",
+			expect.objectContaining({ period: "month" }),
+		);
+	});
+
+	test("opens the next learning session from the primary action", async () => {
+		mockUseQuery.mockReturnValue(populatedOverview);
+		const screen = await render(<AnalyticsScreen />);
+
+		fireEvent.press(screen.getByRole("button", { name: "Mathe weiterlernen" }));
+		expect(mockPush).toHaveBeenCalledWith(
+			"/learning-plans/plan_1/sessions/session_1",
+		);
+	});
+});

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -3,6 +3,7 @@ export const ROUTES = {
 	settings: "/settings",
 	learningTimes: "/learning-times",
 	learningPlans: "/learning-plans",
+	analytics: "/analyse",
 	createExam: "/entry/new?type=exam",
 	createHomework: "/entry/new?type=homework",
 	createLearningPlan: "/learning-plans/new",


### PR DESCRIPTION
## Summary

Adds **Analyse** as a fourth primary navigation destination and gives each learner a private, actionable view of their own exam preparation.

Linear: [DAY-291](https://linear.app/dayova/issue/DAY-291/add-student-facing-analyse-dashboard-to-primary-navigation)

## What changed

- adds the Analyse route and Hugeicons analytics glyph to the existing bottom navigation
- adds an authenticated Convex overview query derived from accepted learning plans, session outcomes, active study time, recovery sessions, answer attempts, and session analyses
- supports 7-day, 30-day, and all-time reporting periods
- shows overall plan progress, the next learning action, study time, completed sessions, current streak, recovery feedback, an activity chart, per-plan progress, and a knowledge summary
- includes loading, first-use empty, partial-data, and history-limit states
- keeps the surface student-private: no teacher/class data, rankings, predicted grades, raw surveillance timelines, or PostHog profile data
- adds backend authorization/range tests and UI interaction/accessibility tests

## Product impact

The page makes Dayova's core promise visible after plan generation: the learner can see whether preparation is turning into completed action, where knowledge is improving, and whether missed work was successfully recovered. The primary action always returns the learner to the next relevant session.

## Validation

- `pnpm check`
- `pnpm test` — 78 Vitest files / 444 tests and 21 UI suites / 56 tests
- `pnpm format:check`
- focused iOS development-client render inspection in dark mode, including navigation, empty state, responsive hierarchy, and accessibility tree

Environment note: the local shell reported Node 25.9 while the repository declares Node 24.x; all checks still completed successfully.