### PR TITLE
Always show exam learning-time validation

### DIFF
--- a/src/app/(creation)/entry/new.tsx
+++ b/src/app/(creation)/entry/new.tsx
@@ -68,7 +68,7 @@ import { useLearningPlanCreationProgress } from "~/features/learning-plans/creat
 import { LearningAvailabilityStep } from "~/features/learning-plans/learning-availability-step";
 import {
 	calculateAvailableStudyMinutes,
-	shouldRequestLearningTimeBeforeExam,
+	shouldShowLearningTimeValidation,
 } from "~/features/learning-plans/plan-workload";
 import { getErrorMessage } from "~/features/learning-plans/utils";
 import { useValidationAnalytics } from "~/lib/use-validation-analytics";
@@ -594,11 +594,9 @@ export default function NewEntryScreen() {
 	const continueFromExamDate = () => {
 		if (learningTimes === undefined && isFutureExam) return;
 		if (
-			learningTimes &&
-			shouldRequestLearningTimeBeforeExam({
+			shouldShowLearningTimeValidation({
 				fromDateKey: todayDayKey,
 				examDateKey: examDayKey,
-				learningTimes,
 			})
 		) {
 			setDidShowLearningAvailability(true);

--- a/src/features/learning-plans/plan-workload.test.ts
+++ b/src/features/learning-plans/plan-workload.test.ts
@@ -3,6 +3,7 @@ import {
 	calculateAvailableStudyMinutes,
 	getAutomaticLearningPreparation,
 	shouldRequestLearningTimeBeforeExam,
+	shouldShowLearningTimeValidation,
 	suggestTotalStudyMinutes,
 } from "./plan-workload";
 
@@ -74,6 +75,21 @@ describe("total study workload suggestion", () => {
 				fromDateKey: "2026-06-01",
 				examDateKey: "2026-06-01",
 				learningTimes: [],
+			}),
+		).toBe(false);
+	});
+
+	test("shows the learning-time validation for every future exam", () => {
+		expect(
+			shouldShowLearningTimeValidation({
+				fromDateKey: "2026-06-01",
+				examDateKey: "2026-06-05",
+			}),
+		).toBe(true);
+		expect(
+			shouldShowLearningTimeValidation({
+				fromDateKey: "2026-06-01",
+				examDateKey: "2026-06-01",
 			}),
 		).toBe(false);
 	});

--- a/src/features/learning-plans/plan-workload.ts
+++ b/src/features/learning-plans/plan-workload.ts
@@ -69,6 +69,14 @@ export const shouldRequestLearningTimeBeforeExam = ({
 		learningTimes,
 	}) < 10;
 
+export const shouldShowLearningTimeValidation = ({
+	fromDateKey,
+	examDateKey,
+}: {
+	fromDateKey: string;
+	examDateKey: string;
+}) => examDateKey > fromDateKey;
+
 export const getAutomaticLearningPreparation = ({
 	examTypeLabel,
 	examDurationMinutes,


### PR DESCRIPTION
## What changed

- routes every future exam through the learning-time validation immediately after its date
- shows `Lernzeit gefunden` when existing availability can hold the plan
- keeps `Lernzeit eintragen` as the action when no usable window exists
- continues to skip the scheduling check for same-day exams, where no pre-exam window can be added

## Root cause

The flow only opened the validation screen when availability was missing. Accounts with an existing or backfilled learning window silently jumped from the date to exam type, so successful validation was never visible.

## Validation

- regression test reproduced the silent skip before the fix
- 87 Vitest files / 514 tests passed
- TypeScript passed
- Biome + ESLint passed
- formatting and `git diff --check` passed
- iOS simulator verified the normal date → `Lernzeit gefunden` path for a future exam with existing availability