### PR TITLE
Keep exam creation progress moving

### DIFF
--- a/src/app/(creation)/entry/new.tsx
+++ b/src/app/(creation)/entry/new.tsx
@@ -63,7 +63,7 @@ import { SelectSheet } from "~/components/ui/select-sheet";
 import { Text } from "~/components/ui/text";
 import { Textarea } from "~/components/ui/textarea";
 import { useAuthSession } from "~/context/AuthContext";
-import { LEARNING_PLAN_CREATION_STEPS } from "~/features/learning-plans/creation-progress";
+import { getExamEntryCreationProgress } from "~/features/learning-plans/creation-progress";
 import { useLearningPlanCreationProgress } from "~/features/learning-plans/creation-progress-shell";
 import { LearningAvailabilityStep } from "~/features/learning-plans/learning-availability-step";
 import {
@@ -659,7 +659,7 @@ export default function NewEntryScreen() {
 	);
 	useLearningPlanCreationProgress({
 		active: !isHomework,
-		currentStep: LEARNING_PLAN_CREATION_STEPS.examDate,
+		currentStep: getExamEntryCreationProgress(step),
 		onBack: handleBack,
 		title: "Prüfung eintragen",
 	});

--- a/src/app/(creation)/learning-plans/[planId]/analysis.tsx
+++ b/src/app/(creation)/learning-plans/[planId]/analysis.tsx
@@ -88,7 +88,7 @@ export default function LearningPlanAnalysisScreen() {
 	};
 	useLearningPlanCreationProgress({
 		active: true,
-		currentStep: LEARNING_PLAN_CREATION_STEPS.materialUpload,
+		currentStep: LEARNING_PLAN_CREATION_STEPS.materialAnalysis,
 		onBack: goBack,
 	});
 

--- a/src/features/learning-plans/creation-progress-header.tsx
+++ b/src/features/learning-plans/creation-progress-header.tsx
@@ -2,7 +2,10 @@ import { View, type ViewProps } from "react-native";
 import { BackButton } from "~/components/ui/button";
 import { FlowProgressBar } from "~/components/ui/flow-progress-bar";
 import { Text } from "~/components/ui/text";
-import { LEARNING_PLAN_CREATION_TOTAL_STEPS } from "~/features/learning-plans/creation-progress";
+import {
+	getLearningPlanCreationProgressPercentage,
+	LEARNING_PLAN_CREATION_TOTAL_STEPS,
+} from "~/features/learning-plans/creation-progress";
 import { cn } from "~/lib/utils";
 
 export function LearningPlanCreationProgressHeader({
@@ -16,10 +19,12 @@ export function LearningPlanCreationProgressHeader({
 	onBack: () => void;
 	title?: string;
 }) {
-	const safeStep = Math.min(
-		Math.max(Math.trunc(currentStep), 1),
+	const safeProgress = Math.min(
+		Math.max(currentStep, 1),
 		LEARNING_PLAN_CREATION_TOTAL_STEPS,
 	);
+	const progressPercentage =
+		getLearningPlanCreationProgressPercentage(safeProgress);
 
 	return (
 		<View className={cn("flex-row items-center gap-4", className)} {...props}>
@@ -38,17 +43,17 @@ export function LearningPlanCreationProgressHeader({
 						// Tabular figures are a native text-rendering setting, not static layout.
 						style={{ fontVariant: ["tabular-nums"] }}
 					>
-						{safeStep} von {LEARNING_PLAN_CREATION_TOTAL_STEPS}
+						{progressPercentage} %
 					</Text>
 				</View>
 				<FlowProgressBar
-					progress={safeStep / LEARNING_PLAN_CREATION_TOTAL_STEPS}
+					progress={safeProgress / LEARNING_PLAN_CREATION_TOTAL_STEPS}
 					accessibilityRole="progressbar"
 					accessibilityValue={{
-						min: 1,
-						max: LEARNING_PLAN_CREATION_TOTAL_STEPS,
-						now: safeStep,
-						text: `Schritt ${safeStep} von ${LEARNING_PLAN_CREATION_TOTAL_STEPS}`,
+						min: 0,
+						max: 100,
+						now: progressPercentage,
+						text: `Fortschritt ${progressPercentage} Prozent`,
 					}}
 				/>
 			</View>

--- a/src/features/learning-plans/creation-progress.test.ts
+++ b/src/features/learning-plans/creation-progress.test.ts
@@ -1,35 +1,60 @@
 import { describe, expect, test } from "vitest";
 import {
 	getDiagnosticQuestionCreationStep,
+	getExamEntryCreationProgress,
+	getLearningPlanCreationProgressPercentage,
 	LEARNING_PLAN_CREATION_STEPS,
 	LEARNING_PLAN_CREATION_TOTAL_STEPS,
 } from "./creation-progress";
 
 describe("learning-plan creation progress", () => {
-	test("groups the creation flow into five stable stages", () => {
+	test("advances visibly through the opening exam questions", () => {
 		expect(LEARNING_PLAN_CREATION_STEPS).toEqual({
 			examDate: 1,
-			examType: 1,
-			examSubject: 1,
+			learningAvailability: 1.25,
+			examType: 1.5,
+			examSubject: 1.75,
 			materialUpload: 2,
-			examEvidence: 2,
+			examEvidence: 2.5,
+			materialAnalysis: 2.75,
 			scopeConfirmation: 3,
-			diagnostic: 4,
+			diagnostic: 3.25,
 			planGeneration: 5,
 		});
 		expect(LEARNING_PLAN_CREATION_TOTAL_STEPS).toBe(5);
+
+		const openingProgress = [
+			LEARNING_PLAN_CREATION_STEPS.examDate,
+			LEARNING_PLAN_CREATION_STEPS.learningAvailability,
+			LEARNING_PLAN_CREATION_STEPS.examType,
+			LEARNING_PLAN_CREATION_STEPS.examSubject,
+		];
+		expect(
+			openingProgress.every(
+				(progress, index) =>
+					index === 0 || progress > (openingProgress[index - 1] ?? 0),
+			),
+		).toBe(true);
 	});
 
-	test("keeps all diagnostic questions inside one visible stage", () => {
+	test("turns intermediate progress into a changing percentage", () => {
+		expect(
+			(["basics", "learningAvailability", "examType", "examDetails"] as const)
+				.map(getExamEntryCreationProgress)
+				.map(getLearningPlanCreationProgressPercentage),
+		).toEqual([20, 25, 30, 35]);
+	});
+
+	test("advances through each diagnostic answer", () => {
 		expect(
 			Array.from({ length: 5 }, (_, index) =>
 				getDiagnosticQuestionCreationStep(index),
 			),
-		).toEqual([4, 4, 4, 4, 4]);
+		).toEqual([3.25, 3.625, 4, 4.375, 4.75]);
 	});
 
-	test("does not let malformed question indexes change the stage", () => {
-		expect(getDiagnosticQuestionCreationStep(-1)).toBe(4);
-		expect(getDiagnosticQuestionCreationStep(99)).toBe(4);
+	test("clamps malformed diagnostic question indexes", () => {
+		expect(getDiagnosticQuestionCreationStep(-1)).toBe(3.25);
+		expect(getDiagnosticQuestionCreationStep(99)).toBe(4.75);
 	});
 });

--- a/src/features/learning-plans/creation-progress.ts
+++ b/src/features/learning-plans/creation-progress.ts
@@ -1,16 +1,59 @@
+const DIAGNOSTIC_QUESTION_COUNT = 5;
+const DIAGNOSTIC_PROGRESS_END = 4.75;
+
 export const LEARNING_PLAN_CREATION_STEPS = {
 	examDate: 1,
-	examType: 1,
-	examSubject: 1,
+	learningAvailability: 1.25,
+	examType: 1.5,
+	examSubject: 1.75,
 	materialUpload: 2,
-	examEvidence: 2,
+	examEvidence: 2.5,
+	materialAnalysis: 2.75,
 	scopeConfirmation: 3,
-	diagnostic: 4,
+	diagnostic: 3.25,
 	planGeneration: 5,
 } as const;
 
 export const LEARNING_PLAN_CREATION_TOTAL_STEPS =
 	LEARNING_PLAN_CREATION_STEPS.planGeneration;
 
-export const getDiagnosticQuestionCreationStep = (_questionIndex: number) =>
-	LEARNING_PLAN_CREATION_STEPS.diagnostic;
+export const getExamEntryCreationProgress = (
+	step:
+		| "basics"
+		| "planning"
+		| "learningAvailability"
+		| "examType"
+		| "examDetails",
+) => {
+	switch (step) {
+		case "learningAvailability":
+			return LEARNING_PLAN_CREATION_STEPS.learningAvailability;
+		case "examType":
+			return LEARNING_PLAN_CREATION_STEPS.examType;
+		case "examDetails":
+			return LEARNING_PLAN_CREATION_STEPS.examSubject;
+		default:
+			return LEARNING_PLAN_CREATION_STEPS.examDate;
+	}
+};
+
+export const getDiagnosticQuestionCreationStep = (questionIndex: number) => {
+	const safeIndex = Math.min(
+		Math.max(Math.trunc(questionIndex), 0),
+		DIAGNOSTIC_QUESTION_COUNT - 1,
+	);
+	const progressPerQuestion =
+		(DIAGNOSTIC_PROGRESS_END - LEARNING_PLAN_CREATION_STEPS.diagnostic) /
+		(DIAGNOSTIC_QUESTION_COUNT - 1);
+	return (
+		LEARNING_PLAN_CREATION_STEPS.diagnostic + safeIndex * progressPerQuestion
+	);
+};
+
+export const getLearningPlanCreationProgressPercentage = (progress: number) => {
+	const safeProgress = Math.min(
+		Math.max(progress, LEARNING_PLAN_CREATION_STEPS.examDate),
+		LEARNING_PLAN_CREATION_TOTAL_STEPS,
+	);
+	return Math.round((safeProgress / LEARNING_PLAN_CREATION_TOTAL_STEPS) * 100);
+};


### PR DESCRIPTION
## What changed

- replaces the frozen `1 von 5` stage counter with continuous percentage progress
- advances the header through exam date, learning-time availability, exam type, and subject
- advances again through teacher evidence, material analysis, and every diagnostic answer
- keeps the five-phase mental model without presenting the learner with an eleven-step questionnaire
- exposes the percentage as an accessible progress value

## Root cause

The shortened flow intentionally mapped the first four screens to the same integer stage. The shared header truncated that value, so both its label and bar remained unchanged while the learner answered questions.

## Validation

- regression test reproduced the frozen opening progress before the fix
- 87 Vitest files / 513 tests passed on the latest `production-app-release`
- TypeScript passed
- Biome + ESLint passed
- formatting and `git diff --check` passed
- iOS simulator verified the transition from 25% on availability to 30% on exam type