### PR TITLE
Use English name for analysis development route

### DIFF
--- a/src/app/analyse/_layout.tsx
+++ b/src/app/analyse/_layout.tsx
@@ -38,7 +38,7 @@ export default function AnalyticsLayout() {
 				options={{ title: "Dein nächster Schritt" }}
 			/>
 			<Stack.Screen
-				name="entwicklung"
+				name="development"
 				options={{ title: "Deine Entwicklung" }}
 			/>
 		</Stack>

--- a/src/app/analyse/development.tsx
+++ b/src/app/analyse/development.tsx
@@ -1,0 +1,1 @@
+export { AnalyticsHistoryScreen as default } from "~/features/analytics/analytics-screen";

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -7,7 +7,7 @@ export const ROUTES = {
 	analyticsKnowledge: "/analyse/wissensstand",
 	analyticsProblem: "/analyse/lernhuerde",
 	analyticsNextStep: "/analyse/naechster-schritt",
-	analyticsHistory: "/analyse/entwicklung",
+	analyticsHistory: "/analyse/development",
 	createExam: "/entry/new?type=exam",
 	createHomework: "/entry/new?type=homework",
 	createLearningPlan: "/learning-plans/new",


### PR DESCRIPTION
## What changed

- Adds the missing analysis development route file using the repository's English naming convention.
- Changes the Expo Router segment from `entwicklung` to `development`.
- Updates `ROUTES.analyticsHistory` to `/analyse/development`.

## Why

The repository uses English implementation names. The merged analysis change also left the German route file untracked locally and absent from the production commit, while its route references were already present. This follow-up fixes the missing screen and aligns the code-facing name with the repository convention.

## Validation

- TypeScript check passed
- Analyse UI suite passed: 6 tests
- Biome passed for all changed files
- Confirmed no remaining `entwicklung` route references