### PR TITLE
Show topic-level knowledge evidence in analytics

### DIFF
--- a/convex/learningContentPlan.ts
+++ b/convex/learningContentPlan.ts
@@ -2,12 +2,18 @@ export type LearningContentPhase = "theory" | "practice" | "rehearsal";
 
 export type LearningTopicPriority = "high" | "medium" | "low";
 
+export type LearningEvidenceDimension =
+	| "understanding"
+	| "problemSolving"
+	| "independent";
+
 export type LearningTopic = {
 	id: string;
 	title: string;
 	learningGoal: string;
 	keywords: string[];
 	priority: LearningTopicPriority;
+	requiredEvidenceDimensions?: LearningEvidenceDimension[];
 };
 
 export type LearningQuestionAngle =

--- a/convex/learningPlanAi.ts
+++ b/convex/learningPlanAi.ts
@@ -270,6 +270,13 @@ const questionsSchema = z
 					8,
 				),
 				priority: z.enum(["high", "medium", "low"]),
+				requiredEvidenceDimensions: z
+					.array(z.enum(["understanding", "problemSolving", "independent"]))
+					.min(1)
+					.max(3)
+					.describe(
+						"Evidence dimensions actually required by the exam material for this topic: understanding for explaining concepts, problemSolving for selecting and applying a method, independent for completing exam-like tasks without hints.",
+					),
 			}),
 			MIN_TOPIC_MAP_COUNT,
 			MAX_LEARNING_TOPIC_COUNT,
@@ -521,6 +528,9 @@ type LearningPlanAiContext = {
 			learningGoal: string;
 			keywords: string[];
 			priority: "high" | "medium" | "low";
+			requiredEvidenceDimensions?: Array<
+				"understanding" | "problemSolving" | "independent"
+			>;
 		}>;
 		topicReadiness?: Array<{
 			topicId: string;
@@ -2806,6 +2816,7 @@ Formuliere alle sichtbaren Texte in korrektem Deutsch mit Umlauten und Sonderzei
 						normalizeAiGeneratedGermanText(keyword),
 					),
 					priority: topic.priority,
