### PR TITLE
Group settings into design-system sections

### DIFF
--- a/src/app/(app)/settings.tsx
+++ b/src/app/(app)/settings.tsx
@@ -1,7 +1,9 @@
 import { useRouter } from "expo-router";
-import { useRef, useState } from "react";
-import { Pressable, useWindowDimensions, View } from "react-native";
+import { type ReactNode, useRef, useState } from "react";
+import { Pressable, View } from "react-native";
+import { ErrorMessage } from "~/components/ui/error-message";
 import {
+	ArrowRight,
 	Bell,
 	CalendarDays,
 	Computer,
@@ -14,8 +16,9 @@ import {
 	Timer,
 } from "~/components/ui/icon";
 import { ListRow } from "~/components/ui/list-row";
-import { ErrorMessage } from "~/components/ui/error-message";
 import { Screen, ScreenScroll } from "~/components/ui/screen";
+import { Surface } from "~/components/ui/surface";
+import { Text } from "~/components/ui/text";
 import { ThemedStatusBar } from "~/components/ui/themed-status-bar";
 import { useAccountActions } from "~/context/AuthContext";
 import { createAsyncActionGate } from "~/lib/async-action-gate";
@@ -44,6 +47,7 @@ function SettingsRow({
 	onPress,
 	disabled = false,
 	busy = false,
+	showDisclosure = true,
 }: {
 	icon: (props: {
 		size?: number;
@@ -55,6 +59,7 @@ function SettingsRow({
 	onPress?: () => void;
 	disabled?: boolean;
 	busy?: boolean;
+	showDisclosure?: boolean;
 }) {
 	const Icon = icon;
 	const { colors } = useDayovaTheme();
@@ -69,8 +74,39 @@ function SettingsRow({
 				busy,
 				disabled,
 			}}
-			trailing={trailing}
+			className="rounded-3xl bg-transparent px-3 shadow-none"
+			trailing={
+				trailing ??
+				(onPress && showDisclosure ? (
+					<ArrowRight size={18} color={colors.secondaryText} strokeWidth={2} />
+				) : undefined)
+			}
+			variant="flat"
 		/>
+	);
+}
+
+function SettingsDivider() {
+	return <View className="mx-4 h-px bg-border" />;
+}
+
+function SettingsSection({
+	children,
+	title,
+}: {
+	children: ReactNode;
+	title: string;
+}) {
+	return (
+		<View className="gap-2">
+			<Text
+				accessibilityRole="header"
+				className="px-4 font-poppins font-semibold text-body-4 text-secondary-text"
+			>
+				{title}
+			</Text>
+			<Surface className="overflow-hidden p-2">{children}</Surface>
+		</View>
 	);
 }
 
@@ -121,11 +157,9 @@ export default function SettingsScreen() {
 	const router = useRouter();
 	const { logout } = useAccountActions();
 	const { preference, setPreference } = useDayovaTheme();
-	const { height } = useWindowDimensions();
 	const [logoutError, setLogoutError] = useState<string | null>(null);
 	const [isLoggingOut, setIsLoggingOut] = useState(false);
 	const logoutGateRef = useRef(createAsyncActionGate());
-	const contentMinHeight = Math.max(height - 268, 360);
 	const handleLogout = () => {
 		void logoutGateRef.current.run(async () => {
 			setLogoutError(null);
@@ -149,29 +183,29 @@ export default function SettingsScreen() {
 	return (
 		<Screen>
 			<ThemedStatusBar />
-			<ScreenScroll topPadding={118} bottomPadding={104} horizontalPadding={24}>
-				<View
-					style={{
-						minHeight: contentMinHeight,
-						justifyContent: "space-between",
-					}}
-				>
-					<View className="gap-5">
-						<SettingsRow
-							icon={Bell}
-							label="Mitteilungen"
-							onPress={() => router.push("/notification-settings")}
-						/>
+			<ScreenScroll topPadding={104} bottomPadding={120} horizontalPadding={24}>
+				<View className="gap-7">
+					<SettingsSection title="Lernen">
 						<SettingsRow
 							icon={Timer}
 							label="Lernzeiten"
 							onPress={() => router.push("/learning-times")}
 						/>
+						<SettingsDivider />
 						<SettingsRow
 							icon={CalendarDays}
 							label="Stundenplan"
 							onPress={() => router.push("/timetable")}
 						/>
+					</SettingsSection>
+
+					<SettingsSection title="App">
+						<SettingsRow
+							icon={Bell}
+							label="Mitteilungen"
+							onPress={() => router.push("/notification-settings")}
+						/>
+						<SettingsDivider />
 						<SettingsRow
 							icon={Palette}
 							label="Design"
@@ -182,26 +216,31 @@ export default function SettingsScreen() {
 								/>
 							}
 						/>
-					</View>
+					</SettingsSection>
 
-					<View className="gap-5">
-						<SettingsRow
-							icon={Settings}
-							label="Profil"
-							onPress={() => router.push("/profile")}
-						/>
-						<SettingsRow
-							icon={SquareLock}
-							label="Passwort ändern"
-							onPress={() => router.push("/change-password")}
-						/>
-						<SettingsRow
-							icon={Logout}
-							label="Abmelden"
-							onPress={handleLogout}
-							disabled={isLoggingOut}
-							busy={isLoggingOut}
-						/>
+					<View className="gap-3">
+						<SettingsSection title="Konto">
+							<SettingsRow
+								icon={Settings}
+								label="Profil"
+								onPress={() => router.push("/profile")}
+							/>
+							<SettingsDivider />
+							<SettingsRow
+								icon={SquareLock}
+								label="Passwort ändern"
+								onPress={() => router.push("/change-password")}
+							/>
+							<SettingsDivider />
+							<SettingsRow
+								icon={Logout}
+								label="Abmelden"
+								onPress={handleLogout}
+								disabled={isLoggingOut}
+								busy={isLoggingOut}
+								showDisclosure={false}
+							/>
+						</SettingsSection>
 						{logoutError ? <ErrorMessage>{logoutError}</ErrorMessage> : null}
 					</View>
 				</View>

--- a/src/features/settings/settings-screen.ui.test.tsx
+++ b/src/features/settings/settings-screen.ui.test.tsx
@@ -1,14 +1,15 @@
-import type { ReactNode } from "react";
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
+import type { ReactNode } from "react";
 import SettingsScreen from "../../app/(app)/settings";
 
 const mockReplace = jest.fn();
+const mockPush = jest.fn();
 const mockLogout = jest.fn<() => Promise<void>>(async () => undefined);
 const mockSetPreference = jest.fn(async () => undefined);
 
 jest.mock("expo-router", () => ({
-	useRouter: () => ({ push: jest.fn(), replace: mockReplace }),
+	useRouter: () => ({ push: mockPush, replace: mockReplace }),
 }));
 
 jest.mock("~/context/AuthContext", () => ({
@@ -52,13 +53,25 @@ jest.mock("~/components/ui/themed-status-bar", () => ({
 	ThemedStatusBar: () => null,
 }));
 
-describe("SettingsScreen logout", () => {
+describe("SettingsScreen", () => {
 	beforeEach(() => {
 		mockLogout.mockReset();
 		mockLogout.mockResolvedValue(undefined);
 		mockReplace.mockReset();
+		mockPush.mockReset();
 		mockSetPreference.mockReset();
 		mockSetPreference.mockResolvedValue(undefined);
+	});
+
+	test("groups destinations by learning, app, and account responsibility", async () => {
+		const screen = await render(<SettingsScreen />);
+
+		expect(screen.getByRole("header", { name: "Lernen" })).toBeOnTheScreen();
+		expect(screen.getByRole("header", { name: "App" })).toBeOnTheScreen();
+		expect(screen.getByRole("header", { name: "Konto" })).toBeOnTheScreen();
+
+		await fireEvent.press(screen.getByRole("button", { name: "Stundenplan" }));
+		expect(mockPush).toHaveBeenCalledWith("/timetable");
 	});
 
 	test("exposes each theme preference as an individually selectable radio", async () => {


### PR DESCRIPTION
## What changed

- groups settings into labeled `Lernen`, `App`, and `Konto` surfaces
- replaces the device-height spacer and disconnected pill stack with shared 32px surfaces, inset 24px rows, and semantic dividers
- adds quiet disclosure arrows to navigation rows while keeping sign-out visually non-navigational
- keeps the existing theme selector, logout transaction gate, and recoverable error behavior intact
- covers the new section hierarchy and destination routing in the settings UI suite

## Why

The previous screen presented every setting as an unrelated pill and used a large responsive gap to split the list. That made the hierarchy dependent on device height instead of the relationship between settings. The new composition follows Dayova’s existing grouped settings-card language and semantic radius system.

## Impact

Learners can scan the screen by responsibility and distinguish navigation from appearance controls more quickly. Existing routes, theme preferences, sign-out behavior, and accessibility semantics remain unchanged.

## Validation

- `biome check` for the changed files
- ESLint for the changed files
- `tsc --noEmit`
- settings UI suite: 4 tests passed
- rendered and inspected on the iOS 26.5 iPhone 17 simulator in dark mode; section headings, buttons, and theme radio states were verified in the accessibility tree

Light-mode and Android rendered inspection were not completed because the isolated development client became unstable when switching Metro sessions; the implementation uses the existing semantic theme tokens and generic React Native surfaces.