+					requiredEvidenceDimensions: topic.requiredEvidenceDimensions,
 				})),
 				sourceSummary: normalizeAiGeneratedGermanText(
 					result.output.sourceSummary,

--- a/convex/learningTopicMap.test.ts
+++ b/convex/learningTopicMap.test.ts
@@ -1,8 +1,24 @@
 import { expect, test } from "vitest";
 import {
 	focusLearningTopics,
+	normalizeLearningTopics,
 	selectSessionLearningTopics,
 } from "./learningTopicMap";
+
+test("preserves only the evidence dimensions required by the exam topic", () => {
+	const [topic] = normalizeLearningTopics([
+		{
+			id: "begriffe",
+			title: "Fachbegriffe erklären",
+			learningGoal: "Die relevanten Fachbegriffe präzise erklären.",
+			keywords: ["Fachbegriffe"],
+			priority: "high",
+			requiredEvidenceDimensions: ["understanding", "understanding"],
+		},
+	]);
+
+	expect(topic?.requiredEvidenceDimensions).toEqual(["understanding"]);
+});
 
 test("focuses content on gaps instead of replaying diagnosed strengths", () => {
 	const focused = focusLearningTopics({

--- a/convex/learningTopicMap.ts
+++ b/convex/learningTopicMap.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { normalizeGeneratedGermanText } from "./generatedGermanText";
 import type {
+	LearningEvidenceDimension,
 	LearningTopic,
 	LearningTopicPriority,
 } from "./learningContentPlan";
@@ -14,13 +15,28 @@ export const learningTopicPriorityValidator = v.union(
 	v.literal("low"),
 );
 
+export const learningEvidenceDimensionValidator = v.union(
+	v.literal("understanding"),
+	v.literal("problemSolving"),
+	v.literal("independent"),
+);
+
 export const learningTopicValidator = v.object({
 	id: v.string(),
 	title: v.string(),
 	learningGoal: v.string(),
 	keywords: v.array(v.string()),
 	priority: learningTopicPriorityValidator,
+	requiredEvidenceDimensions: v.optional(
+		v.array(learningEvidenceDimensionValidator),
+	),
 });
+
+const ALL_EVIDENCE_DIMENSIONS: LearningEvidenceDimension[] = [
+	"understanding",
+	"problemSolving",
+	"independent",
+];
 
 const normalizeTopicId = (value: string, index: number) => {
 	const normalized = value
@@ -41,6 +57,7 @@ export const normalizeLearningTopics = (
 		learningGoal: string;
 		keywords: string[];
 		priority: LearningTopicPriority;
+		requiredEvidenceDimensions?: LearningEvidenceDimension[];
 	}>,
 ): LearningTopic[] => {
 	const usedIds = new Set<string>();
@@ -55,6 +72,10 @@ export const normalizeLearningTopics = (
 		}
 		usedIds.add(id);
 
+		const requiredEvidenceDimensions = ALL_EVIDENCE_DIMENSIONS.filter(
+			(dimension) => topic.requiredEvidenceDimensions?.includes(dimension),
+		);
+
 		return {
 			id,
 			title,
@@ -64,6 +85,11 @@ export const normalizeLearningTopics = (
 				.filter(Boolean)
 				.slice(0, MAX_LEARNING_TOPIC_KEYWORD_COUNT),
 			priority: topic.priority,
+			...(requiredEvidenceDimensions.length > 0
+				? {
+						requiredEvidenceDimensions,
+					}
+				: {}),
 		};
 	});
 };

--- a/convex/userAnalytics.test.ts
+++ b/convex/userAnalytics.test.ts
@@ -239,7 +239,8 @@ test("returns a selected exam analysis grounded in topics, answers, and schedule
 		},
 		readiness: {
 			secure: 0,
-			developing: 2,
+			developing: 1,
+			uncertain: 1,
 			unknown: 0,
 		},
 		abilities: [
@@ -284,7 +285,7 @@ test("returns a selected exam analysis grounded in topics, answers, and schedule
 	expect(analysis.topics).toEqual([
 		expect.objectContaining({
 			id: "steigung",
-			status: "developing",
+			status: "uncertain",
 			priority: "high",
 			summary:
 				"Du nennst die Änderung von y, aber die Änderung von x fehlt noch.",
@@ -293,7 +294,7 @@ test("returns a selected exam analysis grounded in topics, answers, and schedule
 				{
 					kind: "understanding",
 					required: true,
-					status: "developing",
+					status: "uncertain",
 					evidenceCount: 2,
 				},
 				{

--- a/convex/userAnalytics.test.ts
+++ b/convex/userAnalytics.test.ts
@@ -203,6 +203,8 @@ test("returns a selected exam analysis grounded in topics, answers, and schedule
 			.first();
 		if (!recoveryItem) throw new Error("Expected seeded content item");
 		await ctx.db.patch("learningSessionContentItems", recoveryItem._id, {
+			phase: "practice",
+			questionAngle: "recall",
 			topicId: "steigung",
 		});
 		const sessionAnalysis = await ctx.db
@@ -244,6 +246,7 @@ test("returns a selected exam analysis grounded in topics, answers, and schedule
 			{
 				statement: "Du erkennst lineare Zusammenhänge.",
 				evidenceCount: 1,
+				topicId: "steigung",
 			},
 		],
 		primaryProblem: {
@@ -283,6 +286,43 @@ test("returns a selected exam analysis grounded in topics, answers, and schedule
 			id: "steigung",
 			status: "developing",
 			priority: "high",
+			summary:
+				"Du nennst die Änderung von y, aber die Änderung von x fehlt noch.",
+			evidenceCount: 2,
+			dimensions: [
+				{
+					kind: "understanding",
+					required: true,
+					status: "developing",
+					evidenceCount: 2,
+				},
+				{
+					kind: "problemSolving",
+					required: true,
+					status: "unknown",
+					evidenceCount: 0,
+				},
+				{
+					kind: "independent",
+					required: true,
+					status: "unknown",
+					evidenceCount: 0,
+				},
+			],
+			strengths: [
+				{
+					statement: "Du erkennst lineare Zusammenhänge.",
+					evidenceCount: 1,
+				},
+			],
+			weaknesses: [
+				{
+					statement:
+						"Du nennst die Änderung von y, aber die Änderung von x fehlt noch.",
+					evidenceCount: 1,
+				},
+			],
+			controlCheckReason: null,
 		}),
 		expect.objectContaining({
 			id: "achsenschnitt",
@@ -296,6 +336,87 @@ test("returns a selected exam analysis grounded in topics, answers, and schedule
 		}),
 	).resolves.toMatchObject({
 		selectedPlan: { id: learningPlanId },
+	});
+});
+
+test("requests a control check when new evidence contradicts repeated success", async () => {
+	const { t, learningPlanId, firstSessionId, openSessionId } =
+		await seedAnalyticsData();
+	await t.run(async (ctx) => {
+		await ctx.db.patch("learningPlans", learningPlanId, {
+			topicMap: [
+				{
+					id: "steigung",
+					title: "Steigung erklären",
+					learningGoal: "Du kannst die Steigung vollständig erklären.",
+					keywords: ["Steigung", "Änderung"],
+					priority: "high",
+					requiredEvidenceDimensions: [
+						"understanding",
+						"problemSolving",
+						"independent",
+					],
+				},
+			],
+			topicReadiness: [{ topicId: "steigung", status: "developing" }],
+		});
+		const existingItem = await ctx.db
+			.query("learningSessionContentItems")
+			.withIndex("by_ownerTokenIdentifier", (q) =>
+				q.eq("ownerTokenIdentifier", identity.tokenIdentifier),
+			)
+			.first();
+		if (!existingItem) throw new Error("Expected seeded content item");
+		await ctx.db.patch("learningSessionContentItems", existingItem._id, {
+			topicId: "steigung",
+		});
+
+		for (const [index, sessionId] of [
+			firstSessionId,
+			openSessionId,
+		].entries()) {
+			const itemId = await ctx.db.insert("learningSessionContentItems", {
+				ownerTokenIdentifier: identity.tokenIdentifier,
+				learningPlanId,
+				sessionId,
+				phase: "practice",
+				kind: "written",
+				title: `Transfer ${index + 1}`,
+				prompt: "Bestimme die Steigung in einer neuen Aufgabe.",
+				explanation: "Die Steigung wird aus zwei Punkten bestimmt.",
+				idealAnswer: "Die Steigung ist 2.",
+				evaluationKeywords: ["2"],
+				topicId: "steigung",
+				questionAngle: "examTransfer",
+				sortOrder: index,
+				createdAt: Date.UTC(2026, 6, 28, 10 + index),
+				updatedAt: Date.UTC(2026, 6, 28, 10 + index),
+			});
+			await ctx.db.insert("learningSessionAnswerAttempts", {
+				ownerTokenIdentifier: identity.tokenIdentifier,
+				learningPlanId,
+				sessionId,
+				itemId,
+				answerText: "Die Steigung ist 2.",
+				rating: "correct",
+				feedback: "Richtig.",
+				perfectAnswer: "Die Steigung ist 2.",
+				createdAt: Date.UTC(2026, 6, 28, 10 + index, 30),
+			});
+		}
+	});
+
+	const analysis = await t.query(api.userAnalytics.getExamAnalysis, {
+		learningPlanId,
+		todayKey: "2026-07-28",
+	});
+
+	expect(analysis.topics[0]).toMatchObject({
+		id: "steigung",
+		status: "developing",
+		summary: "Kontrollbeleg nötig",
+		controlCheckReason:
+			"Eine neue Antwort widerspricht früheren Belegen zum Verständnis.",
 	});
 });
 

--- a/convex/userAnalytics.ts
+++ b/convex/userAnalytics.ts
@@ -77,6 +77,7 @@ const examPlanOptionValidator = v.object({
 const examTopicStatusValidator = v.union(
 	v.literal("secure"),
 	v.literal("developing"),
+	v.literal("uncertain"),
 	v.literal("unknown"),
 );
 
@@ -135,6 +136,7 @@ const examAnalysisValidator = v.object({
 	readiness: v.object({
 		secure: v.number(),
 		developing: v.number(),
+		uncertain: v.number(),
 		unknown: v.number(),
 	}),
 	abilities: v.array(
@@ -393,7 +395,8 @@ const getExactIssue = (
 	return null;
 };
 
-type TopicEvidenceStatus = "secure" | "developing" | "unknown";
+type TopicEvidenceStatus = "secure" | "developing" | "uncertain" | "unknown";
+type InitialTopicEvidenceStatus = Exclude<TopicEvidenceStatus, "uncertain">;
 
 const evidenceDimensions: LearningEvidenceDimension[] = [
 	"understanding",
@@ -441,7 +444,7 @@ const deriveDimensionEvidence = ({
 	topicAttempts,
 }: {
 	dimension: LearningEvidenceDimension;
-	initialStatus: TopicEvidenceStatus;
+	initialStatus: InitialTopicEvidenceStatus;
 	itemById: Map<
 		Id<"learningSessionContentItems">,
 		Doc<"learningSessionContentItems">
@@ -471,18 +474,23 @@ const deriveDimensionEvidence = ({
 			.map((attempt) => attempt.sessionId),
 	).size;
 	const evidenceCount = relevantAttempts.length + initialEvidenceCount;
+	const needsControlCheck =
+		required &&
+		Boolean(latestAttempt && latestAttempt.rating !== "correct") &&
+		priorCorrectOccasions + initialEvidenceCount >= 2;
+	const latestShowsDifficulty = Boolean(
+		latestAttempt && latestAttempt.rating !== "correct",
+	);
 	const status: TopicEvidenceStatus = !required
 		? "unknown"
 		: latestAttempt?.rating === "correct" &&
 				correctOccasions + initialEvidenceCount >= 2
 			? "secure"
-			: evidenceCount > 0 || (dimension === "understanding" && reviewed)
-				? "developing"
-				: "unknown";
-	const needsControlCheck =
-		required &&
-		Boolean(latestAttempt && latestAttempt.rating !== "correct") &&
-		priorCorrectOccasions + initialEvidenceCount >= 2;
+			: latestShowsDifficulty && !needsControlCheck
+				? "uncertain"
+				: evidenceCount > 0 || (dimension === "understanding" && reviewed)
+					? "developing"
+					: "unknown";
 
 	return {
 		kind: dimension,
@@ -494,6 +502,12 @@ const deriveDimensionEvidence = ({
 };
 
 const topicPriorityRank = { high: 0, medium: 1, low: 2 } as const;
+const topicStatusRiskRank: Record<TopicEvidenceStatus, number> = {
+	uncertain: 0,
+	developing: 1,
+	unknown: 2,
+	secure: 3,
+};
 
 export const getOverview = query({
 	args: {
@@ -835,7 +849,7 @@ export const getExamAnalysis = query({
 				preliminary: true,
 				plans: planOptions,
 				selectedPlan: null,
-				readiness: { secure: 0, developing: 0, unknown: 0 },
+				readiness: { secure: 0, developing: 0, uncertain: 0, unknown: 0 },
 				abilities: [],
 				improvements: [],
 				latestKnowledgeChange: null,
@@ -955,7 +969,7 @@ export const getExamAnalysis = query({
 				return item?.topicId === topic.id && item.kind !== "learnCard";
 			});
 			const initialStatus = (initialReadiness.get(topic.id) ??
-				"unknown") as TopicEvidenceStatus;
+				"unknown") as InitialTopicEvidenceStatus;
 			const requiredDimensions = new Set(
 				topic.requiredEvidenceDimensions?.length
 					? topic.requiredEvidenceDimensions
@@ -980,7 +994,11 @@ export const getExamAnalysis = query({
 				? "secure"
 				: requiredEvidence.every((dimension) => dimension.status === "unknown")
 					? "unknown"
-					: "developing";
+					: requiredEvidence.some(
+								(dimension) => dimension.status === "uncertain",
+							)
+						? "uncertain"
+						: "developing";
 			const controlDimension = dimensions.find(
 				(dimension) => dimension.needsControlCheck,
 			);
@@ -1167,10 +1185,13 @@ export const getExamAnalysis = query({
 			({ priorityRank: _priorityRank, observedAt: _observedAt, ...problem }) =>
 				problem,
 		);
-		const dimensionGapCopy: Record<LearningEvidenceDimension, string> = {
-			understanding: "Verständnis noch nicht sicher belegt.",
-			problemSolving: "Problemlösen noch nicht sicher belegt.",
-			independent: "Selbstständiges Lösen noch nicht sicher belegt.",
+		const observedDifficultyCopy: Record<LearningEvidenceDimension, string> = {
+			understanding:
+				"Bei einer Verständnisfrage war deine letzte Antwort noch nicht vollständig richtig.",
+			problemSolving:
+				"Beim Problemlösen war deine letzte Antwort noch nicht vollständig richtig.",
+			independent:
+				"Beim selbstständigen Lösen war deine letzte Antwort noch nicht vollständig richtig.",
 		};
 		const topics = topicEvidenceProfiles
 			.map((topic) => {
@@ -1224,10 +1245,10 @@ export const getExamAnalysis = query({
 								statement: problem.observation,
 								evidenceCount: problem.evidenceCount,
 							}))
-						: topic.status === "developing" && firstOpenDimension
+						: topic.status === "uncertain" && firstOpenDimension
 							? [
 									{
-										statement: dimensionGapCopy[firstOpenDimension.kind],
+										statement: observedDifficultyCopy[firstOpenDimension.kind],
 										evidenceCount: firstOpenDimension.evidenceCount,
 									},
 								]
@@ -1237,7 +1258,9 @@ export const getExamAnalysis = query({
 					: (weaknesses[0]?.statement ??
 						(topic.status === "secure"
 							? "Alle erforderlichen Wissensbelege vorhanden."
-							: "Noch keine überprüften Antworten."));
+							: topic.status === "developing"
+								? "Erste Belege vorhanden, aber noch nicht stabil."
+								: "Noch keine überprüften Antworten."));
 
 				return {
 					id: topic.id,
@@ -1254,29 +1277,25 @@ export const getExamAnalysis = query({
 					strengths,
 					weaknesses,
 					controlCheckReason: topic.controlCheckReason,
-					hasObservedProblem: topicProblems.length > 0,
 				};
 			})
 			.sort((left, right) => {
 				const leftRisk =
-					(left.status === "secure" ? 100 : 0) +
 					topicPriorityRank[left.priority] * 10 +
-					(left.hasObservedProblem ? 0 : left.status === "unknown" ? 1 : 2);
+					topicStatusRiskRank[left.status];
 				const rightRisk =
-					(right.status === "secure" ? 100 : 0) +
 					topicPriorityRank[right.priority] * 10 +
-					(right.hasObservedProblem ? 0 : right.status === "unknown" ? 1 : 2);
+					topicStatusRiskRank[right.status];
 				return (
 					leftRisk - rightRisk || left.title.localeCompare(right.title, "de")
 				);
-			})
-			.map(({ hasObservedProblem: _hasObservedProblem, ...topic }) => topic);
+			});
 		const readiness = topics.reduce(
 			(counts, topic) => {
 				counts[topic.status] += 1;
 				return counts;
 			},
-			{ secure: 0, developing: 0, unknown: 0 },
+			{ secure: 0, developing: 0, uncertain: 0, unknown: 0 },
 		);
 		const primaryProblem = publicProblems[0] ?? null;
 		const secondaryProblems = publicProblems.slice(1, 3);

--- a/convex/userAnalytics.ts
+++ b/convex/userAnalytics.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
 import { query } from "./_generated/server";
 import { throwUserFacingError } from "./errors";
+import type { LearningEvidenceDimension } from "./learningContentPlan";
 
 const analyticsPeriodValidator = v.union(
 	v.literal("week"),
@@ -79,6 +80,24 @@ const examTopicStatusValidator = v.union(
 	v.literal("unknown"),
 );
 
+const examEvidenceDimensionValidator = v.union(
+	v.literal("understanding"),
+	v.literal("problemSolving"),
+	v.literal("independent"),
+);
+
+const topicEvidenceDimensionValidator = v.object({
+	kind: examEvidenceDimensionValidator,
+	required: v.boolean(),
+	status: examTopicStatusValidator,
+	evidenceCount: v.number(),
+});
+
+const topicEvidenceStatementValidator = v.object({
+	statement: v.string(),
+	evidenceCount: v.number(),
+});
+
 const examDiagnosisTypeValidator = v.union(
 	v.literal("knowledgeGap"),
 	v.literal("misconception"),
@@ -147,6 +166,12 @@ const examAnalysisValidator = v.object({
 				v.literal("low"),
 			),
 			status: examTopicStatusValidator,
+			summary: v.string(),
+			evidenceCount: v.number(),
+			dimensions: v.array(topicEvidenceDimensionValidator),
+			strengths: v.array(topicEvidenceStatementValidator),
+			weaknesses: v.array(topicEvidenceStatementValidator),
+			controlCheckReason: v.union(v.string(), v.null()),
 		}),
 	),
 	recommendation: v.union(
@@ -366,6 +391,106 @@ const getExactIssue = (
 		return feedback;
 	}
 	return null;
+};
+
+type TopicEvidenceStatus = "secure" | "developing" | "unknown";
+
+const evidenceDimensions: LearningEvidenceDimension[] = [
+	"understanding",
+	"problemSolving",
+	"independent",
+];
+
+const evidenceDimensionRank: Record<LearningEvidenceDimension, number> = {
+	understanding: 0,
+	problemSolving: 1,
+	independent: 2,
+};
+
+const getItemEvidenceDimension = (
+	item: Doc<"learningSessionContentItems">,
+): LearningEvidenceDimension => {
+	if (item.phase === "rehearsal" || item.questionAngle === "examTransfer") {
+		return "independent";
+	}
+	if (["recall", "recognize"].includes(item.questionAngle ?? "")) {
+		return "understanding";
+	}
+	if (
+		["apply", "findError", "compare"].includes(item.questionAngle ?? "") ||
+		item.phase === "practice"
+	) {
+		return "problemSolving";
+	}
+	return "understanding";
+};
+
+const attemptSupportsDimension = (
+	item: Doc<"learningSessionContentItems">,
+	dimension: LearningEvidenceDimension,
+) =>
+	evidenceDimensionRank[getItemEvidenceDimension(item)] >=
+	evidenceDimensionRank[dimension];
+
+const deriveDimensionEvidence = ({
+	dimension,
+	initialStatus,
+	itemById,
+	required,
+	reviewed,
+	topicAttempts,
+}: {
+	dimension: LearningEvidenceDimension;
+	initialStatus: TopicEvidenceStatus;
+	itemById: Map<
+		Id<"learningSessionContentItems">,
+		Doc<"learningSessionContentItems">
+	>;
+	required: boolean;
+	reviewed: boolean;
+	topicAttempts: Doc<"learningSessionAnswerAttempts">[];
+}) => {
+	const relevantAttempts = topicAttempts
+		.filter((attempt) => {
+			const item = itemById.get(attempt.itemId);
+			return Boolean(item && attemptSupportsDimension(item, dimension));
+		})
+		.sort((left, right) => right.createdAt - left.createdAt);
+	const initialEvidenceCount =
+		dimension === "understanding" && initialStatus !== "unknown" ? 1 : 0;
+	const correctOccasions = new Set(
+		relevantAttempts
+			.filter((attempt) => attempt.rating === "correct")
+			.map((attempt) => attempt.sessionId),
+	).size;
+	const latestAttempt = relevantAttempts[0];
+	const priorCorrectOccasions = new Set(
+		relevantAttempts
+			.slice(1)
+			.filter((attempt) => attempt.rating === "correct")
+			.map((attempt) => attempt.sessionId),
+	).size;
+	const evidenceCount = relevantAttempts.length + initialEvidenceCount;
+	const status: TopicEvidenceStatus = !required
+		? "unknown"
+		: latestAttempt?.rating === "correct" &&
+				correctOccasions + initialEvidenceCount >= 2
+			? "secure"
+			: evidenceCount > 0 || (dimension === "understanding" && reviewed)
+				? "developing"
+				: "unknown";
+	const needsControlCheck =
+		required &&
+		Boolean(latestAttempt && latestAttempt.rating !== "correct") &&
+		priorCorrectOccasions + initialEvidenceCount >= 2;
+
+	return {
+		kind: dimension,
+		required,
+		status,
+		evidenceCount,
+		needsControlCheck,
+	};
 };
 
 const topicPriorityRank = { high: 0, medium: 1, low: 2 } as const;
@@ -824,59 +949,58 @@ export const getExamAnalysis = query({
 				)
 				.flatMap((item) => (item.topicId ? [item.topicId] : [])),
 		);
-		const topics = sourceTopics.map((topic) => {
+		const topicEvidenceProfiles = sourceTopics.map((topic) => {
 			const topicAttempts = latestAttempts.filter((attempt) => {
 				const item = itemById.get(attempt.itemId);
 				return item?.topicId === topic.id && item.kind !== "learnCard";
 			});
-			const initialStatus = initialReadiness.get(topic.id) ?? "unknown";
-			let status: "secure" | "developing" | "unknown" =
-				initialStatus === "unknown" ? "unknown" : "developing";
-			if (topicAttempts.length > 0) {
-				const hasApplicationEvidence = topicAttempts.some((attempt) => {
-					const item = itemById.get(attempt.itemId);
-					return (
-						attempt.rating === "correct" &&
-						(item?.phase === "rehearsal" ||
-							["apply", "findError", "compare", "examTransfer"].includes(
-								item?.questionAngle ?? "",
-							))
-					);
-				});
-				const correctOccasions = new Set(
-					topicAttempts
-						.filter((attempt) => attempt.rating === "correct")
-						.map((attempt) => attempt.sessionId),
-				).size;
-				const latestAttempt = topicAttempts
-					.slice()
-					.sort((left, right) => right.createdAt - left.createdAt)[0];
-				const evidenceOccasions =
-					correctOccasions + (initialStatus === "secure" ? 1 : 0);
-				status =
-					latestAttempt?.rating === "correct" &&
-					evidenceOccasions >= 2 &&
-					hasApplicationEvidence
-						? "secure"
-						: "developing";
-			} else if (reviewedTopicIds.has(topic.id)) {
-				status = "developing";
-			}
+			const initialStatus = (initialReadiness.get(topic.id) ??
+				"unknown") as TopicEvidenceStatus;
+			const requiredDimensions = new Set(
+				topic.requiredEvidenceDimensions?.length
+					? topic.requiredEvidenceDimensions
+					: evidenceDimensions,
+			);
+			const dimensions = evidenceDimensions.map((dimension) =>
+				deriveDimensionEvidence({
+					dimension,
+					initialStatus,
+					itemById,
+					required: requiredDimensions.has(dimension),
+					reviewed: reviewedTopicIds.has(topic.id),
+					topicAttempts,
+				}),
+			);
+			const requiredEvidence = dimensions.filter(
+				(dimension) => dimension.required,
+			);
+			const status: TopicEvidenceStatus = requiredEvidence.every(
+				(dimension) => dimension.status === "secure",
+			)
+				? "secure"
+				: requiredEvidence.every((dimension) => dimension.status === "unknown")
+					? "unknown"
+					: "developing";
+			const controlDimension = dimensions.find(
+				(dimension) => dimension.needsControlCheck,
+			);
+			const controlCheckReason = controlDimension
+				? controlDimension.kind === "understanding"
+					? "Eine neue Antwort widerspricht früheren Belegen zum Verständnis."
+					: controlDimension.kind === "problemSolving"
+						? "Ein neuer Fehler widerspricht früheren Belegen beim Problemlösen."
+						: "Eine neue Prüfungsaufgabe widerspricht früheren sicheren Lösungen."
+				: null;
 			return {
-				id: topic.id,
-				title: topic.title,
-				learningGoal: topic.learningGoal,
-				priority: topic.priority,
+				...topic,
 				status,
+				dimensions,
+				evidenceCount:
+					topicAttempts.length + (initialStatus !== "unknown" ? 1 : 0),
+				controlCheckReason,
+				topicAttempts,
 			};
 		});
-		const readiness = topics.reduce(
-			(counts, topic) => {
-				counts[topic.status] += 1;
-				return counts;
-			},
-			{ secure: 0, developing: 0, unknown: 0 },
-		);
 
 		const strengthStatements = uniqueRecentStrings(
 			analyses.flatMap((analysis) => analysis.strengths),
@@ -901,7 +1025,7 @@ export const getExamAnalysis = query({
 					)
 					.map((analysis) => analysis.sessionId),
 			);
-			const evidenceCount = latestAttempts.filter((attempt) => {
+			const matchingAttempts = latestAttempts.filter((attempt) => {
 				const item = itemById.get(attempt.itemId);
 				return (
 					matchingSessionIds.has(attempt.sessionId) &&
@@ -910,11 +1034,20 @@ export const getExamAnalysis = query({
 					(item?.kind === "written" || item?.kind === "voice") &&
 					Boolean(getAttemptExcerpt(attempt, item))
 				);
-			}).length;
+			});
+			const matchingTopicIds = new Set(
+				matchingAttempts.flatMap((attempt) => {
+					const topicId = itemById.get(attempt.itemId)?.topicId;
+					return topicId ? [topicId] : [];
+				}),
+			);
 			return {
 				statement,
-				evidenceCount: Math.max(1, evidenceCount),
-				topicId: null,
+				evidenceCount: Math.max(1, matchingAttempts.length),
+				topicId:
+					matchingTopicIds.size === 1
+						? ([...matchingTopicIds][0] ?? null)
+						: null,
 			};
 		});
 
@@ -1033,6 +1166,117 @@ export const getExamAnalysis = query({
 		const publicProblems = uniqueProblemCandidates.map(
 			({ priorityRank: _priorityRank, observedAt: _observedAt, ...problem }) =>
 				problem,
+		);
+		const dimensionGapCopy: Record<LearningEvidenceDimension, string> = {
+			understanding: "Verständnis noch nicht sicher belegt.",
+			problemSolving: "Problemlösen noch nicht sicher belegt.",
+			independent: "Selbstständiges Lösen noch nicht sicher belegt.",
+		};
+		const topics = topicEvidenceProfiles
+			.map((topic) => {
+				const topicProblems = publicProblems.filter(
+					(problem) => problem.topicId === topic.id,
+				);
+				const mappedStrengths = abilities
+					.filter((ability) => ability.topicId === topic.id)
+					.map(({ statement, evidenceCount }) => ({
+						statement,
+						evidenceCount,
+					}));
+				const fallbackStrengths = topic.topicAttempts
+					.filter((attempt) => attempt.rating === "correct")
+					.sort((left, right) => right.createdAt - left.createdAt)
+					.flatMap((attempt) => {
+						const item = itemById.get(attempt.itemId);
+						return item
+							? [
+									{
+										statement: `„${item.title}“ richtig gelöst.`,
+										evidenceCount: 1,
+									},
+								]
+							: [];
+					})
+					.filter(
+						(strength, index, values) =>
+							values.findIndex(
+								(candidate) => candidate.statement === strength.statement,
+							) === index,
+					);
+				const strengths = (
+					mappedStrengths.length > 0
+						? mappedStrengths
+						: topic.status === "secure"
+							? [
+									{
+										statement: topic.learningGoal,
+										evidenceCount: topic.evidenceCount,
+									},
+								]
+							: fallbackStrengths
+				).slice(0, 2);
+				const firstOpenDimension = topic.dimensions.find(
+					(dimension) => dimension.required && dimension.status !== "secure",
+				);
+				const weaknesses =
+					topicProblems.length > 0
+						? topicProblems.slice(0, 2).map((problem) => ({
+								statement: problem.observation,
+								evidenceCount: problem.evidenceCount,
+							}))
+						: topic.status === "developing" && firstOpenDimension
+							? [
+									{
+										statement: dimensionGapCopy[firstOpenDimension.kind],
+										evidenceCount: firstOpenDimension.evidenceCount,
+									},
+								]
+							: [];
+				const summary = topic.controlCheckReason
+					? "Kontrollbeleg nötig"
+					: (weaknesses[0]?.statement ??
+						(topic.status === "secure"
+							? "Alle erforderlichen Wissensbelege vorhanden."
+							: "Noch keine überprüften Antworten."));
+
+				return {
+					id: topic.id,
+					title: topic.title,
+					learningGoal: topic.learningGoal,
+					priority: topic.priority,
+					status: topic.status,
+					summary,
+					evidenceCount: topic.evidenceCount,
+					dimensions: topic.dimensions.map(
+						({ needsControlCheck: _needsControlCheck, ...dimension }) =>
+							dimension,
+					),
+					strengths,
+					weaknesses,
+					controlCheckReason: topic.controlCheckReason,
+					hasObservedProblem: topicProblems.length > 0,
+				};
+			})
+			.sort((left, right) => {
+				const leftRisk =
+					(left.status === "secure" ? 100 : 0) +
+					topicPriorityRank[left.priority] * 10 +
+					(left.hasObservedProblem ? 0 : left.status === "unknown" ? 1 : 2);
+				const rightRisk =
+					(right.status === "secure" ? 100 : 0) +
+					topicPriorityRank[right.priority] * 10 +
+					(right.hasObservedProblem ? 0 : right.status === "unknown" ? 1 : 2);
+				return (
+					leftRisk - rightRisk || left.title.localeCompare(right.title, "de")
+				);
+			})
+			.map(({ hasObservedProblem: _hasObservedProblem, ...topic }) => topic);
+		const readiness = topics.reduce(
+			(counts, topic) => {
+				counts[topic.status] += 1;
+				return counts;
+			},
+			{ secure: 0, developing: 0, unknown: 0 },
 		);
 		const primaryProblem = publicProblems[0] ?? null;
 		const secondaryProblems = publicProblems.slice(1, 3);

--- a/docs/contexts/product/CONTEXT.md
+++ b/docs/contexts/product/CONTEXT.md
@@ -64,6 +64,14 @@ _Avoid_: User-facing copy
 An evidence-based estimate of whether the learner's knowledge of one required assessment topic is secure, developing, or unknown. It combines demonstrated performance with self-reported confidence and shapes the topic's theory, practice, and later verification.
 _Avoid_: Treating confidence alone as mastery, one overall score for the entire assessment
 
+**Belegdimension**:
+One of the exam-specific capabilities Dayova evaluates for a topic: `Verstehen`, `Probleme lösen`, or `Selbstständig lösen`. These are evidence axes, not sequential content phases or point categories.
+_Avoid_: Lernphase, Punktebereich, treating the three dimensions as interchangeable
+
+**Kontrollbeleg**:
+A fresh, relevant answer requested when new performance contradicts previously secure evidence. The contradiction moves the affected topic to `Im Aufbau` while preserving its history; it never erases existing evidence into `Noch nicht belegt`.
+_Avoid_: Reset, punishment, treating one contradiction as no prior knowledge
+
 **Preparation gap**:
 The difference between the preparation Dayova recommends for the assessment and the learning time available before it. A plan with a preparation gap prioritizes the strongest feasible coverage without presenting that reduced plan as complete readiness.
 _Avoid_: Inventing availability, silently treating reduced coverage as fully recommended preparation
@@ -134,6 +142,10 @@ _Avoid_: Treating Generalprobe as a fourth learner-facing phase separate from Pr
 - Uploaded timetable data remains a draft until the learner reviews and activates at least one valid `Unterrichtsstunde`.
 - Only the active `Stundenplan` produces `Unterrichtstermine`; drafts never affect the daily agenda or learning-plan scheduling.
 - `Unterrichtstermine` block overlapping learning appointments but remain informational and cannot be completed.
+- Topic readiness uses the user-facing states `Sicher belegt`, `Im Aufbau`, and `Noch nicht belegt`; missing evidence is not presented as a demonstrated weakness.
+- An assessment topic is `Sicher belegt` only when every `Belegdimension` required by that topic is secure. New topic maps declare the required dimensions; legacy topics conservatively require all three.
+- Evidence is hierarchical: independent exam-like performance may support `Probleme lösen` and `Verstehen`, and guided problem solving may support `Verstehen`; lower-strength evidence never proves a higher dimension.
+- The Analyse overview may count secure topics but must not collapse readiness into a global percentage or points score. Activity or completed theory review alone never proves secure knowledge.
 
 ## Example Dialogue
 

--- a/docs/contexts/product/CONTEXT.md
+++ b/docs/contexts/product/CONTEXT.md
@@ -61,8 +61,12 @@ The internal name for the adaptive five- to eight-question diagnostic part of `P
 _Avoid_: User-facing copy
 
 **Topic readiness**:
-An evidence-based estimate of whether the learner's knowledge of one required assessment topic is secure, developing, or unknown. It combines demonstrated performance with self-reported confidence and shapes the topic's theory, practice, and later verification.
+An evidence-based estimate of whether the learner's knowledge of one required assessment topic is secure, developing, uncertain, or unknown. It combines demonstrated performance with self-reported confidence and shapes the topic's theory, practice, and later verification.
 _Avoid_: Treating confidence alone as mastery, one overall score for the entire assessment
+
+**Unsicher**:
+The user-facing `Topic readiness` state for a concrete weakness shown by the learner's latest graded answer. Missing evidence alone never makes a topic uncertain, and evidence that contradicts an earlier secure pattern remains `Im Aufbau` until a `Kontrollbeleg` resolves it.
+_Avoid_: Schlecht, nicht gelernt, using the state for untested knowledge
 
 **Belegdimension**:
 One of the exam-specific capabilities Dayova evaluates for a topic: `Verstehen`, `Probleme lösen`, or `Selbstständig lösen`. These are evidence axes, not sequential content phases or point categories.
@@ -142,7 +146,7 @@ _Avoid_: Treating Generalprobe as a fourth learner-facing phase separate from Pr
 - Uploaded timetable data remains a draft until the learner reviews and activates at least one valid `Unterrichtsstunde`.
 - Only the active `Stundenplan` produces `Unterrichtstermine`; drafts never affect the daily agenda or learning-plan scheduling.
 - `Unterrichtstermine` block overlapping learning appointments but remain informational and cannot be completed.
-- Topic readiness uses the user-facing states `Sicher belegt`, `Im Aufbau`, and `Noch nicht belegt`; missing evidence is not presented as a demonstrated weakness.
+- The post-session Analyse surface uses the user-facing states `Sicher belegt`, `Im Aufbau`, `Unsicher`, and `Noch nicht belegt`. `Unsicher` requires a recent incorrect or partially correct graded answer; missing evidence is never presented as a demonstrated weakness. Pre-plan `topicReadiness` remains the stored three-state diagnostic estimate (`secure`, `developing`, `unknown`).
 - An assessment topic is `Sicher belegt` only when every `Belegdimension` required by that topic is secure. New topic maps declare the required dimensions; legacy topics conservatively require all three.
 - Evidence is hierarchical: independent exam-like performance may support `Probleme lösen` and `Verstehen`, and guided problem solving may support `Verstehen`; lower-strength evidence never proves a higher dimension.
 - The Analyse overview may count secure topics but must not collapse readiness into a global percentage or points score. Activity or completed theory review alone never proves secure knowledge.

--- a/src/app/analyse/wissensstand.tsx
+++ b/src/app/analyse/wissensstand.tsx
@@ -3,12 +3,16 @@ import type { Id } from "#convex/_generated/dataModel";
 import { AnalyticsDetailScreen } from "~/features/analytics/analytics-screen";
 
 export default function KnowledgeAnalysisRoute() {
-	const { planId } = useLocalSearchParams<{ planId?: string }>();
+	const { planId, topicId } = useLocalSearchParams<{
+		planId?: string;
+		topicId?: string;
+	}>();
 
 	return (
 		<AnalyticsDetailScreen
 			planId={planId as Id<"learningPlans"> | undefined}
 			section="knowledge"
+			topicId={topicId}
 		/>
 	);
 }

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -3,13 +3,13 @@ import { useRouter } from "expo-router";
 import { useMemo, useState } from "react";
 import { View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import Svg, { Circle } from "react-native-svg";
 import { api } from "#convex/_generated/api";
 import type { Id } from "#convex/_generated/dataModel";
 import { NotificationButton } from "~/components/notification-button";
 import { AnimatedFlowerLoader } from "~/components/ui/animated-flower-loader";
 import { Button } from "~/components/ui/button";
 import {
-	Analytics,
 	ArrowDataTransferHorizontal,
 	ArrowRight,
 	ArrowUpRight,
@@ -113,8 +113,75 @@ const formatRemainingDays = (days: number) => {
 	return `Noch ${days} Tage`;
 };
 
+const KNOWLEDGE_RING_SIZE = 112;
+const KNOWLEDGE_RING_STROKE_WIDTH = 10;
+const KNOWLEDGE_RING_RADIUS =
+	(KNOWLEDGE_RING_SIZE - KNOWLEDGE_RING_STROKE_WIDTH) / 2;
+const KNOWLEDGE_RING_CIRCUMFERENCE = 2 * Math.PI * KNOWLEDGE_RING_RADIUS;
+
 // borderCurve is native geometry and has no NativeWind utility.
 const continuousCardStyle = { borderCurve: "continuous" } as const;
+
+function KnowledgeProgressRing({
+	secureTopics,
+	totalTopics,
+}: {
+	secureTopics: number;
+	totalTopics: number;
+}) {
+	const { colors } = useDayovaTheme();
+	const safeTotal = Math.max(0, totalTopics);
+	const safeSecure = Math.min(Math.max(0, secureTopics), safeTotal);
+	const hasTopics = safeTotal > 0;
+	const progress = hasTopics ? safeSecure / safeTotal : 0;
+	const progressOffset = KNOWLEDGE_RING_CIRCUMFERENCE * (1 - progress);
+
+	return (
+		<View accessible={false} className="h-28 w-28 items-center justify-center">
+			<Svg
+				pointerEvents="none"
+				width={KNOWLEDGE_RING_SIZE}
+				height={KNOWLEDGE_RING_SIZE}
+				viewBox={`0 0 ${KNOWLEDGE_RING_SIZE} ${KNOWLEDGE_RING_SIZE}`}
+				// SVG positioning is native geometry and cannot be expressed with NativeWind.
+				style={{ position: "absolute" }}
+			>
+				<Circle
+					cx={KNOWLEDGE_RING_SIZE / 2}
+					cy={KNOWLEDGE_RING_SIZE / 2}
+					r={KNOWLEDGE_RING_RADIUS}
+					fill="none"
+					stroke={colors.border}
+					strokeWidth={KNOWLEDGE_RING_STROKE_WIDTH}
+				/>
+				{hasTopics && safeSecure > 0 ? (
+					<Circle
+						cx={KNOWLEDGE_RING_SIZE / 2}
+						cy={KNOWLEDGE_RING_SIZE / 2}
+						r={KNOWLEDGE_RING_RADIUS}
+						fill="none"
+						stroke={colors.success}
+						strokeDasharray={`${KNOWLEDGE_RING_CIRCUMFERENCE} ${KNOWLEDGE_RING_CIRCUMFERENCE}`}
+						strokeDashoffset={progressOffset}
+						strokeLinecap="round"
+						strokeWidth={KNOWLEDGE_RING_STROKE_WIDTH}
+						transform={`rotate(-90 ${KNOWLEDGE_RING_SIZE / 2} ${KNOWLEDGE_RING_SIZE / 2})`}
+					/>
+				) : null}
+			</Svg>
+			<Text
+				adjustsFontSizeToFit
+				minimumFontScale={0.7}
+				numberOfLines={1}
+				selectable
+				className="font-poppins font-semibold text-heading-2 text-text"
+				style={{ fontVariant: ["tabular-nums"] }}
+			>
+				{hasTopics ? `${safeSecure}/${safeTotal}` : "–"}
+			</Text>
+		</View>
+	);
+}
 
 function useExamAnalysisQuery(
 	selectedPlanId: Id<"learningPlans"> | null | undefined,
@@ -251,130 +318,43 @@ function AnalysisHub({
 	const { colors } = useDayovaTheme();
 	const recommendation = analysis.recommendation;
 	const primaryProblem = analysis.primaryProblem;
-	const leadingAbility = analysis.abilities[0];
 	const totalTopics =
 		analysis.readiness.secure +
 		analysis.readiness.developing +
 		analysis.readiness.unknown;
-	const knowledgeHeadline =
-		totalTopics === 0
-			? "Noch nicht genug Belege für deinen Wissensstand."
-			: analysis.readiness.secure === 0
-				? analysis.readiness.unknown === totalTopics
-					? `Diese ${totalTopics} Prüfungsthemen wurden noch nicht geprüft.`
-					: analysis.readiness.developing === totalTopics
-						? `Du arbeitest an allen ${totalTopics} Prüfungsthemen, aber noch keines ist sicher belegt.`
-						: `Du arbeitest an ${analysis.readiness.developing} von ${totalTopics} Prüfungsthemen, aber noch keines ist sicher belegt.`
-				: `Du kannst ${analysis.readiness.secure} von ${totalTopics} Prüfungsthemen sicher anwenden.`;
-	const readinessItems = [
-		{
-			label: "Sicher",
-			value: analysis.readiness.secure,
-			barClassName: "bg-success",
-		},
-		{
-			label: "In Arbeit",
-			value: analysis.readiness.developing,
-			barClassName: "bg-info",
-		},
-		{
-			label: "Noch unklar",
-			value: analysis.readiness.unknown,
-			barClassName: "bg-primary",
-		},
-	];
+	const hasTopics = totalTopics > 0;
+	const knowledgeAccessibilityLabel = hasTopics
+		? `Wissensstand: ${analysis.readiness.secure} von ${totalTopics} Themen sicher belegt. Details öffnen`
+		: "Wissensstand: Noch keine Prüfungsthemen bewertet. Details öffnen";
 
 	return (
 		<View className="gap-4">
 			<ActionSurface
 				accessibilityHint="Öffnet alle Themen und Wissensbelege."
-				accessibilityLabel={`Wissensstand: ${analysis.readiness.secure} sicher, ${analysis.readiness.developing} in Arbeit, ${analysis.readiness.unknown} noch unklar. Details öffnen`}
+				accessibilityLabel={knowledgeAccessibilityLabel}
 				accessibilityRole="button"
-				className="gap-5 rounded-card border border-border bg-card p-5 shadow-none"
+				className="flex-row items-center gap-4 rounded-card border border-border bg-card p-5 shadow-none"
 				onPress={onOpenKnowledge}
 				style={continuousCardStyle}
 				variant="flat"
 			>
-				<View className="flex-row items-center justify-between gap-4">
-					<View className="flex-row items-center gap-3">
-						<View className="h-10 w-10 items-center justify-center rounded-full bg-system-subtle">
-							<Analytics
-								size={20}
-								color={colors.primaryStrong}
-								strokeWidth={2.2}
-							/>
-						</View>
-						<Text className="font-poppins font-semibold text-body-3 text-primary-strong">
-							Dein Wissensstand
-						</Text>
-					</View>
-					<ArrowRight
-						size={19}
-						color={colors.secondaryText}
-						strokeWidth={2.2}
-					/>
-				</View>
-
-				<View className="gap-2">
+				<KnowledgeProgressRing
+					secureTopics={analysis.readiness.secure}
+					totalTopics={totalTopics}
+				/>
+				<View className="min-w-0 flex-1 gap-1">
+					<Text className="font-poppins font-semibold text-body-3 text-primary-strong">
+						Dein Wissensstand
+					</Text>
 					<Text
 						selectable
-						className="font-poppins font-semibold text-body-1 text-text"
+						className="font-poppins text-body-4 text-secondary-text"
+						numberOfLines={2}
 					>
-						{knowledgeHeadline}
+						{hasTopics ? "Themen sicher belegt" : "Noch keine Themen bewertet"}
 					</Text>
-					{leadingAbility ? (
-						<Text
-							selectable
-							className="font-poppins text-body-4 text-secondary-text"
-							numberOfLines={2}
-						>
-							{`Schon belegt: ${formatGermanUiText(leadingAbility.statement)}`}
-						</Text>
-					) : null}
 				</View>
-
-				<View className="gap-3">
-					<View
-						accessible
-						accessibilityLabel={`${analysis.readiness.secure} sicher, ${analysis.readiness.developing} in Arbeit, ${analysis.readiness.unknown} noch unklar`}
-						className="h-3 flex-row overflow-hidden rounded-full bg-border/60"
-					>
-						{readinessItems
-							.filter((item) => item.value > 0)
-							.map((item) => (
-								<View
-									key={item.label}
-									className={cn("flex-1", item.barClassName)}
-								/>
-							))}
-					</View>
-					<View className="flex-row flex-wrap gap-x-4 gap-y-2">
-						{readinessItems.map((item) => (
-							<View key={item.label} className="flex-row items-center gap-1.5">
-								<View
-									className={cn("h-2 w-2 rounded-full", item.barClassName)}
-								/>
-								<Text
-									className="font-poppins text-body-5 text-secondary-text"
-									style={{ fontVariant: ["tabular-nums"] }}
-								>
-									{`${item.value} ${item.label}`}
-								</Text>
-							</View>
-						))}
-					</View>
-				</View>
-
-				{analysis.latestKnowledgeChange ? (
-					<View className="rounded-info bg-background px-4 py-3">
-						<Text
-							selectable
-							className="font-poppins text-body-4 text-secondary-text"
-						>
-							{analysis.latestKnowledgeChange}
-						</Text>
-					</View>
-				) : null}
+				<ArrowRight size={19} color={colors.secondaryText} strokeWidth={2.2} />
 			</ActionSurface>
 
 			<ActionSurface

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -83,6 +83,11 @@ const TOPIC_STATUS_COPY: Record<
 		pillClassName: "bg-info-subtle",
 		textClassName: "text-info",
 	},
+	uncertain: {
+		label: "Unsicher",
+		pillClassName: "bg-wrong-subtle",
+		textClassName: "text-wrong",
+	},
 	unknown: {
 		label: "Noch nicht belegt",
 		pillClassName: "bg-light-2",
@@ -317,11 +322,15 @@ function AnalysisHub({
 	const totalTopics =
 		analysis.readiness.secure +
 		analysis.readiness.developing +
+		analysis.readiness.uncertain +
 		analysis.readiness.unknown;
 	const hasKnowledgeEvidence =
 		totalTopics > 0 && analysis.topics.some((topic) => topic.evidenceCount > 0);
 	const remainingStatusSummary = hasKnowledgeEvidence
 		? [
+				analysis.readiness.uncertain > 0
+					? `${analysis.readiness.uncertain} unsicher`
+					: null,
 				analysis.readiness.developing > 0
 					? `${analysis.readiness.developing} im Aufbau`
 					: null,
@@ -366,7 +375,7 @@ function AnalysisHub({
 			<View className="gap-4">
 				<SectionHeading
 					title="Deine Prüfungsthemen"
-					description="Nach aktuellem Lernrisiko sortiert."
+					description="Nach Prüfungsrelevanz und Lernrisiko sortiert."
 				/>
 				<Surface
 					className="overflow-hidden"
@@ -720,32 +729,161 @@ function TopicList({
 				accessibilityLabel={`${topic.title}. ${status.label}. ${topic.summary}`}
 				accessibilityRole="button"
 				className={cn(
-					"min-h-16 flex-row items-center gap-3 bg-card px-4 py-3",
+					"min-h-16 gap-2 bg-card px-4 py-4",
 					index > 0 && "border-border border-t",
 				)}
 				onPress={() => onOpenTopic(topic.id)}
 				variant="flat"
 			>
-				<View className="min-w-0 flex-1">
+				<View className="flex-row items-center gap-3">
 					<Text
 						selectable
-						className="font-poppins font-semibold text-body-3 text-text"
+						className="min-w-0 flex-1 font-poppins font-semibold text-body-3 text-text"
 						numberOfLines={3}
 					>
 						{formatGermanUiText(topic.title)}
 					</Text>
+					<View className="flex-row items-center gap-2">
+						<TopicStatusPill status={topic.status} />
+						<ArrowRight
+							size={17}
+							color={colors.secondaryText}
+							strokeWidth={2.2}
+						/>
+					</View>
 				</View>
-				<View className="flex-row items-center gap-2">
-					<TopicStatusPill status={topic.status} />
-					<ArrowRight
-						size={17}
-						color={colors.secondaryText}
-						strokeWidth={2.2}
-					/>
-				</View>
+				{topic.status === "uncertain" ? (
+					<Text
+						selectable
+						className="font-poppins text-body-5 text-secondary-text"
+						numberOfLines={2}
+					>
+						{formatGermanUiText(topic.summary)}
+					</Text>
+				) : null}
 			</ActionSurface>
 		);
 	});
+}
+
+function TopicWeaknessSection({
+	topic,
+}: {
+	topic: ExamAnalysis["topics"][number];
+}) {
+	if (topic.weaknesses.length === 0) return null;
+
+	return (
+		<View className="gap-3">
+			<SectionHeading
+				title={
+					topic.status === "uncertain"
+						? "Warum du hier unsicher bist"
+						: "Das fehlt noch"
+				}
+			/>
+			<Surface className="gap-4 p-5" variant="flat">
+				{topic.weaknesses.map((weakness, index) => (
+					<View
+						key={weakness.statement}
+						className={cn(
+							"flex-row items-start gap-3",
+							index > 0 && "border-border border-t pt-4",
+						)}
+					>
+						<View className="h-8 w-8 items-center justify-center rounded-full bg-wrong-subtle">
+							<CircleAlert
+								size={16}
+								color={DAYOVA_DESIGN_SYSTEM.colors.wrong}
+								strokeWidth={2.2}
+							/>
+						</View>
+						<View className="min-w-0 flex-1 gap-1">
+							<Text selectable className="font-poppins text-body-3 text-text">
+								{formatGermanUiText(weakness.statement)}
+							</Text>
+							<Text
+								selectable
+								className="font-poppins text-body-5 text-secondary-text"
+							>
+								{weakness.evidenceCount === 1
+									? "In einer Antwort beobachtet"
+									: weakness.evidenceCount > 1
+										? `In ${weakness.evidenceCount} Antworten beobachtet`
+										: "Noch nicht überprüft"}
+							</Text>
+						</View>
+					</View>
+				))}
+			</Surface>
+		</View>
+	);
+}
+
+function TopicStrengthSection({
+	topic,
+}: {
+	topic: ExamAnalysis["topics"][number];
+}) {
+	return topic.strengths.length > 0 ? (
+		<View className="gap-3">
+			<SectionHeading title="Das kannst du schon" />
+			<Surface className="gap-4 p-5" variant="flat">
+				{topic.strengths.map((strength, index) => (
+					<View
+						key={strength.statement}
+						className={cn(
+							"flex-row items-start gap-3",
+							index > 0 && "border-border border-t pt-4",
+						)}
+					>
+						<View className="h-8 w-8 items-center justify-center rounded-full bg-success-subtle">
+							<Check
+								size={16}
+								color={DAYOVA_DESIGN_SYSTEM.colors.success}
+								strokeWidth={2.3}
+							/>
+						</View>
+						<View className="min-w-0 flex-1 gap-1">
+							<Text selectable className="font-poppins text-body-3 text-text">
+								{formatGermanUiText(strength.statement)}
+							</Text>
+							<Text
+								selectable
+								className="font-poppins text-body-5 text-secondary-text"
+							>
+								{`${strength.evidenceCount} ${strength.evidenceCount === 1 ? "Beleg" : "Belege"}`}
+							</Text>
+						</View>
+					</View>
+				))}
+			</Surface>
+		</View>
+	) : (
+		<View className="gap-3">
+			<SectionHeading title="Das kannst du schon" />
+			<Surface className="flex-row items-start gap-3 p-5" variant="flat">
+				<View className="h-8 w-8 items-center justify-center rounded-full bg-system-subtle">
+					<Info
+						size={17}
+						color={DAYOVA_DESIGN_SYSTEM.colors.primaryStrong}
+						strokeWidth={2.2}
+					/>
+				</View>
+				<View className="min-w-0 flex-1 gap-1">
+					<Text className="font-poppins font-semibold text-body-4 text-text">
+						Noch keine sichere Stärke
+					</Text>
+					<Text
+						selectable
+						className="font-poppins text-body-4 text-secondary-text"
+					>
+						Dafür fehlen noch wiederholte richtige Antworten.
+					</Text>
+				</View>
+			</Surface>
+		</View>
+	);
 }
 
 function TopicDetailCard({ topic }: { topic: ExamAnalysis["topics"][number] }) {
@@ -811,103 +949,8 @@ function TopicDetailCard({ topic }: { topic: ExamAnalysis["topics"][number] }) {
 				</Surface>
 			</View>
 
-			{topic.strengths.length > 0 ? (
-				<View className="gap-3">
-					<SectionHeading title="Das kannst du schon" />
-					<Surface className="gap-4 p-5" variant="flat">
-						{topic.strengths.map((strength, index) => (
-							<View
-								key={strength.statement}
-								className={cn(
-									"flex-row items-start gap-3",
-									index > 0 && "border-border border-t pt-4",
-								)}
-							>
-								<View className="h-8 w-8 items-center justify-center rounded-full bg-success-subtle">
-									<Check
-										size={16}
-										color={DAYOVA_DESIGN_SYSTEM.colors.success}
-										strokeWidth={2.3}
-									/>
-								</View>
-								<View className="min-w-0 flex-1 gap-1">
-									<Text
-										selectable
-										className="font-poppins text-body-3 text-text"
-									>
-										{formatGermanUiText(strength.statement)}
-									</Text>
-									<Text className="font-poppins text-body-5 text-secondary-text">
-										{`${strength.evidenceCount} ${strength.evidenceCount === 1 ? "Beleg" : "Belege"}`}
-									</Text>
-								</View>
-							</View>
-						))}
-					</Surface>
-				</View>
-			) : (
-				<View className="gap-3">
-					<SectionHeading title="Das kannst du schon" />
-					<Surface className="flex-row items-start gap-3 p-5" variant="flat">
-						<View className="h-8 w-8 items-center justify-center rounded-full bg-system-subtle">
-							<Info
-								size={17}
-								color={DAYOVA_DESIGN_SYSTEM.colors.primaryStrong}
-								strokeWidth={2.2}
-							/>
-						</View>
-						<View className="min-w-0 flex-1 gap-1">
-							<Text className="font-poppins font-semibold text-body-4 text-text">
-								Noch keine sichere Stärke
-							</Text>
-							<Text
-								selectable
-								className="font-poppins text-body-4 text-secondary-text"
-							>
-								Dafür fehlen noch wiederholte richtige Antworten.
-							</Text>
-						</View>
-					</Surface>
-				</View>
-			)}
-
-			{topic.weaknesses.length > 0 ? (
-				<View className="gap-3">
-					<SectionHeading title="Das fehlt noch" />
-					<Surface className="gap-4 p-5" variant="flat">
-						{topic.weaknesses.map((weakness, index) => (
-							<View
-								key={weakness.statement}
-								className={cn(
-									"flex-row items-start gap-3",
-									index > 0 && "border-border border-t pt-4",
-								)}
-							>
-								<View className="h-8 w-8 items-center justify-center rounded-full bg-wrong-subtle">
-									<CircleAlert
-										size={16}
-										color={DAYOVA_DESIGN_SYSTEM.colors.wrong}
-										strokeWidth={2.2}
-									/>
-								</View>
-								<View className="min-w-0 flex-1 gap-1">
-									<Text
-										selectable
-										className="font-poppins text-body-3 text-text"
-									>
-										{formatGermanUiText(weakness.statement)}
-									</Text>
-									<Text className="font-poppins text-body-5 text-secondary-text">
-										{weakness.evidenceCount > 0
-											? `${weakness.evidenceCount} ${weakness.evidenceCount === 1 ? "Beleg" : "Belege"}`
-											: "Noch nicht überprüft"}
-									</Text>
-								</View>
-							</View>
-						))}
-					</Surface>
-				</View>
-			) : null}
+			<TopicWeaknessSection topic={topic} />
+			<TopicStrengthSection topic={topic} />
 
 			{topic.controlCheckReason ? (
 				<Surface

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -75,24 +75,30 @@ const TOPIC_STATUS_COPY: Record<
 	}
 > = {
 	secure: {
-		label: "Sicher",
+		label: "Sicher belegt",
 		dotClassName: "bg-success",
 		pillClassName: "bg-success-subtle",
 		textClassName: "text-success",
 	},
 	developing: {
-		label: "In Arbeit",
+		label: "Im Aufbau",
 		dotClassName: "bg-info",
 		pillClassName: "bg-info-subtle",
 		textClassName: "text-info",
 	},
 	unknown: {
-		label: "Noch unklar",
-		dotClassName: "bg-primary",
-		pillClassName: "bg-system-subtle",
-		textClassName: "text-primary-strong",
+		label: "Noch nicht belegt",
+		dotClassName: "bg-path-3",
+		pillClassName: "bg-light-2",
+		textClassName: "text-secondary-text",
 	},
 };
+
+const EVIDENCE_DIMENSION_COPY = {
+	understanding: "Verstehen",
+	problemSolving: "Probleme lösen",
+	independent: "Selbstständig lösen",
+} as const;
 
 const PRIORITY_COPY = {
 	high: "Hohe Prüfungsrelevanz",
@@ -303,110 +309,79 @@ function ExamSwitcher({
 
 function AnalysisHub({
 	analysis,
-	onOpenKnowledge,
 	onOpenNextStep,
-	onOpenProblem,
+	onOpenTopic,
 }: {
 	analysis: ExamAnalysis;
-	onOpenKnowledge: () => void;
 	onOpenNextStep: () => void;
-	onOpenProblem: () => void;
+	onOpenTopic: (topicId: string) => void;
 }) {
 	const { colors } = useDayovaTheme();
 	const recommendation = analysis.recommendation;
-	const primaryProblem = analysis.primaryProblem;
 	const totalTopics =
 		analysis.readiness.secure +
 		analysis.readiness.developing +
 		analysis.readiness.unknown;
-	const hasTopics = totalTopics > 0;
-	const knowledgeAccessibilityLabel = hasTopics
-		? `Wissensstand: ${analysis.readiness.secure} von ${totalTopics} Themen sicher belegt. Details öffnen`
-		: "Wissensstand: Noch keine Prüfungsthemen bewertet. Details öffnen";
+	const hasKnowledgeEvidence =
+		totalTopics > 0 && analysis.topics.some((topic) => topic.evidenceCount > 0);
 
 	return (
 		<View className="gap-4">
-			<ActionSurface
-				accessibilityHint="Öffnet alle Themen und Wissensbelege."
-				accessibilityLabel={knowledgeAccessibilityLabel}
-				accessibilityRole="button"
-				className="flex-row items-center gap-4 rounded-card border border-border bg-card p-5 shadow-none"
-				onPress={onOpenKnowledge}
+			<Surface
+				className="overflow-hidden border border-border"
 				style={continuousCardStyle}
 				variant="flat"
 			>
-				<KnowledgeProgressRing
-					secureTopics={analysis.readiness.secure}
-					totalTopics={totalTopics}
-				/>
-				<View className="min-w-0 flex-1 gap-1">
-					<Text className="font-poppins font-semibold text-body-3 text-primary-strong">
-						Dein Wissensstand
-					</Text>
-					<Text
-						selectable
-						className="font-poppins text-body-4 text-secondary-text"
-						numberOfLines={2}
-					>
-						{hasTopics ? "Themen sicher belegt" : "Noch keine Themen bewertet"}
-					</Text>
-				</View>
-				<ArrowRight size={19} color={colors.secondaryText} strokeWidth={2.2} />
-			</ActionSurface>
-
-			<ActionSurface
-				accessibilityHint="Öffnet die Antwort und die genaue Diagnose."
-				accessibilityLabel={`Lernhürde: ${
-					primaryProblem?.observation ?? "Noch keine klare Schwäche erkannt"
-				} Details öffnen`}
-				accessibilityRole="button"
-				className="gap-4 rounded-card border border-wrong/20 bg-card p-5 shadow-none"
-				onPress={onOpenProblem}
-				style={continuousCardStyle}
-				variant="flat"
-			>
-				<View className="flex-row items-center justify-between gap-4">
-					<View className="flex-row items-center gap-3">
-						<View className="h-10 w-10 items-center justify-center rounded-full bg-wrong-subtle">
-							<CircleAlert size={20} color={colors.wrong} strokeWidth={2.2} />
+				<View className="gap-4 p-5">
+					<View className="flex-row items-center gap-4">
+						<KnowledgeProgressRing
+							secureTopics={analysis.readiness.secure}
+							totalTopics={hasKnowledgeEvidence ? totalTopics : 0}
+						/>
+						<View className="min-w-0 flex-1 gap-1">
+							<Text className="font-poppins font-semibold text-body-3 text-primary-strong">
+								Dein Wissensstand
+							</Text>
+							<Text
+								selectable
+								className="font-poppins font-semibold text-body-1 text-text"
+							>
+								{hasKnowledgeEvidence
+									? `${analysis.readiness.secure} von ${totalTopics} Themen sicher`
+									: "Noch keine Wissensbelege"}
+							</Text>
+							<Text
+								selectable
+								className="font-poppins text-body-5 text-secondary-text"
+							>
+								Nach aktuellem Lernrisiko sortiert
+							</Text>
 						</View>
-						<Text className="font-poppins font-semibold text-body-3 text-wrong">
-							Größte Lernhürde
-						</Text>
 					</View>
-					<ArrowRight
-						size={19}
-						color={colors.secondaryText}
-						strokeWidth={2.2}
-					/>
+					<View className="flex-row flex-wrap gap-x-4 gap-y-2">
+						{(
+							[
+								["secure", analysis.readiness.secure],
+								["developing", analysis.readiness.developing],
+								["unknown", analysis.readiness.unknown],
+							] as const
+						).map(([statusKey, count]) => {
+							const status = TOPIC_STATUS_COPY[statusKey];
+							return (
+								<View key={statusKey} className="flex-row items-center gap-2">
+									<View
+										className={cn("h-2 w-2 rounded-full", status.dotClassName)}
+									/>
+									<Text className="font-poppins text-body-5 text-secondary-text">
+										{`${count} ${status.label}`}
+									</Text>
+								</View>
+							);
+						})}
+					</View>
 				</View>
-				<View className="gap-2">
-					<Text
-						selectable
-						className="font-poppins font-semibold text-body-2 text-text"
-						numberOfLines={3}
-					>
-						{formatGermanUiText(
-							primaryProblem?.observation ??
-								"Noch keine klare Schwäche erkannt",
-						)}
-					</Text>
-					<Text
-						selectable
-						className="font-poppins text-body-4 text-secondary-text"
-						numberOfLines={2}
-					>
-						{primaryProblem?.evidenceExcerpt
-							? `Deine Antwort: „${primaryProblem.evidenceExcerpt}“`
-							: "Noch nicht genug Belege für eine konkrete Diagnose."}
-					</Text>
-				</View>
-				{analysis.secondaryProblems.length > 0 ? (
-					<Text className="font-poppins font-semibold text-body-5 text-wrong">
-						{`${analysis.secondaryProblems.length} weitere ${analysis.secondaryProblems.length === 1 ? "Lernhürde" : "Lernhürden"} ansehen`}
-					</Text>
-				) : null}
-			</ActionSurface>
+				<TopicList topics={analysis.topics} onOpenTopic={onOpenTopic} />
+			</Surface>
 
 			<ActionSurface
 				accessibilityHint="Öffnet deinen empfohlenen nächsten Lernschritt."
@@ -450,194 +425,6 @@ function AnalysisHub({
 				</View>
 				<ArrowRight size={19} color={colors.primaryStrong} strokeWidth={2.2} />
 			</ActionSurface>
-		</View>
-	);
-}
-
-function ReadinessSummary({ analysis }: { analysis: ExamAnalysis }) {
-	const statusItems = [
-		{
-			label: "Sicher",
-			value: analysis.readiness.secure,
-			className: "bg-success-subtle",
-			valueClassName: "text-success",
-		},
-		{
-			label: "In Arbeit",
-			value: analysis.readiness.developing,
-			className: "bg-info-subtle",
-			valueClassName: "text-info",
-		},
-		{
-			label: "Noch unklar",
-			value: analysis.readiness.unknown,
-			className: "bg-system-subtle",
-			valueClassName: "text-primary-strong",
-		},
-	];
-
-	return (
-		<Surface className="gap-5 p-5" variant="flat">
-			<View className="flex-row items-start justify-between gap-4">
-				<View className="min-w-0 flex-1 gap-1">
-					<Text
-						selectable
-						className="font-poppins font-semibold text-body-1 text-text"
-					>
-						Dein aktueller Stand
-					</Text>
-					<Text
-						selectable
-						className="font-poppins text-body-4 text-secondary-text"
-					>
-						{analysis.preliminary
-							? "Erste Einschätzung aus deinen Antworten. Sie wird mit jeder Einheit genauer."
-							: "Aus deinen bisherigen Antworten für diese Prüfung."}
-					</Text>
-				</View>
-				{analysis.preliminary ? (
-					<View className="rounded-full bg-system-subtle px-3 py-1.5">
-						<Text className="font-poppins font-semibold text-body-5 text-primary-strong">
-							Erste Einschätzung
-						</Text>
-					</View>
-				) : null}
-			</View>
-			<View className="flex-row gap-2">
-				{statusItems.map((item) => (
-					<View
-						key={item.label}
-						accessible
-						accessibilityLabel={`${item.label}: ${item.value} Themen`}
-						className={cn(
-							"min-w-0 flex-1 items-center gap-0.5 rounded-info px-2 py-4",
-							item.className,
-						)}
-					>
-						<Text
-							selectable
-							className={cn(
-								"font-poppins font-semibold text-heading-2",
-								item.valueClassName,
-							)}
-							style={{ fontVariant: ["tabular-nums"] }}
-						>
-							{item.value}
-						</Text>
-						<Text className="text-center font-poppins font-semibold text-body-5 text-secondary-text">
-							{item.label}
-						</Text>
-					</View>
-				))}
-			</View>
-		</Surface>
-	);
-}
-
-function AbilitySection({
-	abilities,
-}: {
-	abilities: ExamAnalysis["abilities"];
-}) {
-	if (abilities.length === 0) {
-		return (
-			<View className="gap-4">
-				<SectionHeading title="Das kannst du schon" />
-				<Surface className="gap-2 p-5" variant="flat">
-					<Text
-						selectable
-						className="font-poppins font-semibold text-body-3 text-text"
-					>
-						Noch nicht genug Belege
-					</Text>
-					<Text
-						selectable
-						className="font-poppins text-body-4 text-secondary-text"
-					>
-						Nach deinen nächsten schriftlichen oder gesprochenen Antworten kann
-						Dayova deine Fähigkeiten genauer benennen.
-					</Text>
-				</Surface>
-			</View>
-		);
-	}
-
-	return (
-		<View className="gap-4">
-			<SectionHeading
-				title="Das kannst du schon"
-				description="Konkrete Fähigkeiten, die du bereits gezeigt hast."
-			/>
-			<View className="gap-3">
-				{abilities.map((ability) => (
-					<Surface
-						key={ability.statement}
-						accessible
-						accessibilityLabel={`${ability.statement} Belegt durch ${ability.evidenceCount} Antworten.`}
-						className="flex-row items-start gap-3 p-5"
-						variant="flat"
-					>
-						<View className="h-8 w-8 items-center justify-center rounded-full bg-success-subtle">
-							<Check
-								size={17}
-								color={DAYOVA_DESIGN_SYSTEM.colors.success}
-								strokeWidth={2.4}
-							/>
-						</View>
-						<View className="min-w-0 flex-1 gap-1">
-							<Text
-								selectable
-								className="font-poppins font-semibold text-body-3 text-text"
-							>
-								{ability.statement}
-							</Text>
-							<Text
-								selectable
-								className="font-poppins text-body-5 text-secondary-text"
-							>
-								{`Belegt durch ${ability.evidenceCount} ${ability.evidenceCount === 1 ? "Antwort" : "Antworten"}`}
-							</Text>
-						</View>
-					</Surface>
-				))}
-			</View>
-		</View>
-	);
-}
-
-function ImprovementSection({
-	improvements,
-}: {
-	improvements: ExamAnalysis["improvements"];
-}) {
-	if (improvements.length === 0) return null;
-
-	return (
-		<View className="gap-4">
-			<SectionHeading
-				title="Das hast du verbessert"
-				description="Neuere Antworten ersetzen frühere Unsicherheiten."
-			/>
-			<Surface className="gap-4 bg-success-subtle p-5" variant="flat">
-				{improvements.map((improvement) => (
-					<View
-						key={improvement.statement}
-						className="flex-row items-start gap-3"
-					>
-						<Check
-							size={19}
-							color={DAYOVA_DESIGN_SYSTEM.colors.success}
-							strokeWidth={2.3}
-						/>
-						<Text
-							selectable
-							className="min-w-0 flex-1 font-poppins text-body-3 text-text"
-						>
-							{improvement.statement}
-						</Text>
-					</View>
-				))}
-			</Surface>
 		</View>
 	);
 }
@@ -902,60 +689,305 @@ function RecommendationSection({
 	);
 }
 
-function TopicOverview({ topics }: { topics: ExamAnalysis["topics"] }) {
+function TopicStatusPill({ status }: { status: TopicStatus }) {
+	const copy = TOPIC_STATUS_COPY[status];
+
 	return (
-		<View className="gap-4">
-			<SectionHeading
-				title="Dein Prüfungsstoff"
-				description="Auch ungetestete Themen bleiben sichtbar."
-			/>
-			<Surface className="overflow-hidden" variant="flat">
-				{topics.map((topic, index) => {
-					const status = TOPIC_STATUS_COPY[topic.status];
-					return (
+		<View className={cn("rounded-full px-3 py-1.5", copy.pillClassName)}>
+			<Text
+				className={cn(
+					"font-poppins font-semibold text-body-5",
+					copy.textClassName,
+				)}
+				numberOfLines={1}
+			>
+				{copy.label}
+			</Text>
+		</View>
+	);
+}
+
+function TopicList({
+	onOpenTopic,
+	selectedTopicId,
+	topics,
+}: {
+	onOpenTopic: (topicId: string) => void;
+	selectedTopicId?: string;
+	topics: ExamAnalysis["topics"];
+}) {
+	const { colors } = useDayovaTheme();
+
+	return topics.map((topic) => {
+		const status = TOPIC_STATUS_COPY[topic.status];
+		const selected = topic.id === selectedTopicId;
+		return (
+			<ActionSurface
+				key={topic.id}
+				accessibilityHint="Öffnet Stärken, Lücken und Wissensbelege für dieses Thema."
+				accessibilityLabel={`${topic.title}. ${status.label}. ${topic.summary}`}
+				accessibilityRole="button"
+				accessibilityState={{ selected }}
+				className={cn(
+					"flex-row items-center gap-3 border-border border-t bg-card px-5 py-4",
+					selected && "bg-system-subtle",
+				)}
+				onPress={() => onOpenTopic(topic.id)}
+				variant="flat"
+			>
+				<View
+					accessible={false}
+					className={cn(
+						"h-10 w-10 items-center justify-center rounded-full",
+						status.pillClassName,
+					)}
+				>
+					<View className={cn("h-3 w-3 rounded-full", status.dotClassName)} />
+				</View>
+				<View className="min-w-0 flex-1 gap-1">
+					<Text
+						selectable
+						className="font-poppins font-semibold text-body-3 text-text"
+						numberOfLines={2}
+					>
+						{formatGermanUiText(topic.title)}
+					</Text>
+					<Text
+						selectable
+						className="font-poppins text-body-5 text-secondary-text"
+						numberOfLines={2}
+					>
+						{formatGermanUiText(topic.summary)}
+					</Text>
+				</View>
+				<View className="items-end gap-2">
+					<TopicStatusPill status={topic.status} />
+					<ArrowRight
+						size={17}
+						color={colors.secondaryText}
+						strokeWidth={2.2}
+					/>
+				</View>
+			</ActionSurface>
+		);
+	});
+}
+
+function TopicDetailCard({ topic }: { topic: ExamAnalysis["topics"][number] }) {
+	const requiredDimensions = topic.dimensions.filter(
+		(dimension) => dimension.required,
+	);
+
+	return (
+		<Surface className="gap-6 p-5" variant="flat">
+			<View className="gap-3">
+				<View className="flex-row flex-wrap items-center justify-between gap-3">
+					<View className="rounded-full bg-background px-3 py-1.5">
+						<Text className="font-poppins font-semibold text-body-5 text-secondary-text">
+							{PRIORITY_COPY[topic.priority]}
+						</Text>
+					</View>
+					<TopicStatusPill status={topic.status} />
+				</View>
+				<View className="gap-1">
+					<Text
+						selectable
+						className="font-poppins font-semibold text-body-1 text-text"
+					>
+						{formatGermanUiText(topic.title)}
+					</Text>
+					<Text
+						selectable
+						className="font-poppins text-body-4 text-secondary-text"
+					>
+						{formatGermanUiText(topic.learningGoal)}
+					</Text>
+				</View>
+			</View>
+
+			<View className="gap-3">
+				<Text className="font-poppins font-semibold text-body-4 text-text">
+					Dein Wissensprofil
+				</Text>
+				<View className="overflow-hidden rounded-info border border-border">
+					{requiredDimensions.map((dimension, index) => (
 						<View
-							key={topic.id}
-							accessible
-							accessibilityLabel={`${topic.title}. ${status.label}. ${PRIORITY_COPY[topic.priority]}.`}
+							key={dimension.kind}
 							className={cn(
-								"flex-row items-center gap-3 px-5 py-4",
+								"flex-row items-center justify-between gap-3 bg-card px-4 py-3",
 								index > 0 && "border-border border-t",
 							)}
 						>
-							<View
-								accessible={false}
-								className={cn("h-3 w-3 rounded-full", status.dotClassName)}
-							/>
 							<View className="min-w-0 flex-1 gap-0.5">
-								<Text
-									selectable
-									className="font-poppins font-semibold text-body-3 text-text"
-								>
-									{formatGermanUiText(topic.title)}
+								<Text className="font-poppins font-semibold text-body-3 text-text">
+									{EVIDENCE_DIMENSION_COPY[dimension.kind]}
 								</Text>
-								<Text
-									selectable
-									className="font-poppins text-body-5 text-secondary-text"
-								>
-									{PRIORITY_COPY[topic.priority]}
+								<Text className="font-poppins text-body-5 text-secondary-text">
+									{dimension.evidenceCount === 0
+										? "Noch kein Beleg"
+										: `${dimension.evidenceCount} ${dimension.evidenceCount === 1 ? "Beleg" : "Belege"}`}
 								</Text>
 							</View>
-							<View
-								className={cn("rounded-full px-3 py-1.5", status.pillClassName)}
-							>
-								<Text
-									className={cn(
-										"font-poppins font-semibold text-body-5",
-										status.textClassName,
-									)}
-								>
-									{status.label}
-								</Text>
-							</View>
+							<TopicStatusPill status={dimension.status} />
 						</View>
-					);
-				})}
+					))}
+				</View>
+			</View>
+
+			{topic.strengths.length > 0 ? (
+				<View className="gap-3">
+					<Text className="font-poppins font-semibold text-body-4 text-text">
+						Das kannst du schon
+					</Text>
+					<View className="gap-3 rounded-info bg-success-subtle p-4">
+						{topic.strengths.map((strength) => (
+							<View
+								key={strength.statement}
+								className="flex-row items-start gap-3"
+							>
+								<Check
+									size={18}
+									color={DAYOVA_DESIGN_SYSTEM.colors.success}
+									strokeWidth={2.3}
+								/>
+								<View className="min-w-0 flex-1 gap-1">
+									<Text
+										selectable
+										className="font-poppins text-body-3 text-text"
+									>
+										{formatGermanUiText(strength.statement)}
+									</Text>
+									<Text className="font-poppins text-body-5 text-secondary-text">
+										{`${strength.evidenceCount} ${strength.evidenceCount === 1 ? "Beleg" : "Belege"}`}
+									</Text>
+								</View>
+							</View>
+						))}
+					</View>
+				</View>
+			) : (
+				<View className="flex-row items-start gap-3 rounded-info bg-background p-4">
+					<Info
+						size={19}
+						color={DAYOVA_DESIGN_SYSTEM.colors.primaryStrong}
+						strokeWidth={2.2}
+					/>
+					<View className="min-w-0 flex-1 gap-1">
+						<Text className="font-poppins font-semibold text-body-4 text-text">
+							Noch keine sichere Stärke
+						</Text>
+						<Text
+							selectable
+							className="font-poppins text-body-4 text-secondary-text"
+						>
+							Dafür fehlen noch wiederholte richtige Antworten.
+						</Text>
+					</View>
+				</View>
+			)}
+
+			{topic.weaknesses.length > 0 ? (
+				<View className="gap-3">
+					<Text className="font-poppins font-semibold text-body-4 text-text">
+						Das fehlt noch
+					</Text>
+					<View className="gap-3 rounded-info bg-wrong-subtle p-4">
+						{topic.weaknesses.map((weakness) => (
+							<View
+								key={weakness.statement}
+								className="flex-row items-start gap-3"
+							>
+								<CircleAlert
+									size={18}
+									color={DAYOVA_DESIGN_SYSTEM.colors.wrong}
+									strokeWidth={2.2}
+								/>
+								<View className="min-w-0 flex-1 gap-1">
+									<Text
+										selectable
+										className="font-poppins text-body-3 text-text"
+									>
+										{formatGermanUiText(weakness.statement)}
+									</Text>
+									<Text className="font-poppins text-body-5 text-secondary-text">
+										{weakness.evidenceCount > 0
+											? `${weakness.evidenceCount} ${weakness.evidenceCount === 1 ? "Beleg" : "Belege"}`
+											: "Noch nicht überprüft"}
+									</Text>
+								</View>
+							</View>
+						))}
+					</View>
+				</View>
+			) : null}
+
+			{topic.controlCheckReason ? (
+				<View className="flex-row items-start gap-3 rounded-info bg-system-subtle p-4">
+					<Info
+						size={19}
+						color={DAYOVA_DESIGN_SYSTEM.colors.primaryStrong}
+						strokeWidth={2.2}
+					/>
+					<View className="min-w-0 flex-1 gap-1">
+						<Text className="font-poppins font-semibold text-body-4 text-primary-strong">
+							Kontrollbeleg nötig
+						</Text>
+						<Text selectable className="font-poppins text-body-4 text-text">
+							{topic.controlCheckReason}
+						</Text>
+					</View>
+				</View>
+			) : null}
+		</Surface>
+	);
+}
+
+function KnowledgeDetailContent({
+	analysis,
+	initialTopicId,
+}: {
+	analysis: ExamAnalysis;
+	initialTopicId?: string;
+}) {
+	const [selectedTopicId, setSelectedTopicId] = useState(
+		initialTopicId ?? analysis.topics[0]?.id,
+	);
+	const selectedTopic =
+		analysis.topics.find((topic) => topic.id === selectedTopicId) ??
+		analysis.topics[0];
+
+	if (!selectedTopic) {
+		return (
+			<Surface className="gap-2 p-5" variant="flat">
+				<Text className="font-poppins font-semibold text-body-3 text-text">
+					Noch keine Prüfungsthemen
+				</Text>
+				<Text
+					selectable
+					className="font-poppins text-body-4 text-secondary-text"
+				>
+					Sobald dein Lernplan Themen enthält, erscheinen hier deine Belege.
+				</Text>
 			</Surface>
+		);
+	}
+
+	return (
+		<View className="gap-8">
+			<TopicDetailCard topic={selectedTopic} />
+			<View className="gap-4">
+				<SectionHeading
+					title="Alle Prüfungsthemen"
+					description="Nach aktuellem Lernrisiko sortiert."
+				/>
+				<Surface className="overflow-hidden" variant="flat">
+					<TopicList
+						onOpenTopic={setSelectedTopicId}
+						selectedTopicId={selectedTopic.id}
+						topics={analysis.topics}
+					/>
+				</Surface>
+			</View>
 		</View>
 	);
 }
@@ -1155,14 +1187,6 @@ export function AnalyticsScreen() {
 					) : analysis.hasData ? (
 						<AnalysisHub
 							analysis={analysis}
-							onOpenKnowledge={() => {
-								if (selectedPlanIdForRoute) {
-									router.push({
-										pathname: ROUTES.analyticsKnowledge,
-										params: { planId: selectedPlanIdForRoute },
-									});
-								}
-							}}
 							onOpenNextStep={() => {
 								if (selectedPlanIdForRoute) {
 									router.push({
@@ -1171,11 +1195,11 @@ export function AnalyticsScreen() {
 									});
 								}
 							}}
-							onOpenProblem={() => {
+							onOpenTopic={(topicId) => {
 								if (selectedPlanIdForRoute) {
 									router.push({
-										pathname: ROUTES.analyticsProblem,
-										params: { planId: selectedPlanIdForRoute },
+										pathname: ROUTES.analyticsKnowledge,
+										params: { planId: selectedPlanIdForRoute, topicId },
 									});
 								}
 							}}
@@ -1374,8 +1398,7 @@ export function AnalyticsHistoryScreen() {
 export type AnalyticsDetailSection = "knowledge" | "problem" | "nextStep";
 
 const DETAIL_DESCRIPTION: Record<AnalyticsDetailSection, string> = {
-	knowledge:
-		"Was du sicher kannst, was noch offen ist und wie dein Prüfungsstoff eingeordnet wird.",
+	knowledge: "Stärken, Lücken und Belege – Thema für Thema.",
 	problem:
 		"Welche Antwort die Hürde zeigt und welches Missverständnis dahinterliegt.",
 	nextStep:
@@ -1384,23 +1407,23 @@ const DETAIL_DESCRIPTION: Record<AnalyticsDetailSection, string> = {
 
 function AnalyticsDetailContent({
 	analysis,
+	initialTopicId,
 	onOpenPlan,
 	onOpenSession,
 	section,
 }: {
 	analysis: ExamAnalysis;
+	initialTopicId?: string;
 	onOpenPlan: () => void;
 	onOpenSession: (sessionId: Id<"learningPlanSessions">) => void;
 	section: AnalyticsDetailSection;
 }) {
 	if (section === "knowledge") {
 		return (
-			<View className="gap-9">
-				<ReadinessSummary analysis={analysis} />
-				<AbilitySection abilities={analysis.abilities} />
-				<ImprovementSection improvements={analysis.improvements} />
-				<TopicOverview topics={analysis.topics} />
-			</View>
+			<KnowledgeDetailContent
+				analysis={analysis}
+				initialTopicId={initialTopicId}
+			/>
 		);
 	}
 
@@ -1428,9 +1451,11 @@ function AnalyticsDetailContent({
 export function AnalyticsDetailScreen({
 	planId,
 	section,
+	topicId,
 }: {
 	planId?: Id<"learningPlans">;
 	section: AnalyticsDetailSection;
+	topicId?: string;
 }) {
 	const router = useRouter();
 	const analysis = useExamAnalysisQuery(planId);
@@ -1471,6 +1496,7 @@ export function AnalyticsDetailScreen({
 						</View>
 						<AnalyticsDetailContent
 							analysis={analysis}
+							initialTopicId={topicId}
 							onOpenPlan={() => {
 								if (selectedPlanIdForRoute) {
 									router.push(`/learning-plans/${selectedPlanIdForRoute}`);

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -69,26 +69,22 @@ const TOPIC_STATUS_COPY: Record<
 	TopicStatus,
 	{
 		label: string;
-		dotClassName: string;
 		pillClassName: string;
 		textClassName: string;
 	}
 > = {
 	secure: {
 		label: "Sicher belegt",
-		dotClassName: "bg-success",
 		pillClassName: "bg-success-subtle",
 		textClassName: "text-success",
 	},
 	developing: {
 		label: "Im Aufbau",
-		dotClassName: "bg-info",
 		pillClassName: "bg-info-subtle",
 		textClassName: "text-info",
 	},
 	unknown: {
 		label: "Noch nicht belegt",
-		dotClassName: "bg-path-3",
 		pillClassName: "bg-light-2",
 		textClassName: "text-secondary-text",
 	},
@@ -118,8 +114,8 @@ const formatRemainingDays = (days: number) => {
 	return `Noch ${days} Tage`;
 };
 
-const KNOWLEDGE_RING_SIZE = 112;
-const KNOWLEDGE_RING_STROKE_WIDTH = 10;
+const KNOWLEDGE_RING_SIZE = 96;
+const KNOWLEDGE_RING_STROKE_WIDTH = 9;
 const KNOWLEDGE_RING_RADIUS =
 	(KNOWLEDGE_RING_SIZE - KNOWLEDGE_RING_STROKE_WIDTH) / 2;
 const KNOWLEDGE_RING_CIRCUMFERENCE = 2 * Math.PI * KNOWLEDGE_RING_RADIUS;
@@ -142,7 +138,7 @@ function KnowledgeProgressRing({
 	const progressOffset = KNOWLEDGE_RING_CIRCUMFERENCE * (1 - progress);
 
 	return (
-		<View accessible={false} className="h-28 w-28 items-center justify-center">
+		<View accessible={false} className="h-24 w-24 items-center justify-center">
 			<Svg
 				pointerEvents="none"
 				width={KNOWLEDGE_RING_SIZE}
@@ -324,64 +320,62 @@ function AnalysisHub({
 		analysis.readiness.unknown;
 	const hasKnowledgeEvidence =
 		totalTopics > 0 && analysis.topics.some((topic) => topic.evidenceCount > 0);
+	const remainingStatusSummary = hasKnowledgeEvidence
+		? [
+				analysis.readiness.developing > 0
+					? `${analysis.readiness.developing} im Aufbau`
+					: null,
+				analysis.readiness.unknown > 0
+					? `${analysis.readiness.unknown} noch nicht belegt`
+					: null,
+			]
+				.filter(Boolean)
+				.join(" · ") || "Alle Themen sind sicher belegt"
+		: "Noch kein Thema überprüft";
 
 	return (
-		<View className="gap-4">
-			<Surface
-				className="overflow-hidden border border-border"
-				style={continuousCardStyle}
-				variant="flat"
-			>
-				<View className="gap-4 p-5">
-					<View className="flex-row items-center gap-4">
-						<KnowledgeProgressRing
-							secureTopics={analysis.readiness.secure}
-							totalTopics={hasKnowledgeEvidence ? totalTopics : 0}
-						/>
-						<View className="min-w-0 flex-1 gap-1">
-							<Text className="font-poppins font-semibold text-body-3 text-primary-strong">
-								Dein Wissensstand
-							</Text>
-							<Text
-								selectable
-								className="font-poppins font-semibold text-body-1 text-text"
-							>
-								{hasKnowledgeEvidence
-									? `${analysis.readiness.secure} von ${totalTopics} Themen sicher`
-									: "Noch keine Wissensbelege"}
-							</Text>
-							<Text
-								selectable
-								className="font-poppins text-body-5 text-secondary-text"
-							>
-								Nach aktuellem Lernrisiko sortiert
-							</Text>
-						</View>
-					</View>
-					<View className="flex-row flex-wrap gap-x-4 gap-y-2">
-						{(
-							[
-								["secure", analysis.readiness.secure],
-								["developing", analysis.readiness.developing],
-								["unknown", analysis.readiness.unknown],
-							] as const
-						).map(([statusKey, count]) => {
-							const status = TOPIC_STATUS_COPY[statusKey];
-							return (
-								<View key={statusKey} className="flex-row items-center gap-2">
-									<View
-										className={cn("h-2 w-2 rounded-full", status.dotClassName)}
-									/>
-									<Text className="font-poppins text-body-5 text-secondary-text">
-										{`${count} ${status.label}`}
-									</Text>
-								</View>
-							);
-						})}
+		<View className="gap-7">
+			<Surface className="p-5" style={continuousCardStyle} variant="flat">
+				<View className="flex-row items-center gap-4">
+					<KnowledgeProgressRing
+						secureTopics={analysis.readiness.secure}
+						totalTopics={hasKnowledgeEvidence ? totalTopics : 0}
+					/>
+					<View className="min-w-0 flex-1 gap-1">
+						<Text className="font-poppins font-semibold text-body-4 text-primary-strong">
+							Dein Wissensstand
+						</Text>
+						<Text
+							selectable
+							className="font-poppins font-semibold text-body-1 text-text"
+						>
+							{hasKnowledgeEvidence
+								? `${analysis.readiness.secure} von ${totalTopics} sicher belegt`
+								: "Noch keine Wissensbelege"}
+						</Text>
+						<Text
+							selectable
+							className="font-poppins text-body-5 text-secondary-text"
+						>
+							{remainingStatusSummary}
+						</Text>
 					</View>
 				</View>
-				<TopicList topics={analysis.topics} onOpenTopic={onOpenTopic} />
 			</Surface>
+
+			<View className="gap-4">
+				<SectionHeading
+					title="Deine Prüfungsthemen"
+					description="Nach aktuellem Lernrisiko sortiert."
+				/>
+				<Surface
+					className="overflow-hidden"
+					style={continuousCardStyle}
+					variant="flat"
+				>
+					<TopicList topics={analysis.topics} onOpenTopic={onOpenTopic} />
+				</Surface>
+			</View>
 
 			<ActionSurface
 				accessibilityHint="Öffnet deinen empfohlenen nächsten Lernschritt."
@@ -695,6 +689,7 @@ function TopicStatusPill({ status }: { status: TopicStatus }) {
 	return (
 		<View className={cn("rounded-full px-3 py-1.5", copy.pillClassName)}>
 			<Text
+				selectable
 				className={cn(
 					"font-poppins font-semibold text-body-5",
 					copy.textClassName,
@@ -709,58 +704,38 @@ function TopicStatusPill({ status }: { status: TopicStatus }) {
 
 function TopicList({
 	onOpenTopic,
-	selectedTopicId,
 	topics,
 }: {
 	onOpenTopic: (topicId: string) => void;
-	selectedTopicId?: string;
 	topics: ExamAnalysis["topics"];
 }) {
 	const { colors } = useDayovaTheme();
 
-	return topics.map((topic) => {
+	return topics.map((topic, index) => {
 		const status = TOPIC_STATUS_COPY[topic.status];
-		const selected = topic.id === selectedTopicId;
 		return (
 			<ActionSurface
 				key={topic.id}
 				accessibilityHint="Öffnet Stärken, Lücken und Wissensbelege für dieses Thema."
 				accessibilityLabel={`${topic.title}. ${status.label}. ${topic.summary}`}
 				accessibilityRole="button"
-				accessibilityState={{ selected }}
 				className={cn(
-					"flex-row items-center gap-3 border-border border-t bg-card px-5 py-4",
-					selected && "bg-system-subtle",
+					"min-h-16 flex-row items-center gap-3 bg-card px-4 py-3",
+					index > 0 && "border-border border-t",
 				)}
 				onPress={() => onOpenTopic(topic.id)}
 				variant="flat"
 			>
-				<View
-					accessible={false}
-					className={cn(
-						"h-10 w-10 items-center justify-center rounded-full",
-						status.pillClassName,
-					)}
-				>
-					<View className={cn("h-3 w-3 rounded-full", status.dotClassName)} />
-				</View>
-				<View className="min-w-0 flex-1 gap-1">
+				<View className="min-w-0 flex-1">
 					<Text
 						selectable
 						className="font-poppins font-semibold text-body-3 text-text"
-						numberOfLines={2}
+						numberOfLines={3}
 					>
 						{formatGermanUiText(topic.title)}
 					</Text>
-					<Text
-						selectable
-						className="font-poppins text-body-5 text-secondary-text"
-						numberOfLines={2}
-					>
-						{formatGermanUiText(topic.summary)}
-					</Text>
 				</View>
-				<View className="items-end gap-2">
+				<View className="flex-row items-center gap-2">
 					<TopicStatusPill status={topic.status} />
 					<ArrowRight
 						size={17}
@@ -779,14 +754,15 @@ function TopicDetailCard({ topic }: { topic: ExamAnalysis["topics"][number] }) {
 	);
 
 	return (
-		<Surface className="gap-6 p-5" variant="flat">
-			<View className="gap-3">
-				<View className="flex-row flex-wrap items-center justify-between gap-3">
-					<View className="rounded-full bg-background px-3 py-1.5">
-						<Text className="font-poppins font-semibold text-body-5 text-secondary-text">
-							{PRIORITY_COPY[topic.priority]}
-						</Text>
-					</View>
+		<View className="gap-8">
+			<Surface className="gap-4 p-5" variant="flat">
+				<View className="flex-row items-center justify-between gap-3">
+					<Text
+						selectable
+						className="min-w-0 flex-1 font-poppins font-semibold text-body-5 text-primary-strong"
+					>
+						{PRIORITY_COPY[topic.priority]}
+					</Text>
 					<TopicStatusPill status={topic.status} />
 				</View>
 				<View className="gap-1">
@@ -803,18 +779,16 @@ function TopicDetailCard({ topic }: { topic: ExamAnalysis["topics"][number] }) {
 						{formatGermanUiText(topic.learningGoal)}
 					</Text>
 				</View>
-			</View>
+			</Surface>
 
 			<View className="gap-3">
-				<Text className="font-poppins font-semibold text-body-4 text-text">
-					Dein Wissensprofil
-				</Text>
-				<View className="overflow-hidden rounded-info border border-border">
+				<SectionHeading title="Dein Wissensprofil" />
+				<Surface className="overflow-hidden" variant="flat">
 					{requiredDimensions.map((dimension, index) => (
 						<View
 							key={dimension.kind}
 							className={cn(
-								"flex-row items-center justify-between gap-3 bg-card px-4 py-3",
+								"flex-row items-center justify-between gap-3 bg-card px-4 py-4",
 								index > 0 && "border-border border-t",
 							)}
 						>
@@ -822,7 +796,10 @@ function TopicDetailCard({ topic }: { topic: ExamAnalysis["topics"][number] }) {
 								<Text className="font-poppins font-semibold text-body-3 text-text">
 									{EVIDENCE_DIMENSION_COPY[dimension.kind]}
 								</Text>
-								<Text className="font-poppins text-body-5 text-secondary-text">
+								<Text
+									selectable
+									className="font-poppins text-body-5 text-secondary-text"
+								>
 									{dimension.evidenceCount === 0
 										? "Noch kein Beleg"
 										: `${dimension.evidenceCount} ${dimension.evidenceCount === 1 ? "Beleg" : "Belege"}`}
@@ -831,25 +808,28 @@ function TopicDetailCard({ topic }: { topic: ExamAnalysis["topics"][number] }) {
 							<TopicStatusPill status={dimension.status} />
 						</View>
 					))}
-				</View>
+				</Surface>
 			</View>
 
 			{topic.strengths.length > 0 ? (
 				<View className="gap-3">
-					<Text className="font-poppins font-semibold text-body-4 text-text">
-						Das kannst du schon
-					</Text>
-					<View className="gap-3 rounded-info bg-success-subtle p-4">
-						{topic.strengths.map((strength) => (
+					<SectionHeading title="Das kannst du schon" />
+					<Surface className="gap-4 p-5" variant="flat">
+						{topic.strengths.map((strength, index) => (
 							<View
 								key={strength.statement}
-								className="flex-row items-start gap-3"
+								className={cn(
+									"flex-row items-start gap-3",
+									index > 0 && "border-border border-t pt-4",
+								)}
 							>
-								<Check
-									size={18}
-									color={DAYOVA_DESIGN_SYSTEM.colors.success}
-									strokeWidth={2.3}
-								/>
+								<View className="h-8 w-8 items-center justify-center rounded-full bg-success-subtle">
+									<Check
+										size={16}
+										color={DAYOVA_DESIGN_SYSTEM.colors.success}
+										strokeWidth={2.3}
+									/>
+								</View>
 								<View className="min-w-0 flex-1 gap-1">
 									<Text
 										selectable
@@ -863,45 +843,53 @@ function TopicDetailCard({ topic }: { topic: ExamAnalysis["topics"][number] }) {
 								</View>
 							</View>
 						))}
-					</View>
+					</Surface>
 				</View>
 			) : (
-				<View className="flex-row items-start gap-3 rounded-info bg-background p-4">
-					<Info
-						size={19}
-						color={DAYOVA_DESIGN_SYSTEM.colors.primaryStrong}
-						strokeWidth={2.2}
-					/>
-					<View className="min-w-0 flex-1 gap-1">
-						<Text className="font-poppins font-semibold text-body-4 text-text">
-							Noch keine sichere Stärke
-						</Text>
-						<Text
-							selectable
-							className="font-poppins text-body-4 text-secondary-text"
-						>
-							Dafür fehlen noch wiederholte richtige Antworten.
-						</Text>
-					</View>
+				<View className="gap-3">
+					<SectionHeading title="Das kannst du schon" />
+					<Surface className="flex-row items-start gap-3 p-5" variant="flat">
+						<View className="h-8 w-8 items-center justify-center rounded-full bg-system-subtle">
+							<Info
+								size={17}
+								color={DAYOVA_DESIGN_SYSTEM.colors.primaryStrong}
+								strokeWidth={2.2}
+							/>
+						</View>
+						<View className="min-w-0 flex-1 gap-1">
+							<Text className="font-poppins font-semibold text-body-4 text-text">
+								Noch keine sichere Stärke
+							</Text>
+							<Text
+								selectable
+								className="font-poppins text-body-4 text-secondary-text"
+							>
+								Dafür fehlen noch wiederholte richtige Antworten.
+							</Text>
+						</View>
+					</Surface>
 				</View>
 			)}
 
 			{topic.weaknesses.length > 0 ? (
 				<View className="gap-3">
-					<Text className="font-poppins font-semibold text-body-4 text-text">
-						Das fehlt noch
-					</Text>
-					<View className="gap-3 rounded-info bg-wrong-subtle p-4">
-						{topic.weaknesses.map((weakness) => (
+					<SectionHeading title="Das fehlt noch" />
+					<Surface className="gap-4 p-5" variant="flat">
+						{topic.weaknesses.map((weakness, index) => (
 							<View
 								key={weakness.statement}
-								className="flex-row items-start gap-3"
+								className={cn(
+									"flex-row items-start gap-3",
+									index > 0 && "border-border border-t pt-4",
+								)}
 							>
-								<CircleAlert
-									size={18}
-									color={DAYOVA_DESIGN_SYSTEM.colors.wrong}
-									strokeWidth={2.2}
-								/>
+								<View className="h-8 w-8 items-center justify-center rounded-full bg-wrong-subtle">
+									<CircleAlert
+										size={16}
+										color={DAYOVA_DESIGN_SYSTEM.colors.wrong}
+										strokeWidth={2.2}
+									/>
+								</View>
 								<View className="min-w-0 flex-1 gap-1">
 									<Text
 										selectable
@@ -917,12 +905,15 @@ function TopicDetailCard({ topic }: { topic: ExamAnalysis["topics"][number] }) {
 								</View>
 							</View>
 						))}
-					</View>
+					</Surface>
 				</View>
 			) : null}
 
 			{topic.controlCheckReason ? (
-				<View className="flex-row items-start gap-3 rounded-info bg-system-subtle p-4">
+				<Surface
+					className="flex-row items-start gap-3 rounded-info border border-primary/20 bg-system-subtle p-4"
+					variant="flat"
+				>
 					<Info
 						size={19}
 						color={DAYOVA_DESIGN_SYSTEM.colors.primaryStrong}
@@ -936,9 +927,9 @@ function TopicDetailCard({ topic }: { topic: ExamAnalysis["topics"][number] }) {
 							{topic.controlCheckReason}
 						</Text>
 					</View>
-				</View>
+				</Surface>
 			) : null}
-		</Surface>
+		</View>
 	);
 }
 
@@ -949,11 +940,8 @@ function KnowledgeDetailContent({
 	analysis: ExamAnalysis;
 	initialTopicId?: string;
 }) {
-	const [selectedTopicId, setSelectedTopicId] = useState(
-		initialTopicId ?? analysis.topics[0]?.id,
-	);
 	const selectedTopic =
-		analysis.topics.find((topic) => topic.id === selectedTopicId) ??
+		analysis.topics.find((topic) => topic.id === initialTopicId) ??
 		analysis.topics[0];
 
 	if (!selectedTopic) {
@@ -972,24 +960,7 @@ function KnowledgeDetailContent({
 		);
 	}
 
-	return (
-		<View className="gap-8">
-			<TopicDetailCard topic={selectedTopic} />
-			<View className="gap-4">
-				<SectionHeading
-					title="Alle Prüfungsthemen"
-					description="Nach aktuellem Lernrisiko sortiert."
-				/>
-				<Surface className="overflow-hidden" variant="flat">
-					<TopicList
-						onOpenTopic={setSelectedTopicId}
-						selectedTopicId={selectedTopic.id}
-						topics={analysis.topics}
-					/>
-				</Surface>
-			</View>
-		</View>
-	);
+	return <TopicDetailCard topic={selectedTopic} />;
 }
 
 function PreparationSummary({
@@ -1397,8 +1368,8 @@ export function AnalyticsHistoryScreen() {
 
 export type AnalyticsDetailSection = "knowledge" | "problem" | "nextStep";
 
-const DETAIL_DESCRIPTION: Record<AnalyticsDetailSection, string> = {
-	knowledge: "Stärken, Lücken und Belege – Thema für Thema.",
+const DETAIL_DESCRIPTION: Record<AnalyticsDetailSection, string | null> = {
+	knowledge: null,
 	problem:
 		"Welche Antwort die Hürde zeigt und welches Missverständnis dahinterliegt.",
 	nextStep:
@@ -1487,12 +1458,14 @@ export function AnalyticsDetailScreen({
 									{selectedExamContext}
 								</Text>
 							) : null}
-							<Text
-								selectable
-								className="font-poppins text-body-2 text-secondary-text"
-							>
-								{DETAIL_DESCRIPTION[section]}
-							</Text>
+							{DETAIL_DESCRIPTION[section] ? (
+								<Text
+									selectable
+									className="font-poppins text-body-2 text-secondary-text"
+								>
+									{DETAIL_DESCRIPTION[section]}
+								</Text>
+							) : null}
 						</View>
 						<AnalyticsDetailContent
 							analysis={analysis}

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -19,7 +19,6 @@ import {
 	Info,
 	Sparkles,
 	Time04,
-	TimeManagement,
 } from "~/components/ui/icon";
 import { Screen, ScreenScroll } from "~/components/ui/screen";
 import { SelectSheet } from "~/components/ui/select-sheet";
@@ -307,13 +306,11 @@ function AnalysisHub({
 	onOpenKnowledge,
 	onOpenNextStep,
 	onOpenProblem,
-	onOpenHistory,
 }: {
 	analysis: ExamAnalysis;
 	onOpenKnowledge: () => void;
 	onOpenNextStep: () => void;
 	onOpenProblem: () => void;
-	onOpenHistory: () => void;
 }) {
 	const { colors } = useDayovaTheme();
 	const recommendation = analysis.recommendation;
@@ -452,24 +449,6 @@ function AnalysisHub({
 					</View>
 				</View>
 				<ArrowRight size={19} color={colors.primaryStrong} strokeWidth={2.2} />
-			</ActionSurface>
-
-			<ActionSurface
-				accessibilityLabel="Deine Entwicklung über mehrere Prüfungen öffnen"
-				accessibilityRole="button"
-				className="flex-row items-center gap-3 rounded-info bg-transparent px-4 py-3"
-				onPress={onOpenHistory}
-				variant="flat"
-			>
-				<TimeManagement
-					size={19}
-					color={colors.secondaryText}
-					strokeWidth={2.1}
-				/>
-				<Text className="min-w-0 flex-1 font-poppins font-semibold text-body-4 text-secondary-text">
-					Deine Entwicklung über mehrere Prüfungen
-				</Text>
-				<ArrowRight size={17} color={colors.secondaryText} strokeWidth={2.1} />
 			</ActionSurface>
 		</View>
 	);
@@ -1200,7 +1179,6 @@ export function AnalyticsScreen() {
 									});
 								}
 							}}
-							onOpenHistory={() => router.push(ROUTES.analyticsHistory)}
 						/>
 					) : (
 						<EmptyState

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -235,6 +235,41 @@ const examAnalysis = {
 			learningGoal: "Du kannst die Steigung vollständig erklären.",
 			priority: "high",
 			status: "developing",
+			summary: "Steigung noch präziser erklären.",
+			evidenceCount: 2,
+			dimensions: [
+				{
+					kind: "understanding",
+					required: true,
+					status: "secure",
+					evidenceCount: 2,
+				},
+				{
+					kind: "problemSolving",
+					required: true,
+					status: "developing",
+					evidenceCount: 1,
+				},
+				{
+					kind: "independent",
+					required: true,
+					status: "unknown",
+					evidenceCount: 0,
+				},
+			],
+			strengths: [
+				{
+					statement: "Du erkennst lineare Zusammenhänge.",
+					evidenceCount: 2,
+				},
+			],
+			weaknesses: [
+				{
+					statement: "Steigung noch präziser erklären.",
+					evidenceCount: 1,
+				},
+			],
+			controlCheckReason: null,
 		},
 		{
 			id: "achsenschnitt",
@@ -242,6 +277,36 @@ const examAnalysis = {
 			learningGoal: "Du kannst Achsenschnittpunkte sicher bestimmen.",
 			priority: "medium",
 			status: "secure",
+			summary: "Alle erforderlichen Wissensbelege vorhanden.",
+			evidenceCount: 3,
+			dimensions: [
+				{
+					kind: "understanding",
+					required: true,
+					status: "secure",
+					evidenceCount: 3,
+				},
+				{
+					kind: "problemSolving",
+					required: true,
+					status: "secure",
+					evidenceCount: 2,
+				},
+				{
+					kind: "independent",
+					required: true,
+					status: "secure",
+					evidenceCount: 2,
+				},
+			],
+			strengths: [
+				{
+					statement: "Du bestimmst Achsenschnittpunkte sicher.",
+					evidenceCount: 3,
+				},
+			],
+			weaknesses: [],
+			controlCheckReason: null,
 		},
 	],
 	recommendation: {
@@ -322,12 +387,14 @@ describe("AnalyticsScreen", () => {
 		expect(mockPush).toHaveBeenCalledWith("/learning-plans/new");
 	});
 
-	test("summarizes secure knowledge and keeps details behind the card", async () => {
+	test("shows every topic and opens its exact knowledge evidence", async () => {
 		mockUseQuery.mockReturnValue(examAnalysis);
 		const screen = await render(<AnalyticsScreen />);
 
 		expect(screen.getByText("1/2")).toBeOnTheScreen();
-		expect(screen.getByText("Themen sicher belegt")).toBeOnTheScreen();
+		expect(screen.getByText("1 von 2 Themen sicher")).toBeOnTheScreen();
+		expect(screen.getByText("Steigung erklären")).toBeOnTheScreen();
+		expect(screen.getByText("Achsenschnittpunkte bestimmen")).toBeOnTheScreen();
 		expect(
 			screen.getByText("Steigung noch präziser erklären."),
 		).toBeOnTheScreen();
@@ -345,7 +412,7 @@ describe("AnalyticsScreen", () => {
 		).not.toBeOnTheScreen();
 		expect(screen.getByText("Dein nächster Schritt")).toBeOnTheScreen();
 		expect(screen.getByText("Dein Wissensstand")).toBeOnTheScreen();
-		expect(screen.getByText("Größte Lernhürde")).toBeOnTheScreen();
+		expect(screen.queryByText("Größte Lernhürde")).not.toBeOnTheScreen();
 		expect(screen.queryByText("Dein Prüfungsstoff")).not.toBeOnTheScreen();
 		expect(
 			screen.queryByText("Deine Entwicklung über mehrere Prüfungen"),
@@ -363,22 +430,12 @@ describe("AnalyticsScreen", () => {
 
 		await fireEvent.press(
 			screen.getByRole("button", {
-				name: "Lernhürde: Steigung noch präziser erklären. Details öffnen",
-			}),
-		);
-		expect(mockPush).toHaveBeenCalledWith({
-			pathname: "/analyse/lernhuerde",
-			params: { planId: "plan_1" },
-		});
-
-		await fireEvent.press(
-			screen.getByRole("button", {
-				name: "Wissensstand: 1 von 2 Themen sicher belegt. Details öffnen",
+				name: "Steigung erklären. Im Aufbau. Steigung noch präziser erklären.",
 			}),
 		);
 		expect(mockPush).toHaveBeenCalledWith({
 			pathname: "/analyse/wissensstand",
-			params: { planId: "plan_1" },
+			params: { planId: "plan_1", topicId: "steigung" },
 		});
 	});
 
@@ -394,11 +451,8 @@ describe("AnalyticsScreen", () => {
 		const screen = await render(<AnalyticsScreen />);
 
 		expect(screen.getByText("0/5")).toBeOnTheScreen();
-		expect(
-			screen.getByRole("button", {
-				name: "Wissensstand: 0 von 5 Themen sicher belegt. Details öffnen",
-			}),
-		).toBeOnTheScreen();
+		expect(screen.getByText("0 von 5 Themen sicher")).toBeOnTheScreen();
+		expect(screen.getByText("0 Sicher belegt")).toBeOnTheScreen();
 		expect(
 			screen.queryByText(
 				"Du arbeitest an allen 5 Prüfungsthemen, aber noch keines ist sicher belegt.",
@@ -412,24 +466,53 @@ describe("AnalyticsScreen", () => {
 			readiness: {
 				secure: 0,
 				developing: 0,
-				unknown: 0,
+				unknown: 2,
 			},
+			topics: examAnalysis.topics.map((topic) => ({
+				...topic,
+				status: "unknown",
+				summary: "Noch keine überprüften Antworten.",
+				evidenceCount: 0,
+				dimensions: topic.dimensions.map((dimension) => ({
+					...dimension,
+					status: "unknown",
+					evidenceCount: 0,
+				})),
+				strengths: [],
+				weaknesses: [],
+				controlCheckReason: null,
+			})),
 		});
 		const screen = await render(<AnalyticsScreen />);
 
 		expect(screen.getByText("–")).toBeOnTheScreen();
-		expect(screen.getByText("Noch keine Themen bewertet")).toBeOnTheScreen();
-		expect(
-			screen.getByRole("button", {
-				name: "Wissensstand: Noch keine Prüfungsthemen bewertet. Details öffnen",
-			}),
-		).toBeOnTheScreen();
-		expect(screen.queryByText("0/0")).not.toBeOnTheScreen();
+		expect(screen.getByText("Noch keine Wissensbelege")).toBeOnTheScreen();
+		expect(screen.queryByText("0/2")).not.toBeOnTheScreen();
 	});
 
 	test("reveals evidence and starts the recommendation from focused pages", async () => {
 		mockUseQuery.mockReturnValue(examAnalysis);
 		const planId = "plan_1" as Id<"learningPlans">;
+		const knowledgeScreen = await render(
+			<AnalyticsDetailScreen
+				planId={planId}
+				section="knowledge"
+				topicId="steigung"
+			/>,
+		);
+
+		expect(knowledgeScreen.getByText("Dein Wissensprofil")).toBeOnTheScreen();
+		expect(knowledgeScreen.getByText("Verstehen")).toBeOnTheScreen();
+		expect(knowledgeScreen.getByText("Probleme lösen")).toBeOnTheScreen();
+		expect(knowledgeScreen.getByText("Selbstständig lösen")).toBeOnTheScreen();
+		expect(
+			knowledgeScreen.getByText("Du erkennst lineare Zusammenhänge."),
+		).toBeOnTheScreen();
+		expect(
+			knowledgeScreen.getAllByText("Steigung noch präziser erklären."),
+		).not.toHaveLength(0);
+
+		await knowledgeScreen.unmount();
 		const problemScreen = await render(
 			<AnalyticsDetailScreen planId={planId} section="problem" />,
 		);

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -347,6 +347,9 @@ describe("AnalyticsScreen", () => {
 		expect(screen.getByText("Dein Wissensstand")).toBeOnTheScreen();
 		expect(screen.getByText("Größte Lernhürde")).toBeOnTheScreen();
 		expect(screen.queryByText("Dein Prüfungsstoff")).not.toBeOnTheScreen();
+		expect(
+			screen.queryByText("Deine Entwicklung über mehrere Prüfungen"),
+		).not.toBeOnTheScreen();
 
 		await fireEvent.press(
 			screen.getByRole("button", {

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -129,8 +129,10 @@ jest.mock("~/components/ui/select-sheet", () => {
 jest.mock("~/lib/theme", () => ({
 	useDayovaTheme: () => ({
 		colors: {
+			border: "#DCE6EE",
 			primaryStrong: "#00A0E6",
 			secondaryText: "#697586",
+			success: "#34C759",
 			text: "#151D30",
 			theorie: "#5856D6",
 			wrong: "#FF9500",
@@ -320,23 +322,30 @@ describe("AnalyticsScreen", () => {
 		expect(mockPush).toHaveBeenCalledWith("/learning-plans/new");
 	});
 
-	test("leads with current knowledge and keeps the next step compact", async () => {
+	test("summarizes secure knowledge and keeps details behind the card", async () => {
 		mockUseQuery.mockReturnValue(examAnalysis);
 		const screen = await render(<AnalyticsScreen />);
 
-		expect(
-			screen.getByText("Schon belegt: Du erkennst lineare Zusammenhänge."),
-		).toBeOnTheScreen();
+		expect(screen.getByText("1/2")).toBeOnTheScreen();
+		expect(screen.getByText("Themen sicher belegt")).toBeOnTheScreen();
 		expect(
 			screen.getByText("Steigung noch präziser erklären."),
 		).toBeOnTheScreen();
 		expect(screen.queryByText("„Änderung von y.“")).not.toBeOnTheScreen();
+		expect(
+			screen.queryByText("Schon belegt: Du erkennst lineare Zusammenhänge."),
+		).not.toBeOnTheScreen();
+		expect(
+			screen.queryByText("Du kannst 1 von 2 Prüfungsthemen sicher anwenden."),
+		).not.toBeOnTheScreen();
+		expect(
+			screen.queryByText(
+				"Seit deinem letzten Check: Steigung gelingt dir jetzt sicherer.",
+			),
+		).not.toBeOnTheScreen();
 		expect(screen.getByText("Dein nächster Schritt")).toBeOnTheScreen();
 		expect(screen.getByText("Dein Wissensstand")).toBeOnTheScreen();
 		expect(screen.getByText("Größte Lernhürde")).toBeOnTheScreen();
-		expect(
-			screen.getByText("Du kannst 1 von 2 Prüfungsthemen sicher anwenden."),
-		).toBeOnTheScreen();
 		expect(screen.queryByText("Dein Prüfungsstoff")).not.toBeOnTheScreen();
 
 		await fireEvent.press(
@@ -361,13 +370,58 @@ describe("AnalyticsScreen", () => {
 
 		await fireEvent.press(
 			screen.getByRole("button", {
-				name: "Wissensstand: 1 sicher, 1 in Arbeit, 0 noch unklar. Details öffnen",
+				name: "Wissensstand: 1 von 2 Themen sicher belegt. Details öffnen",
 			}),
 		);
 		expect(mockPush).toHaveBeenCalledWith({
 			pathname: "/analyse/wissensstand",
 			params: { planId: "plan_1" },
 		});
+	});
+
+	test("shows zero of five secure topics without explanatory overview copy", async () => {
+		mockUseQuery.mockReturnValue({
+			...examAnalysis,
+			readiness: {
+				secure: 0,
+				developing: 5,
+				unknown: 0,
+			},
+		});
+		const screen = await render(<AnalyticsScreen />);
+
+		expect(screen.getByText("0/5")).toBeOnTheScreen();
+		expect(
+			screen.getByRole("button", {
+				name: "Wissensstand: 0 von 5 Themen sicher belegt. Details öffnen",
+			}),
+		).toBeOnTheScreen();
+		expect(
+			screen.queryByText(
+				"Du arbeitest an allen 5 Prüfungsthemen, aber noch keines ist sicher belegt.",
+			),
+		).not.toBeOnTheScreen();
+	});
+
+	test("does not present zero evaluated topics as zero progress", async () => {
+		mockUseQuery.mockReturnValue({
+			...examAnalysis,
+			readiness: {
+				secure: 0,
+				developing: 0,
+				unknown: 0,
+			},
+		});
+		const screen = await render(<AnalyticsScreen />);
+
+		expect(screen.getByText("–")).toBeOnTheScreen();
+		expect(screen.getByText("Noch keine Themen bewertet")).toBeOnTheScreen();
+		expect(
+			screen.getByRole("button", {
+				name: "Wissensstand: Noch keine Prüfungsthemen bewertet. Details öffnen",
+			}),
+		).toBeOnTheScreen();
+		expect(screen.queryByText("0/0")).not.toBeOnTheScreen();
 	});
 
 	test("reveals evidence and starts the recommendation from focused pages", async () => {

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -148,6 +148,7 @@ const emptyAnalysis = {
 	readiness: {
 		secure: 0,
 		developing: 0,
+		uncertain: 0,
 		unknown: 0,
 	},
 	abilities: [],
@@ -196,7 +197,8 @@ const examAnalysis = {
 	},
 	readiness: {
 		secure: 1,
-		developing: 1,
+		developing: 0,
+		uncertain: 1,
 		unknown: 0,
 	},
 	abilities: [
@@ -234,7 +236,7 @@ const examAnalysis = {
 			title: "Steigung erklären",
 			learningGoal: "Du kannst die Steigung vollständig erklären.",
 			priority: "high",
-			status: "developing",
+			status: "uncertain",
 			summary: "Steigung noch präziser erklären.",
 			evidenceCount: 2,
 			dimensions: [
@@ -247,7 +249,7 @@ const examAnalysis = {
 				{
 					kind: "problemSolving",
 					required: true,
-					status: "developing",
+					status: "uncertain",
 					evidenceCount: 1,
 				},
 				{
@@ -393,13 +395,13 @@ describe("AnalyticsScreen", () => {
 
 		expect(screen.getByText("1/2")).toBeOnTheScreen();
 		expect(screen.getByText("1 von 2 sicher belegt")).toBeOnTheScreen();
-		expect(screen.getByText("1 im Aufbau")).toBeOnTheScreen();
+		expect(screen.getByText("1 unsicher")).toBeOnTheScreen();
 		expect(screen.getByText("Deine Prüfungsthemen")).toBeOnTheScreen();
 		expect(screen.getByText("Steigung erklären")).toBeOnTheScreen();
 		expect(screen.getByText("Achsenschnittpunkte bestimmen")).toBeOnTheScreen();
 		expect(
-			screen.queryByText("Steigung noch präziser erklären."),
-		).not.toBeOnTheScreen();
+			screen.getByText("Steigung noch präziser erklären."),
+		).toBeOnTheScreen();
 		expect(screen.queryByText("„Änderung von y.“")).not.toBeOnTheScreen();
 		expect(
 			screen.queryByText("Schon belegt: Du erkennst lineare Zusammenhänge."),
@@ -432,7 +434,7 @@ describe("AnalyticsScreen", () => {
 
 		await fireEvent.press(
 			screen.getByRole("button", {
-				name: "Steigung erklären. Im Aufbau. Steigung noch präziser erklären.",
+				name: "Steigung erklären. Unsicher. Steigung noch präziser erklären.",
 			}),
 		);
 		expect(mockPush).toHaveBeenCalledWith({
@@ -447,6 +449,7 @@ describe("AnalyticsScreen", () => {
 			readiness: {
 				secure: 0,
 				developing: 5,
+				uncertain: 0,
 				unknown: 0,
 			},
 		});
@@ -468,6 +471,7 @@ describe("AnalyticsScreen", () => {
 			readiness: {
 				secure: 0,
 				developing: 0,
+				uncertain: 0,
 				unknown: 2,
 			},
 			topics: examAnalysis.topics.map((topic) => ({
@@ -507,6 +511,12 @@ describe("AnalyticsScreen", () => {
 		expect(knowledgeScreen.getByText("Verstehen")).toBeOnTheScreen();
 		expect(knowledgeScreen.getByText("Probleme lösen")).toBeOnTheScreen();
 		expect(knowledgeScreen.getByText("Selbstständig lösen")).toBeOnTheScreen();
+		expect(
+			knowledgeScreen.getByText("Warum du hier unsicher bist"),
+		).toBeOnTheScreen();
+		expect(
+			knowledgeScreen.getByText("In einer Antwort beobachtet"),
+		).toBeOnTheScreen();
 		expect(
 			knowledgeScreen.getByText("Du erkennst lineare Zusammenhänge."),
 		).toBeOnTheScreen();

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -392,12 +392,14 @@ describe("AnalyticsScreen", () => {
 		const screen = await render(<AnalyticsScreen />);
 
 		expect(screen.getByText("1/2")).toBeOnTheScreen();
-		expect(screen.getByText("1 von 2 Themen sicher")).toBeOnTheScreen();
+		expect(screen.getByText("1 von 2 sicher belegt")).toBeOnTheScreen();
+		expect(screen.getByText("1 im Aufbau")).toBeOnTheScreen();
+		expect(screen.getByText("Deine Prüfungsthemen")).toBeOnTheScreen();
 		expect(screen.getByText("Steigung erklären")).toBeOnTheScreen();
 		expect(screen.getByText("Achsenschnittpunkte bestimmen")).toBeOnTheScreen();
 		expect(
-			screen.getByText("Steigung noch präziser erklären."),
-		).toBeOnTheScreen();
+			screen.queryByText("Steigung noch präziser erklären."),
+		).not.toBeOnTheScreen();
 		expect(screen.queryByText("„Änderung von y.“")).not.toBeOnTheScreen();
 		expect(
 			screen.queryByText("Schon belegt: Du erkennst lineare Zusammenhänge."),
@@ -451,8 +453,8 @@ describe("AnalyticsScreen", () => {
 		const screen = await render(<AnalyticsScreen />);
 
 		expect(screen.getByText("0/5")).toBeOnTheScreen();
-		expect(screen.getByText("0 von 5 Themen sicher")).toBeOnTheScreen();
-		expect(screen.getByText("0 Sicher belegt")).toBeOnTheScreen();
+		expect(screen.getByText("0 von 5 sicher belegt")).toBeOnTheScreen();
+		expect(screen.getByText("5 im Aufbau")).toBeOnTheScreen();
 		expect(
 			screen.queryByText(
 				"Du arbeitest an allen 5 Prüfungsthemen, aber noch keines ist sicher belegt.",
@@ -511,6 +513,12 @@ describe("AnalyticsScreen", () => {
 		expect(
 			knowledgeScreen.getAllByText("Steigung noch präziser erklären."),
 		).not.toHaveLength(0);
+		expect(
+			knowledgeScreen.queryByText("Alle Prüfungsthemen"),
+		).not.toBeOnTheScreen();
+		expect(
+			knowledgeScreen.queryByText("Achsenschnittpunkte bestimmen"),
+		).not.toBeOnTheScreen();
 
 		await knowledgeScreen.unmount();
 		const problemScreen = await render(


### PR DESCRIPTION
## What changed

- make the current-exam Analyse page topic-first, with every exam topic visible and sorted by exam relevance and current learning risk
- use four evidence states: `Sicher belegt`, `Im Aufbau`, `Unsicher`, and the neutral `Noch nicht belegt`
- reserve `Unsicher` for a concrete weakness shown by the learner's latest incorrect or partially correct graded answer
- separate the compact secure-topic summary from the topic list so both scan as distinct Dayova surfaces
- show the exact observed reason directly below uncertain topics while keeping other overview rows compact
- open each topic into a focused detail view with `Verstehen`, `Probleme lösen`, and `Selbstständig lösen`
- place `Warum du hier unsicher bist` directly after the evidence profile, including how many answers showed the issue
- split topic details into calm profile, weakness, strength, and control-check sections and rely on native back navigation instead of repeating every topic below the detail
- show topic-scoped strengths, exact observed gaps, evidence counts, and a neutral no-strength state
- mark contradictory new answers as `Kontrollbeleg nötig` instead of erasing earlier evidence
- let newly generated topic maps declare which evidence dimensions the exact exam actually requires; legacy topics conservatively require all three
- keep the secure-topic ring as a compact summary, but show a dash instead of `0/x` when no knowledge evidence exists
- remove the duplicated largest-hurdle card from the overview; its evidence now lives with the affected topic
- retain the focused next-step and existing detailed problem screens

## Evidence model

- stronger evidence supports lower dimensions: independent exam performance can also support problem solving and understanding
- lower-strength evidence never proves a higher dimension
- a topic becomes secure only when every exam-required dimension is securely evidenced
- a recent non-correct graded answer makes the affected dimension and topic uncertain when it does not contradict an earlier secure pattern
- missing evidence alone remains `Noch nicht belegt`; it never becomes a demonstrated weakness
- a relevant new error that contradicts secure history moves the dimension back to developing and requests a control evidence check
- activity, confidence, and completed theory review alone never count as secure knowledge

## Validation

- full Vitest suite: 86 files, 517 tests passed
- full UI suite: 27 suites, 76 tests passed
- targeted analytics backend: 7 tests passed
- targeted analytics UI: 8 tests passed
- targeted Biome and ESLint checks passed
- `pnpm typecheck` passed
- inspected the four-state topic overview and Subnetting detail on an iPhone 17 simulator in dark mode, including five simultaneous uncertain topics, long exact reasons, status pills, hierarchy, and accessibility labels

## Existing validation issue

`pnpm check` still reports two pre-existing React Hook lint errors in `src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx` (`react-hooks/exhaustive-deps` and `react-hooks/set-state-in-effect`). This PR does not modify that file.
