### PR TITLE
Build adaptive rolling learning plans

### DIFF
--- a/convex/adaptiveLearningPlan.ts
+++ b/convex/adaptiveLearningPlan.ts
@@ -1,0 +1,465 @@
+import type { Doc, Id } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
+import {
+	type AdaptiveLearningTarget,
+	type AdaptiveTargetHistory,
+	type AdaptiveTopicEvidence,
+	adaptiveSessionCopy,
+	selectNextAdaptiveLearningTarget,
+} from "./adaptiveLearningPlanPolicy";
+import { deleteSessionLearningDataForSession } from "./learningSessionContent";
+import { normalizeLearningTopics } from "./learningTopicMap";
+import { getScheduleConflictMessage } from "./scheduleConflicts";
+
+const MAX_LEARNING_TIMES = 50;
+
+type RollingPlanCalendar = {
+	clearSession: (
+		ctx: MutationCtx,
+		session: Doc<"learningPlanSessions">,
+	) => Promise<void>;
+	syncSession: (
+		ctx: MutationCtx,
+		plan: Doc<"learningPlans">,
+		session: Doc<"learningPlanSessions">,
+	) => Promise<unknown>;
+};
+
+const getSessionExecutionStatus = (session: Doc<"learningPlanSessions">) =>
+	session.executionStatus ?? (session.completed ? "completed" : "notStarted");
+
+const getAdaptiveEvidenceDimension = (
+	item: Doc<"learningSessionContentItems">,
+): AdaptiveTopicEvidence["dimension"] => {
+	if (item.phase === "rehearsal" || item.questionAngle === "examTransfer") {
+		return "independent";
+	}
+	if (
+		["apply", "findError", "compare"].includes(item.questionAngle ?? "") ||
+		item.phase === "practice"
+	) {
+		return "problemSolving";
+	}
+	return "understanding";
+};
+
+const loadAdaptiveEvidence = async (
+	ctx: MutationCtx,
+	sessions: Doc<"learningPlanSessions">[],
+) => {
+	const evidence: AdaptiveTopicEvidence[] = [];
+	const history: AdaptiveTargetHistory[] = [];
+	for (const session of sessions) {
+		if (session.targetEvidenceDimension && session.targetTopicIds?.[0]) {
+			history.push({
+				topicId: session.targetTopicIds[0],
+				dimension: session.targetEvidenceDimension,
+				targetedAt: session.outcomeAt ?? session.createdAt,
+			});
+		}
+		const items = await ctx.db
+			.query("learningSessionContentItems")
+			.withIndex("by_sessionId_and_sortOrder", (q) =>
+				q.eq("sessionId", session._id),
+			)
+			.take(50);
+		const itemById = new Map(items.map((item) => [item._id, item]));
+		const attempts = await ctx.db
+			.query("learningSessionAnswerAttempts")
+			.withIndex("by_sessionId_and_createdAt", (q) =>
+				q.eq("sessionId", session._id),
+			)
+			.order("desc")
+			.take(100);
+		const seenItemIds = new Set<Id<"learningSessionContentItems">>();
+		for (const attempt of attempts) {
+			if (seenItemIds.has(attempt.itemId)) continue;
+			seenItemIds.add(attempt.itemId);
+			const item = itemById.get(attempt.itemId);
+			const topicId = item?.topicId ?? session.targetTopicIds?.[0];
+			if (!item || !topicId || item.kind === "learnCard") continue;
+			evidence.push({
+				topicId,
+				dimension: getAdaptiveEvidenceDimension(item),
+				rating: attempt.rating,
+				sessionId: session._id,
+				createdAt: attempt.createdAt,
+			});
+		}
+	}
+	return { evidence, history };
+};
+
+const parseTimeMinutes = (value: string) => {
+	const match = /^(\d{2}):(\d{2})$/.exec(value);
+	if (!match) return null;
+	const hours = Number(match[1]);
+	const minutes = Number(match[2]);
+	return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59
+		? hours * 60 + minutes
+		: null;
+};
+
+const formatTimeMinutes = (value: number) =>
+	`${String(Math.floor(value / 60)).padStart(2, "0")}:${String(value % 60).padStart(2, "0")}`;
+
+const startOfUtcDay = (date: Date) => {
+	const next = new Date(date);
+	next.setUTCHours(0, 0, 0, 0);
+	return next;
+};
+
+const formatDateLabel = (date: Date) =>
+	new Intl.DateTimeFormat("de-DE", {
+		timeZone: "Europe/Berlin",
+		day: "numeric",
+		month: "long",
+		year: "numeric",
+	}).format(date);
+
+const getRollingSessionSchedule = async (
+	ctx: MutationCtx,
+	args: {
+		ownerTokenIdentifier: string;
+		plan: Doc<"learningPlans">;
+		afterSession: Doc<"learningPlanSessions">;
+		durationMinutes: number;
+		excludeSession?: Doc<"learningPlanSessions">;
+	},
+) => {
+	const learningTimes = await ctx.db
+		.query("userLearningTimes")
+		.withIndex("by_ownerTokenIdentifier", (q) =>
+			q.eq("ownerTokenIdentifier", args.ownerTokenIdentifier),
+		)
+		.take(MAX_LEARNING_TIMES);
+	const afterDate = new Date(
+		`${args.afterSession.dateKey.slice(0, 10)}T12:00:00Z`,
+	);
+	const today = startOfUtcDay(new Date());
+	const cursor = Number.isNaN(afterDate.getTime()) ? today : afterDate;
+	if (cursor < today) cursor.setTime(today.getTime());
+	cursor.setUTCDate(cursor.getUTCDate() + 1);
+	const examDate = new Date(`${args.plan.examDateKey.slice(0, 10)}T12:00:00Z`);
+	if (Number.isNaN(examDate.getTime())) return null;
+
+	while (cursor < examDate) {
+		const dateKey = cursor.toISOString().slice(0, 10);
+		const utcDay = cursor.getUTCDay();
+		const dayOfWeek = utcDay === 0 ? 7 : utcDay;
+		const windows = learningTimes
+			.filter((entry) => entry.dayOfWeek === dayOfWeek)
+			.sort((left, right) => left.startTime.localeCompare(right.startTime));
+		const candidates =
+			windows.length > 0
+				? windows.flatMap((window) => {
+						const start = parseTimeMinutes(window.startTime);
+						const end = parseTimeMinutes(window.endTime);
+						if (start === null || end === null || end - start < 10) return [];
+						return [
+							{
+								startTime: formatTimeMinutes(start),
+								durationMinutes: Math.min(args.durationMinutes, end - start),
+							},
+						];
+					})
+				: [
+						{
+							startTime: args.afterSession.startTime,
+							durationMinutes: args.durationMinutes,
+						},
+					];
+
+		for (const candidate of candidates) {
+			const conflict = await getScheduleConflictMessage(ctx, {
+				ownerTokenIdentifier: args.ownerTokenIdentifier,
+				dayKey: dateKey,
+				time: candidate.startTime,
+				durationMinutes: candidate.durationMinutes,
+				excludeDayEntryId: args.excludeSession?.dayEntryId,
+				excludeLearningPlanSessionId: args.excludeSession?._id,
+			});
+			if (!conflict) {
+				return {
+					dateKey,
+					dateLabel: formatDateLabel(cursor),
+					startTime: candidate.startTime,
+					durationMinutes: candidate.durationMinutes,
+				};
+			}
+		}
+		cursor.setUTCDate(cursor.getUTCDate() + 1);
+	}
+	return null;
+};
+
+const removeRollingSession = async (
+	ctx: MutationCtx,
+	session: Doc<"learningPlanSessions">,
+) => {
+	await deleteSessionLearningDataForSession(ctx, session._id);
+	if (session.dayEntryId) {
+		const dayEntry = await ctx.db.get("dayEntries", session.dayEntryId);
+		if (dayEntry?.ownerTokenIdentifier === session.ownerTokenIdentifier) {
+			await ctx.db.delete("dayEntries", session.dayEntryId);
+		}
+	}
+	await ctx.db.delete("learningPlanSessions", session._id);
+};
+
+const patchRollingSessionTarget = async (
+	ctx: MutationCtx,
+	args: {
+		plan: Doc<"learningPlans">;
+		session: Doc<"learningPlanSessions">;
+		target: AdaptiveLearningTarget;
+		planningStatus: "committed" | "provisional";
+		adaptationRevision: number;
+		calendar: RollingPlanCalendar;
+	},
+) => {
+	const targetMatches =
+		args.session.targetTopicIds?.[0] === args.target.topicId &&
+		args.session.targetEvidenceDimension === args.target.dimension;
+	if (!targetMatches) {
+		await deleteSessionLearningDataForSession(ctx, args.session._id);
+	}
+	const copy = adaptiveSessionCopy(args.target);
+	await ctx.db.patch("learningPlanSessions", args.session._id, {
+		...copy,
+		phase: args.target.phase,
+		compositionVariant: args.target.phase === "theory" ? "split" : "control",
+		knowledgeValidationStatus:
+			args.target.phase === "theory" ? "pending" : undefined,
+		knowledgeValidationConfidence: undefined,
+		planningStatus: args.planningStatus,
+		targetTopicIds: [args.target.topicId],
+		targetEvidenceDimension: args.target.dimension,
+		selectionReason: args.target.reason,
+		adaptationRevision: args.adaptationRevision,
+		...(!targetMatches
+			? {
+					contentGenerationStatus:
+						args.planningStatus === "committed"
+							? ("queued" as const)
+							: undefined,
+					contentGenerationError: undefined,
+					contentGenerationStartedAt: undefined,
+					contentGeneratedAt: undefined,
+				}
+			: args.planningStatus === "committed" &&
+					args.session.contentGenerationStatus === undefined
+				? { contentGenerationStatus: "queued" as const }
+				: {}),
+		updatedAt: Date.now(),
+	});
+	const updated = await ctx.db.get("learningPlanSessions", args.session._id);
+	if (updated && args.plan.status === "accepted") {
+		if (args.planningStatus === "committed") {
+			await args.calendar.syncSession(ctx, args.plan, updated);
+		} else {
+			await args.calendar.clearSession(ctx, updated);
+		}
+	}
+	return updated;
+};
+
+export const advanceRollingLearningPlan = async (
+	ctx: MutationCtx,
+	plan: Doc<"learningPlans">,
+	calendar: RollingPlanCalendar,
+) => {
+	if (!plan.rollingPlanEnabled) return null;
+	const sessions = await ctx.db
+		.query("learningPlanSessions")
+		.withIndex("by_learningPlanId_and_sortOrder", (q) =>
+			q.eq("learningPlanId", plan._id),
+		)
+		.order("asc")
+		.take(50);
+	const { evidence, history } = await loadAdaptiveEvidence(ctx, sessions);
+	const topics =
+		plan.topicMap && plan.topicMap.length > 0
+			? plan.topicMap
+			: normalizeLearningTopics([
+					{
+						id: "exam-scope",
+						title: plan.topicDescription,
+						learningGoal: plan.topicDescription,
+						keywords: [plan.subject],
+						priority: "high" as const,
+					},
+				]);
+	const committedTarget = selectNextAdaptiveLearningTarget({
+		topics,
+		initialReadiness: plan.topicReadiness ?? [],
+		evidence,
+		history,
+	});
+	const provisionalSessions = sessions.filter(
+		(session) =>
+			session.planningStatus === "provisional" &&
+			getSessionExecutionStatus(session) === "notStarted",
+	);
+	let provisional: Doc<"learningPlanSessions"> | null =
+		provisionalSessions[0] ?? null;
+	for (const duplicate of provisionalSessions.slice(1)) {
+		await removeRollingSession(ctx, duplicate);
+	}
+	const adaptationRevision = (plan.adaptationRevision ?? 0) + 1;
+	if (!committedTarget) {
+		if (provisional) await removeRollingSession(ctx, provisional);
+		await ctx.db.patch("learningPlans", plan._id, {
+			adaptationRevision,
+			updatedAt: Date.now(),
+		});
+		return { committedSessionId: null, provisionalSessionId: null };
+	}
+
+	let committed: Doc<"learningPlanSessions"> | null = null;
+	if (provisional) {
+		const todayKey = new Date().toISOString().slice(0, 10);
+		const scheduleConflict = await getScheduleConflictMessage(ctx, {
+			ownerTokenIdentifier: plan.ownerTokenIdentifier,
+			dayKey: provisional.dateKey,
+			time: provisional.startTime,
+			durationMinutes: provisional.durationMinutes,
+			excludeDayEntryId: provisional.dayEntryId,
+			excludeLearningPlanSessionId: provisional._id,
+		});
+		if (provisional.dateKey.slice(0, 10) <= todayKey || scheduleConflict) {
+			const previousSession = sessions
+				.filter((session) => session._id !== provisional?._id)
+				.at(-1);
+			const replacementSchedule = previousSession
+				? await getRollingSessionSchedule(ctx, {
+						ownerTokenIdentifier: plan.ownerTokenIdentifier,
+						plan,
+						afterSession: previousSession,
+						durationMinutes: Math.min(provisional.durationMinutes, 20),
+						excludeSession: provisional,
+					})
+				: null;
+			if (!replacementSchedule) {
+				await removeRollingSession(ctx, provisional);
+				provisional = null;
+			} else {
+				await ctx.db.patch(
+					"learningPlanSessions",
+					provisional._id,
+					replacementSchedule,
+				);
+				provisional = await ctx.db.get("learningPlanSessions", provisional._id);
+			}
+		}
+	}
+	if (provisional) {
+		committed = await patchRollingSessionTarget(ctx, {
+			plan,
+			session: provisional,
+			target: committedTarget,
+			planningStatus: "committed",
+			adaptationRevision,
+			calendar,
+		});
+	} else {
+		const previousSession = sessions.at(-1);
+		const schedule = previousSession
+			? await getRollingSessionSchedule(ctx, {
+					ownerTokenIdentifier: plan.ownerTokenIdentifier,
+					plan,
+					afterSession: previousSession,
+					durationMinutes: Math.min(previousSession.durationMinutes, 20),
+				})
+			: null;
+		if (previousSession && schedule) {
+			const copy = adaptiveSessionCopy(committedTarget);
+			const committedId = await ctx.db.insert("learningPlanSessions", {
+				ownerTokenIdentifier: plan.ownerTokenIdentifier,
+				learningPlanId: plan._id,
+				phase: committedTarget.phase,
+				...copy,
+				...schedule,
+				compositionVariant:
+					committedTarget.phase === "theory" ? "split" : "control",
+				...(committedTarget.phase === "theory"
+					? { knowledgeValidationStatus: "pending" as const }
+					: {}),
+				contentGenerationStatus: "queued",
+				planningStatus: "committed",
+				targetTopicIds: [committedTarget.topicId],
+				targetEvidenceDimension: committedTarget.dimension,
+				selectionReason: committedTarget.reason,
+				adaptationRevision,
+				sortOrder: previousSession.sortOrder + 1,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			});
+			committed = await ctx.db.get("learningPlanSessions", committedId);
+			if (committed && plan.status === "accepted") {
+				await calendar.syncSession(ctx, plan, committed);
+			}
+		}
+	}
+	if (!committed) return null;
+	const previewTarget = selectNextAdaptiveLearningTarget({
+		topics,
+		initialReadiness: plan.topicReadiness ?? [],
+		evidence: [
+			...evidence,
+			{
+				topicId: committedTarget.topicId,
+				dimension: committedTarget.dimension,
+				rating: "correct",
+				sessionId: `projected-${committed._id}`,
+				createdAt: Date.now() + 1,
+			},
+		],
+		history,
+	});
+	const schedule = previewTarget
+		? await getRollingSessionSchedule(ctx, {
+				ownerTokenIdentifier: plan.ownerTokenIdentifier,
+				plan,
+				afterSession: committed,
+				durationMinutes: Math.min(committed.durationMinutes, 20),
+			})
+		: null;
+	let provisionalSessionId: Id<"learningPlanSessions"> | null = null;
+	if (previewTarget && schedule) {
+		const highestSortOrder = Math.max(
+			committed.sortOrder,
+			...sessions.map((session) => session.sortOrder),
+		);
+		const copy = adaptiveSessionCopy(previewTarget);
+		provisionalSessionId = await ctx.db.insert("learningPlanSessions", {
+			ownerTokenIdentifier: plan.ownerTokenIdentifier,
+			learningPlanId: plan._id,
+			phase: previewTarget.phase,
+			...copy,
+			...schedule,
+			compositionVariant:
+				previewTarget.phase === "theory" ? "split" : "control",
+			...(previewTarget.phase === "theory"
+				? { knowledgeValidationStatus: "pending" as const }
+				: {}),
+			planningStatus: "provisional",
+			targetTopicIds: [previewTarget.topicId],
+			targetEvidenceDimension: previewTarget.dimension,
+			selectionReason: previewTarget.reason,
+			adaptationRevision,
+			sortOrder: highestSortOrder + 1,
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		});
+	}
+	await ctx.db.patch("learningPlans", plan._id, {
+		adaptationRevision,
+		contentGenerationStage: "ready",
+		updatedAt: Date.now(),
+	});
+	return {
+		committedSessionId: committed._id,
+		provisionalSessionId,
+	};
+};

--- a/convex/adaptiveLearningPlanPolicy.test.ts
+++ b/convex/adaptiveLearningPlanPolicy.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "vitest";
+import {
+	type AdaptiveTopicEvidence,
+	selectNextAdaptiveLearningTarget,
+} from "./adaptiveLearningPlanPolicy";
+
+const topics = [
+	{
+		id: "steigung",
+		title: "Steigung berechnen",
+		learningGoal: "Steigungen aus zwei Punkten berechnen.",
+		keywords: ["Steigung"],
+		priority: "high" as const,
+		requiredEvidenceDimensions: [
+			"understanding" as const,
+			"problemSolving" as const,
+			"independent" as const,
+		],
+	},
+	{
+		id: "achsenschnitt",
+		title: "Achsenschnittpunkte",
+		learningGoal: "Achsenschnittpunkte sicher bestimmen.",
+		keywords: ["Achse"],
+		priority: "medium" as const,
+		requiredEvidenceDimensions: ["understanding" as const],
+	},
+];
+
+const evidence = (
+	overrides: Partial<AdaptiveTopicEvidence>,
+): AdaptiveTopicEvidence => ({
+	topicId: "steigung",
+	dimension: "understanding",
+	rating: "correct",
+	sessionId: "session-1",
+	createdAt: 1,
+	...overrides,
+});
+
+describe("adaptive learning plan policy", () => {
+	test("starts with understanding when a high-priority topic is unknown", () => {
+		expect(
+			selectNextAdaptiveLearningTarget({
+				topics,
+				initialReadiness: [],
+				evidence: [],
+			}),
+		).toMatchObject({
+			topicId: "steigung",
+			dimension: "understanding",
+			phase: "theory",
+			status: "unknown",
+		});
+	});
+
+	test("moves to problem solving after understanding is secure", () => {
+		expect(
+			selectNextAdaptiveLearningTarget({
+				topics,
+				initialReadiness: [{ topicId: "steigung", status: "secure" }],
+				evidence: [],
+			}),
+		).toMatchObject({
+			topicId: "steigung",
+			dimension: "problemSolving",
+			phase: "practice",
+		});
+	});
+
+	test("uses independent work after repeated problem-solving success", () => {
+		const attempts = [
+			evidence({
+				dimension: "problemSolving",
+				sessionId: "practice-1",
+				createdAt: 1,
+			}),
+			evidence({
+				dimension: "problemSolving",
+				sessionId: "practice-2",
+				createdAt: 2,
+			}),
+		];
+
+		expect(
+			selectNextAdaptiveLearningTarget({
+				topics,
+				initialReadiness: [{ topicId: "steigung", status: "secure" }],
+				evidence: attempts,
+			}),
+		).toMatchObject({
+			dimension: "independent",
+			phase: "rehearsal",
+		});
+	});
+
+	test("prioritizes a contradictory result as a control check", () => {
+		const attempts = [
+			evidence({ sessionId: "understanding-1", createdAt: 1 }),
+			evidence({ sessionId: "understanding-2", createdAt: 2 }),
+			evidence({
+				sessionId: "understanding-3",
+				createdAt: 3,
+				rating: "notCorrect",
+			}),
+		];
+
+		expect(
+			selectNextAdaptiveLearningTarget({
+				topics,
+				initialReadiness: [],
+				evidence: attempts,
+			}),
+		).toMatchObject({
+			topicId: "steigung",
+			dimension: "understanding",
+			needsControlCheck: true,
+		});
+	});
+
+	test("can exclude the committed target when choosing the preview", () => {
+		expect(
+			selectNextAdaptiveLearningTarget({
+				topics,
+				initialReadiness: [],
+				evidence: [],
+				excludeTargetKeys: ["steigung:understanding"],
+			}),
+		).toMatchObject({
+			topicId: "steigung",
+			dimension: "problemSolving",
+		});
+	});
+
+	test("returns no target when every required dimension is secure", () => {
+		const attempts = [
+			...(["understanding", "problemSolving", "independent"] as const).flatMap(
+				(dimension, dimensionIndex) => [
+					evidence({
+						dimension,
+						sessionId: `${dimension}-1`,
+						createdAt: dimensionIndex * 2 + 1,
+					}),
+					evidence({
+						dimension,
+						sessionId: `${dimension}-2`,
+						createdAt: dimensionIndex * 2 + 2,
+					}),
+				],
+			),
+			evidence({
+				topicId: "achsenschnitt",
+				sessionId: "axis-1",
+				createdAt: 10,
+			}),
+			evidence({
+				topicId: "achsenschnitt",
+				sessionId: "axis-2",
+				createdAt: 11,
+			}),
+		];
+
+		expect(
+			selectNextAdaptiveLearningTarget({
+				topics,
+				initialReadiness: [],
+				evidence: attempts,
+			}),
+		).toBeNull();
+	});
+});

--- a/convex/adaptiveLearningPlanPolicy.ts
+++ b/convex/adaptiveLearningPlanPolicy.ts
@@ -1,0 +1,246 @@
+import type {
+	LearningEvidenceDimension,
+	LearningTopic,
+} from "./learningContentPlan";
+
+export type AdaptiveEvidenceRating =
+	| "notCorrect"
+	| "partiallyCorrect"
+	| "correct";
+
+export type AdaptiveTopicEvidence = {
+	topicId: string;
+	dimension: LearningEvidenceDimension;
+	rating: AdaptiveEvidenceRating;
+	sessionId: string;
+	createdAt: number;
+};
+
+export type AdaptiveTargetHistory = {
+	topicId: string;
+	dimension: LearningEvidenceDimension;
+	targetedAt: number;
+};
+
+export type AdaptiveLearningTarget = {
+	topicId: string;
+	topicTitle: string;
+	learningGoal: string;
+	dimension: LearningEvidenceDimension;
+	phase: "theory" | "practice" | "rehearsal";
+	status: "unknown" | "developing";
+	needsControlCheck: boolean;
+	reason: string;
+};
+
+const evidenceDimensions: LearningEvidenceDimension[] = [
+	"understanding",
+	"problemSolving",
+	"independent",
+];
+
+const dimensionRank: Record<LearningEvidenceDimension, number> = {
+	understanding: 0,
+	problemSolving: 1,
+	independent: 2,
+};
+
+const priorityRank = { high: 0, medium: 1, low: 2 } as const;
+
+const dimensionLabel: Record<LearningEvidenceDimension, string> = {
+	understanding: "Verstehen",
+	problemSolving: "Problemlösen",
+	independent: "selbstständiges Lösen",
+};
+
+const phaseForDimension: Record<
+	LearningEvidenceDimension,
+	AdaptiveLearningTarget["phase"]
+> = {
+	understanding: "theory",
+	problemSolving: "practice",
+	independent: "rehearsal",
+};
+
+const evidenceSupportsDimension = (
+	evidence: AdaptiveTopicEvidence,
+	dimension: LearningEvidenceDimension,
+) => dimensionRank[evidence.dimension] >= dimensionRank[dimension];
+
+const deriveDimensionStatus = (args: {
+	dimension: LearningEvidenceDimension;
+	initialStatus: "secure" | "developing" | "unknown";
+	evidence: AdaptiveTopicEvidence[];
+}) => {
+	const relevantEvidence = args.evidence
+		.filter((entry) => evidenceSupportsDimension(entry, args.dimension))
+		.sort((left, right) => right.createdAt - left.createdAt);
+	const initialEvidenceCount =
+		args.dimension === "understanding"
+			? args.initialStatus === "secure"
+				? 2
+				: args.initialStatus === "developing"
+					? 1
+					: 0
+			: 0;
+	const correctOccasions = new Set(
+		relevantEvidence
+			.filter((entry) => entry.rating === "correct")
+			.map((entry) => entry.sessionId),
+	).size;
+	const latest = relevantEvidence[0];
+	const priorCorrectOccasions = new Set(
+		relevantEvidence
+			.slice(1)
+			.filter((entry) => entry.rating === "correct")
+			.map((entry) => entry.sessionId),
+	).size;
+	const evidenceCount = relevantEvidence.length + initialEvidenceCount;
+	const status =
+		(args.dimension === "understanding" &&
+			args.initialStatus === "secure" &&
+			relevantEvidence.length === 0) ||
+		(latest?.rating === "correct" &&
+			correctOccasions + initialEvidenceCount >= 2)
+			? ("secure" as const)
+			: evidenceCount > 0
+				? ("developing" as const)
+				: ("unknown" as const);
+	const needsControlCheck =
+		Boolean(latest && latest.rating !== "correct") &&
+		priorCorrectOccasions + initialEvidenceCount >= 2;
+
+	return { status, needsControlCheck, evidenceCount };
+};
+
+const reasonForTarget = (
+	topicTitle: string,
+	dimension: LearningEvidenceDimension,
+	status: "unknown" | "developing",
+	needsControlCheck: boolean,
+) => {
+	if (needsControlCheck) {
+		return `Kontrollcheck: Neue Evidenz zu „${topicTitle}“ widerspricht früheren sicheren Lösungen.`;
+	}
+	if (status === "unknown") {
+		return `Warum jetzt: Für „${topicTitle}“ fehlt noch Evidenz im ${dimensionLabel[dimension]}.`;
+	}
+	return `Warum jetzt: „${topicTitle}“ ist im ${dimensionLabel[dimension]} noch nicht stabil.`;
+};
+
+export const selectNextAdaptiveLearningTarget = (args: {
+	topics: LearningTopic[];
+	initialReadiness: Array<{
+		topicId: string;
+		status: "secure" | "developing" | "unknown";
+	}>;
+	evidence: AdaptiveTopicEvidence[];
+	history?: AdaptiveTargetHistory[];
+	excludeTargetKeys?: string[];
+}): AdaptiveLearningTarget | null => {
+	const readinessByTopicId = new Map(
+		args.initialReadiness.map((entry) => [entry.topicId, entry.status]),
+	);
+	const latestTargetedAtByKey = new Map<string, number>();
+	for (const entry of args.history ?? []) {
+		const key = `${entry.topicId}:${entry.dimension}`;
+		latestTargetedAtByKey.set(
+			key,
+			Math.max(latestTargetedAtByKey.get(key) ?? 0, entry.targetedAt),
+		);
+	}
+	const excludedTargetKeys = new Set(args.excludeTargetKeys ?? []);
+	const candidates = args.topics.flatMap((topic) => {
+		const requiredDimensions = topic.requiredEvidenceDimensions?.length
+			? evidenceDimensions.filter((dimension) =>
+					topic.requiredEvidenceDimensions?.includes(dimension),
+				)
+			: evidenceDimensions;
+		const topicEvidence = args.evidence.filter(
+			(entry) => entry.topicId === topic.id,
+		);
+		return requiredDimensions.flatMap((dimension) => {
+			const key = `${topic.id}:${dimension}`;
+			if (excludedTargetKeys.has(key)) return [];
+			const dimensionStatus = deriveDimensionStatus({
+				dimension,
+				initialStatus: readinessByTopicId.get(topic.id) ?? "unknown",
+				evidence: topicEvidence,
+			});
+			if (dimensionStatus.status === "secure") return [];
+			const status: "unknown" | "developing" = dimensionStatus.status;
+
+			return [
+				{
+					topic,
+					dimension,
+					...dimensionStatus,
+					status,
+					lastTargetedAt: latestTargetedAtByKey.get(key) ?? 0,
+				},
+			];
+		});
+	});
+
+	candidates.sort(
+		(left, right) =>
+			Number(right.needsControlCheck) - Number(left.needsControlCheck) ||
+			priorityRank[left.topic.priority] - priorityRank[right.topic.priority] ||
+			dimensionRank[left.dimension] - dimensionRank[right.dimension] ||
+			left.lastTargetedAt - right.lastTargetedAt ||
+			left.evidenceCount - right.evidenceCount ||
+			left.topic.title.localeCompare(right.topic.title, "de"),
+	);
+	const selected = candidates[0];
+	if (!selected) return null;
+
+	return {
+		topicId: selected.topic.id,
+		topicTitle: selected.topic.title,
+		learningGoal: selected.topic.learningGoal,
+		dimension: selected.dimension,
+		phase: phaseForDimension[selected.dimension],
+		status: selected.status,
+		needsControlCheck: selected.needsControlCheck,
+		reason: reasonForTarget(
+			selected.topic.title,
+			selected.dimension,
+			selected.status,
+			selected.needsControlCheck,
+		),
+	};
+};
+
+export const adaptiveSessionCopy = (target: AdaptiveLearningTarget) => {
+	if (target.dimension === "understanding") {
+		return {
+			title: target.topicTitle,
+			goal: `Verstehe ${target.topicTitle}: ${target.learningGoal}`,
+			tasks: [
+				"Kernidee an einem Beispiel nachvollziehen",
+				"Verständnis ohne Vorlage erklären",
+			],
+			expectedOutcome: `Du kannst ${target.topicTitle} verständlich erklären.`,
+		};
+	}
+	if (target.dimension === "problemSolving") {
+		return {
+			title: target.topicTitle,
+			goal: `Löse Aufgaben zu ${target.topicTitle} mit einer passenden Strategie.`,
+			tasks: [
+				"Lösungsweg selbst auswählen",
+				"Fehler finden und Ergebnis prüfen",
+			],
+			expectedOutcome: `Du löst neue Aufgaben zu ${target.topicTitle} begründet.`,
+		};
+	}
+	return {
+		title: target.topicTitle,
+		goal: `Bearbeite ${target.topicTitle} selbstständig unter Prüfungsbedingungen.`,
+		tasks: [
+			"Prüfungsnahe Aufgabe ohne Hinweise lösen",
+			"Ergebnis und Zeitbedarf kontrollieren",
+		],
+		expectedOutcome: `Du löst ${target.topicTitle} selbstständig und prüfungsnah.`,
+	};
+};

--- a/convex/learningPlanAi.ts
+++ b/convex/learningPlanAi.ts
@@ -346,7 +346,7 @@ const questionsSchema = z
 						"Short expected concept or result used to evaluate demonstrated knowledge.",
 					),
 					1,
-					5,
+					2,
 				),
 			}),
 			5,
@@ -613,6 +613,8 @@ type LearningSessionContentAiContext = {
 		goal: string;
 		tasks: string[];
 		expectedOutcome: string;
+		targetTopicIds?: string[];
+		planningStatus?: "committed" | "provisional";
 		sortOrder: number;
 	};
 	planSessions: Array<{
@@ -1632,6 +1634,14 @@ const getLearningContentTopics = (
 	context: LearningSessionContentAiContext,
 ): LearningTopic[] => {
 	if (context.plan.topicMap && context.plan.topicMap.length > 0) {
+		const explicitlyTargetedTopics = context.session.targetTopicIds?.length
+			? context.plan.topicMap.filter((topic) =>
+					context.session.targetTopicIds?.includes(topic.id),
+				)
+			: [];
+		if (explicitlyTargetedTopics.length > 0) {
+			return explicitlyTargetedTopics;
+		}
 		const topics = getSessionLearningTopics({
 			topics: context.plan.topicMap,
 			strengths: context.plan.insight?.strengths ?? [],
@@ -2599,6 +2609,18 @@ export const ensureSessionContent = action({
 		) {
 			return { itemCount: context.existingItemCount };
 		}
+		if (context.session.planningStatus === "provisional") {
+			const budgetStatus = await ctx.runQuery(
+				internal.learningPlanAiUsage.getBudgetStatus,
+				{
+					learningPlanId: context.session.learningPlanId,
+					projectedCostUsdMicros: 30_000,
+				},
+			);
+			if (!budgetStatus.speculativeGenerationAllowed) {
+				return { itemCount: 0 };
+			}
+		}
 		const claimed: boolean = await ctx.runMutation(
 			internal.learningPlans.claimSessionContentGeneration,
 			{ sessionId: args.sessionId },
@@ -3002,7 +3024,7 @@ MVP-Vorgabe:
 - Session-Titel müssen kurze UI-Labels mit maximal ${MAX_SESSION_TITLE_CHARS} Zeichen sein.
 - Nenne in Session-Titeln, goal, tasks und expectedOutcome keine Dauer in Minuten. Die tatsächliche Session-Dauer wird anschließend aus den persönlichen Lernzeiten festgelegt und separat angezeigt.
 - insight.strengths darf maximal 4 Punkte enthalten, insight.gaps maximal 5 Punkte.
-- Gib höchstens 5 fachlich unterschiedliche Session-Archetypen zurück. Die Kalenderlogik erweitert sie anschließend auf alle benötigten kurzen Lernsessionen.
+- Gib höchstens 2 fachlich unterschiedliche Session-Archetypen für die unmittelbar nächsten Lernschritte zurück. Spätere Schritte werden erst nach neuer Lernevidenz festgelegt.
 - Bevorzuge mehrere kurze Session-Archetypen: Theorie 10–15 Min., angeleitetes Üben 10–20 Min. und Praxis 20–30 Min. Vermeide lange Sammelblöcke.
 - Plane fachlich sinnvolle Lernblöcke, aber die finale Kalenderplatzierung erfolgt ausschließlich innerhalb der persönlichen Lernzeiten. Verwende keine anderen Tage oder Uhrzeiten als Empfehlung.
 - Nutze dayOffsetBeforeExam relativ zum Prüfungstag: 1 = einen Tag vor der Prüfung.
@@ -3109,7 +3131,7 @@ MVP-Vorgabe:
 							generateText({
 								model: model(planModelId),
 								temperature: 0.25,
-								maxOutputTokens: 4_800,
+								maxOutputTokens: 3_200,
 								abortSignal,
 								providerOptions: vertexProviderOptions,
 								output: Output.object({ schema: generatedPlanSchema }),
@@ -3143,6 +3165,7 @@ MVP-Vorgabe:
 					sessionCompositionVariant,
 					deferReadyUntilContent: true,
 					deferFutureContent: true,
+					rollingWindow: true,
 					generationId,
 					sessions: generatedPlan.sessions,
 				},

--- a/convex/learningPlanAiUsage.test.ts
+++ b/convex/learningPlanAiUsage.test.ts
@@ -227,3 +227,28 @@ test("forfeits a stale plan reservation from the previous month", async () => {
 
 	expect(july).toMatchObject({ requestCount: 1, budgetCostUsdMicros: 20_000 });
 });
+
+test("stops speculative generation at the normal plan allowance", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	const learningPlanId = await createPlan(t, "generation-policy");
+	await reserve(t, learningPlanId, "target-allowance", 100_000);
+	await t.mutation(internal.learningPlanAiUsage.settle, {
+		reservationId: "target-allowance",
+		inputTokens: 10_000,
+		cachedInputTokens: 0,
+		outputTokens: 10_000,
+		estimatedCostUsdMicros: 100_000,
+	});
+
+	const policy = await t.query(
+		api.learningPlanAiUsage.getPlanGenerationPolicy,
+		{ learningPlanId },
+	);
+
+	expect(policy).toEqual({
+		economyMode: true,
+		speculativeGenerationAllowed: false,
+		limitReached: false,
+		blockReason: null,
+	});
+});

--- a/convex/learningPlanAiUsage.ts
+++ b/convex/learningPlanAiUsage.ts
@@ -261,6 +261,29 @@ export const getBudgetStatus = internalQuery({
 	},
 });
 
+export const getPlanGenerationPolicy = query({
+	args: { learningPlanId: v.id("learningPlans") },
+	handler: async (ctx, args) => {
+		const { identity } = await requireOwnedPlan(ctx, args.learningPlanId);
+		const budget = await loadBudgetInputs(ctx, {
+			ownerTokenIdentifier: identity.tokenIdentifier,
+			learningPlanId: args.learningPlanId,
+			now: Date.now(),
+		});
+		const decision = evaluateLearningPlanAiBudget({
+			...budget,
+			projectedCostUsdMicros: 30_000,
+			limits: getLearningPlanAiBudgetLimits(),
+		});
+		return {
+			economyMode: decision.economyMode,
+			speculativeGenerationAllowed: decision.speculativeGenerationAllowed,
+			limitReached: !decision.allowed,
+			blockReason: decision.blockReason,
+		};
+	},
+});
+
 export const reserve = internalMutation({
 	args: {
 		learningPlanId: v.id("learningPlans"),

--- a/convex/learningPlans.test.ts
+++ b/convex/learningPlans.test.ts
@@ -295,6 +295,205 @@ test("commits only the next session while future session content stays adaptive"
 	).resolves.toBe("2026-06-01");
 });
 
+test("keeps one committed and one provisional session in the rolling window", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	const learningPlanId = await createPlan(t);
+	await t.mutation(api.learningTimes.upsertMine, {
+		dayOfWeek: 3,
+		startTime: "17:00",
+		endTime: "18:00",
+	});
+	await t.mutation(internal.learningPlans.storeKnowledgeQuestions, {
+		learningPlanId,
+		sourceSummary: "Lineare Funktionen mit Steigung.",
+		topics: [
+			{
+				id: "steigung",
+				title: "Steigung berechnen",
+				learningGoal: "Steigungen aus zwei Punkten berechnen.",
+				keywords: ["Steigung"],
+				priority: "high",
+				requiredEvidenceDimensions: ["understanding", "problemSolving"],
+			},
+		],
+		questions: [],
+	});
+	await t.mutation(internal.learningPlans.replaceGeneratedSessions, {
+		learningPlanId,
+		knowledgeAnswersJson: "[]",
+		sourceSummary: "Testmaterial",
+		insight: {
+			summary: "Die Steigung ist noch offen.",
+			strengths: [],
+			gaps: ["Steigung"],
+		},
+		deferReadyUntilContent: true,
+		deferFutureContent: true,
+		rollingWindow: true,
+		sessions: [
+			{
+				phase: "practice",
+				title: "Erster Slot",
+				dateKey: "2026-06-01",
+				dateLabel: "1. Juni 2026",
+				startTime: "17:00",
+				durationMinutes: 15,
+				goal: "Erster Lernslot.",
+				tasks: ["Aufgabe lösen"],
+				expectedOutcome: "Erster Schritt erledigt.",
+			},
+			{
+				phase: "practice",
+				title: "Zweiter Slot",
+				dateKey: "2026-06-02",
+				dateLabel: "2. Juni 2026",
+				startTime: "17:00",
+				durationMinutes: 15,
+				goal: "Zweiter Lernslot.",
+				tasks: ["Aufgabe lösen"],
+				expectedOutcome: "Zweiter Schritt erledigt.",
+			},
+		],
+	});
+
+	const initial = await t.query(api.learningPlans.getSnapshot, {
+		id: learningPlanId,
+	});
+	expect(initial?.sessions).toHaveLength(2);
+	expect(initial?.sessions[0]).toMatchObject({
+		planningStatus: "committed",
+		targetEvidenceDimension: "understanding",
+		contentGenerationStatus: "queued",
+	});
+	expect(initial?.sessions[1]).toMatchObject({
+		planningStatus: "provisional",
+		targetEvidenceDimension: "understanding",
+	});
+	expect(initial?.sessions[1]?.contentGenerationStatus).toBeUndefined();
+	const provisionalSessionId = initial?.sessions[1]?.id;
+	if (!provisionalSessionId) throw new Error("Expected provisional session.");
+	await expect(
+		t.mutation(api.learningPlans.startSession, {
+			sessionId: provisionalSessionId,
+		}),
+	).rejects.toThrow("nur eine Vorschau");
+
+	const committedSessionId = initial?.sessions[0]?.id;
+	if (!committedSessionId) throw new Error("Expected committed session.");
+	await t.mutation(internal.learningPlans.setSessionContentGenerationStatus, {
+		sessionId: committedSessionId,
+		status: "ready",
+	});
+	await t.mutation(internal.learningPlans.finalizeContentGeneration, {
+		learningPlanId,
+	});
+	await t.mutation(api.learningPlans.acceptPlan, { learningPlanId });
+	await t.mutation(api.learningPlans.startSession, {
+		sessionId: committedSessionId,
+	});
+	await t.mutation(api.learningPlans.recordSessionOutcome, {
+		sessionId: committedSessionId,
+		outcome: "completed",
+	});
+
+	const advanced = await t.query(api.learningPlans.getSnapshot, {
+		id: learningPlanId,
+	});
+	const openSessions = advanced?.sessions.filter(
+		(session) => session.executionStatus === "notStarted",
+	);
+	expect(openSessions).toHaveLength(2);
+	expect(
+		openSessions?.filter((session) => session.planningStatus === "committed"),
+	).toHaveLength(1);
+	expect(
+		openSessions?.filter((session) => session.planningStatus === "provisional"),
+	).toHaveLength(1);
+	expect(
+		openSessions?.find((session) => session.planningStatus === "committed"),
+	).toMatchObject({
+		targetEvidenceDimension: "understanding",
+		contentGenerationStatus: "queued",
+	});
+	const storedOpenSessions = await t.run(async (ctx) =>
+		Promise.all(
+			(openSessions ?? []).map((session) =>
+				ctx.db.get("learningPlanSessions", session.id),
+			),
+		),
+	);
+	expect(
+		storedOpenSessions.find(
+			(session) => session?.planningStatus === "committed",
+		)?.dayEntryId,
+	).toBeDefined();
+	expect(
+		storedOpenSessions.find(
+			(session) => session?.planningStatus === "provisional",
+		)?.dayEntryId,
+	).toBeUndefined();
+
+	const nextCommitted = openSessions?.find(
+		(session) => session.planningStatus === "committed",
+	);
+	if (!nextCommitted) throw new Error("Expected the next committed session.");
+	await t.mutation(api.learningPlans.missSession, {
+		sessionId: nextCommitted.id,
+		reason: "no_time",
+	});
+	await t.mutation(api.learningPlans.adjustMissedSession, {
+		sessionId: nextCommitted.id,
+		dateKey: "2026-06-04",
+		dateLabel: "4. Juni 2026",
+		startTime: "17:30",
+		durationMinutes: 10,
+	});
+
+	const recovered = await t.query(api.learningPlans.getSnapshot, {
+		id: learningPlanId,
+	});
+	const recoveredOpenSessions = recovered?.sessions.filter(
+		(session) => session.executionStatus === "notStarted",
+	);
+	expect(
+		recoveredOpenSessions?.filter(
+			(session) => session.planningStatus === "committed",
+		),
+	).toHaveLength(1);
+	expect(
+		recoveredOpenSessions?.filter(
+			(session) => session.planningStatus === "provisional",
+		),
+	).toHaveLength(1);
+	expect(
+		recoveredOpenSessions?.find(
+			(session) => session.planningStatus === "committed",
+		),
+	).toMatchObject({
+		adjustedFromSessionId: nextCommitted.id,
+		contentGenerationStatus: "queued",
+		dateKey: "2026-06-04",
+		durationMinutes: 10,
+	});
+	const recoveredStoredSessions = await t.run(async (ctx) =>
+		Promise.all(
+			(recoveredOpenSessions ?? []).map((session) =>
+				ctx.db.get("learningPlanSessions", session.id),
+			),
+		),
+	);
+	expect(
+		recoveredStoredSessions.find(
+			(session) => session?.planningStatus === "committed",
+		)?.dayEntryId,
+	).toBeDefined();
+	expect(
+		recoveredStoredSessions.find(
+			(session) => session?.planningStatus === "provisional",
+		)?.dayEntryId,
+	).toBeUndefined();
+});
+
 test("atomically claims one session content generation at a time", async () => {
 	const t = convexTest(schema, modules).withIdentity(user);
 	const learningPlanId = await createPlan(t);

--- a/convex/learningPlans.ts
+++ b/convex/learningPlans.ts
@@ -10,6 +10,12 @@ import {
 	type QueryCtx,
 	query,
 } from "./_generated/server";
+import { advanceRollingLearningPlan } from "./adaptiveLearningPlan";
+import {
+	type AdaptiveLearningTarget,
+	adaptiveSessionCopy,
+	selectNextAdaptiveLearningTarget,
+} from "./adaptiveLearningPlanPolicy";
 import { getDayKeyQueryVariants } from "./dayKeyVariants";
 import { deriveTopicReadiness } from "./diagnosticReadiness";
 import { throwUserFacingError } from "./errors";
@@ -117,6 +123,42 @@ const generatedSessionValidator = v.object({
 	expectedOutcome: v.string(),
 });
 
+type NormalizedGeneratedSession = {
+	phase: "theory" | "practice" | "rehearsal";
+	title: string;
+	dateKey: string;
+	dateLabel: string;
+	startTime: string;
+	durationMinutes: number;
+	goal: string;
+	tasks: string[];
+	expectedOutcome: string;
+	compositionVariant: "control" | "split";
+	planningStatus?: "committed" | "provisional";
+	targetTopicIds?: string[];
+	targetEvidenceDimension?: "understanding" | "problemSolving" | "independent";
+	selectionReason?: string;
+	adaptationRevision?: number;
+};
+
+const applyAdaptiveTargetToSession = (
+	session: NormalizedGeneratedSession,
+	target: AdaptiveLearningTarget,
+	planningStatus: "committed" | "provisional",
+	adaptationRevision: number,
+) => ({
+	...session,
+	...adaptiveSessionCopy(target),
+	phase: target.phase,
+	compositionVariant:
+		target.phase === "theory" ? ("split" as const) : ("control" as const),
+	planningStatus,
+	targetTopicIds: [target.topicId],
+	targetEvidenceDimension: target.dimension,
+	selectionReason: target.reason,
+	adaptationRevision,
+});
+
 type PublicDocument = {
 	id: Id<"learningPlanDocuments">;
 	fileName: string;
@@ -167,6 +209,11 @@ type PublicSession = {
 		| "unclear"
 		| "other";
 	adjustedFromSessionId?: Id<"learningPlanSessions">;
+	planningStatus?: "committed" | "provisional";
+	targetTopicIds?: string[];
+	targetEvidenceDimension?: "understanding" | "problemSolving" | "independent";
+	selectionReason?: string;
+	adaptationRevision?: number;
 	sortOrder: number;
 };
 
@@ -346,11 +393,21 @@ const publicSession = (
 	outcomeAt: session.outcomeAt,
 	missedReason: session.missedReason,
 	adjustedFromSessionId: session.adjustedFromSessionId,
+	planningStatus: session.planningStatus,
+	targetTopicIds: session.targetTopicIds,
+	targetEvidenceDimension: session.targetEvidenceDimension,
+	selectionReason: session.selectionReason,
+	adaptationRevision: session.adaptationRevision,
 	sortOrder: session.sortOrder,
 });
 
 const getSessionExecutionStatus = (session: Doc<"learningPlanSessions">) =>
 	session.executionStatus ?? (session.completed ? "completed" : "notStarted");
+
+const isContentCommittedSession = (session: Doc<"learningPlanSessions">) =>
+	session.planningStatus === "committed" ||
+	(session.planningStatus === undefined &&
+		session.contentGenerationStatus !== undefined);
 
 const isCompletedStatus = (
 	status: ReturnType<typeof getSessionExecutionStatus>,
@@ -796,13 +853,17 @@ export const getSnapshot = query({
 			)
 			.take(1);
 		const readySessionCount = sessions.filter(
-			(session) => session.contentGenerationStatus === "ready",
+			(session) =>
+				session.planningStatus !== "provisional" &&
+				session.contentGenerationStatus === "ready",
 		).length;
 		const failedSessionCount = sessions.filter(
-			(session) => session.contentGenerationStatus === "failed",
+			(session) =>
+				session.planningStatus !== "provisional" &&
+				session.contentGenerationStatus === "failed",
 		).length;
 		const committedSessionCount = sessions.filter(
-			(session) => session.contentGenerationStatus !== undefined,
+			isContentCommittedSession,
 		).length;
 
 		return {
@@ -831,6 +892,8 @@ export const getSnapshot = query({
 				planningHint: getCurrentPlanningHint(plan.planningHint, {
 					hasLearningTimes: learningTimes.length > 0,
 				}),
+				rollingPlanEnabled: plan.rollingPlanEnabled,
+				adaptationRevision: plan.adaptationRevision,
 				sessionCompositionVariant: plan.sessionCompositionVariant,
 				contentGeneration: plan.contentGenerationStage
 					? {
@@ -875,7 +938,12 @@ export const listOverview = query({
 				(session) => session.completed === true,
 			).length;
 			const currentSession =
-				sessions.find((session) => session.completed !== true) ??
+				sessions.find(
+					(session) =>
+						["notStarted", "started"].includes(
+							getSessionExecutionStatus(session),
+						) && session.planningStatus !== "provisional",
+				) ??
 				sessions.at(-1) ??
 				null;
 			const progressPercent =
@@ -1455,6 +1523,7 @@ export const replaceGeneratedSessions = internalMutation({
 		sessionCompositionVariant: v.optional(sessionCompositionVariantValidator),
 		deferReadyUntilContent: v.optional(v.boolean()),
 		deferFutureContent: v.optional(v.boolean()),
+		rollingWindow: v.optional(v.boolean()),
 		generationId: v.optional(v.string()),
 		sessions: v.array(generatedSessionValidator),
 	},
@@ -1477,27 +1546,87 @@ export const replaceGeneratedSessions = internalMutation({
 			),
 			gaps: args.insight.gaps.map((gap) => normalizeGeneratedGermanText(gap)),
 		};
-		const normalizedSessions = args.sessions.map((session) => ({
-			phase: session.phase,
-			title: normalizeGeneratedGermanText(session.title),
-			dateKey: session.dateKey,
-			dateLabel: session.dateLabel,
-			startTime: session.startTime,
-			durationMinutes: session.durationMinutes,
-			goal: normalizeGeneratedGermanText(session.goal),
-			tasks: session.tasks.map((task) => normalizeGeneratedGermanText(task)),
-			expectedOutcome: normalizeGeneratedGermanText(session.expectedOutcome),
-			compositionVariant:
-				getLearningSessionComposition({
-					phase: session.phase,
-					durationMinutes: session.durationMinutes,
-					variant:
-						args.sessionCompositionVariant ??
-						(session.phase === "theory" ? "split" : "control"),
-				}).length > 1
-					? ("split" as const)
-					: ("control" as const),
-		}));
+		const normalizedSessions: NormalizedGeneratedSession[] = args.sessions.map(
+			(session) => ({
+				phase: session.phase,
+				title: normalizeGeneratedGermanText(session.title),
+				dateKey: session.dateKey,
+				dateLabel: session.dateLabel,
+				startTime: session.startTime,
+				durationMinutes: session.durationMinutes,
+				goal: normalizeGeneratedGermanText(session.goal),
+				tasks: session.tasks.map((task) => normalizeGeneratedGermanText(task)),
+				expectedOutcome: normalizeGeneratedGermanText(session.expectedOutcome),
+				compositionVariant:
+					getLearningSessionComposition({
+						phase: session.phase,
+						durationMinutes: session.durationMinutes,
+						variant:
+							args.sessionCompositionVariant ??
+							(session.phase === "theory" ? "split" : "control"),
+					}).length > 1
+						? ("split" as const)
+						: ("control" as const),
+			}),
+		);
+		const adaptationRevision = args.rollingWindow
+			? (plan.adaptationRevision ?? 0) + 1
+			: (plan.adaptationRevision ?? 0);
+		const sourceTopics =
+			plan.topicMap && plan.topicMap.length > 0
+				? plan.topicMap
+				: normalizeLearningTopics([
+						{
+							id: "exam-scope",
+							title: plan.topicDescription,
+							learningGoal: plan.topicDescription,
+							keywords: [plan.subject],
+							priority: "high" as const,
+						},
+					]);
+		const firstTarget = args.rollingWindow
+			? selectNextAdaptiveLearningTarget({
+					topics: sourceTopics,
+					initialReadiness: plan.topicReadiness ?? [],
+					evidence: [],
+				})
+			: null;
+		const secondTarget =
+			args.rollingWindow && firstTarget
+				? selectNextAdaptiveLearningTarget({
+						topics: sourceTopics,
+						initialReadiness: plan.topicReadiness ?? [],
+						evidence: [
+							{
+								topicId: firstTarget.topicId,
+								dimension: firstTarget.dimension,
+								rating: "correct",
+								sessionId: "projected-first-session",
+								createdAt: Date.now(),
+							},
+						],
+					})
+				: null;
+		const sessionsToStore = args.rollingWindow
+			? normalizedSessions.slice(0, 2).flatMap((session, index) => {
+					const target = index === 0 ? firstTarget : secondTarget;
+					if (!target && index > 0) return [];
+					return [
+						target
+							? applyAdaptiveTargetToSession(
+									session,
+									target,
+									index === 0 ? "committed" : "provisional",
+									adaptationRevision,
+								)
+							: {
+									...session,
+									planningStatus: "committed" as const,
+									adaptationRevision,
+								},
+					];
+				})
+			: normalizedSessions;
 
 		const existingSessions = await ctx.db
 			.query("learningPlanSessions")
@@ -1518,10 +1647,13 @@ export const replaceGeneratedSessions = internalMutation({
 
 		const now = Date.now();
 		const sessionIds: Id<"learningPlanSessions">[] = [];
-		for (const [index, session] of normalizedSessions.entries()) {
+		for (const [index, session] of sessionsToStore.entries()) {
 			const shouldPrepareContent =
 				args.deferReadyUntilContent &&
-				(!args.deferFutureContent || index === 0);
+				(!args.deferFutureContent ||
+					(args.rollingWindow
+						? session.planningStatus !== "provisional"
+						: index === 0));
 			const sessionId = await ctx.db.insert("learningPlanSessions", {
 				ownerTokenIdentifier: plan.ownerTokenIdentifier,
 				learningPlanId: args.learningPlanId,
@@ -1544,6 +1676,8 @@ export const replaceGeneratedSessions = internalMutation({
 			planningHint: args.planningHint,
 			sourceSummary: normalizedSourceSummary,
 			insight: normalizedInsight,
+			rollingPlanEnabled: args.rollingWindow === true,
+			adaptationRevision,
 			sessionCompositionVariant: args.sessionCompositionVariant ?? "split",
 			status: args.deferReadyUntilContent ? "questionsReady" : "generated",
 			contentGenerationStage: args.deferReadyUntilContent
@@ -1640,15 +1774,13 @@ export const finalizeContentGeneration = internalMutation({
 				q.eq("learningPlanId", args.learningPlanId),
 			)
 			.take(50);
-		const failedSessionCount = sessions.filter(
+		const committedSessions = sessions.filter(isContentCommittedSession);
+		const failedSessionCount = committedSessions.filter(
 			(session) => session.contentGenerationStatus === "failed",
 		).length;
-		const readySessionCount = sessions.filter(
+		const readySessionCount = committedSessions.filter(
 			(session) => session.contentGenerationStatus === "ready",
 		).length;
-		const committedSessions = sessions.filter(
-			(session) => session.contentGenerationStatus !== undefined,
-		);
 		const isReady =
 			committedSessions.length > 0 &&
 			readySessionCount === committedSessions.length;
@@ -1705,6 +1837,7 @@ export const claimIncompleteContentGenerationSessions = internalMutation({
 		const sessionIds = sessions
 			.filter(
 				(session) =>
+					session.planningStatus !== "provisional" &&
 					session.contentGenerationStatus !== undefined &&
 					session.contentGenerationStatus !== "ready",
 			)
@@ -1924,19 +2057,34 @@ export const syncSessionsToCalendar = mutation({
 			.take(50);
 
 		for (const session of sessions) {
-			await syncSessionDayEntry(ctx, plan, session);
+			if (session.planningStatus !== "provisional") {
+				await syncSessionDayEntry(ctx, plan, session);
+			}
 		}
 
 		return sessions.length;
 	},
 });
 
+const advanceOwnedRollingLearningPlan = (
+	ctx: MutationCtx,
+	plan: Doc<"learningPlans">,
+) =>
+	advanceRollingLearningPlan(ctx, plan, {
+		clearSession: clearSessionDayEntry,
+		syncSession: syncSessionDayEntry,
+	});
 export const startSession = mutation({
 	args: {
 		sessionId: v.id("learningPlanSessions"),
 	},
 	handler: async (ctx, args) => {
 		const { session, plan } = await getOwnedSessionAndPlan(ctx, args.sessionId);
+		if (session.planningStatus === "provisional") {
+			throwUserFacingError(
+				"Dieser Lernblock ist nur eine Vorschau und kann sich noch ändern.",
+			);
+		}
 		const status = getSessionExecutionStatus(session);
 		if (status !== "notStarted") {
 			throwUserFacingError("Dieser Lernblock wurde bereits gestartet.");
@@ -1993,11 +2141,13 @@ export const recordSessionOutcome = mutation({
 				completed: args.outcome === "completed",
 			},
 		);
+		const rollingUpdate = await advanceOwnedRollingLearningPlan(ctx, plan);
 
 		return {
 			...learningSessionEventPayload(plan, updatedSession ?? session),
 			outcome: args.outcome,
 			outcomeAt: now,
+			rollingUpdate,
 		};
 	},
 });
@@ -2066,9 +2216,20 @@ export const adjustMissedSession = mutation({
 			.withIndex("by_learningPlanId_and_sortOrder", (q) =>
 				q.eq("learningPlanId", session.learningPlanId),
 			)
-			.order("desc")
-			.take(1);
-		const sortOrder = (sessions[0]?.sortOrder ?? -1) + 1;
+			.order("asc")
+			.take(50);
+		const provisional = plan.rollingPlanEnabled
+			? sessions.find((candidate) => candidate.planningStatus === "provisional")
+			: undefined;
+		const sortOrder = plan.rollingPlanEnabled
+			? session.sortOrder + 1
+			: (sessions.at(-1)?.sortOrder ?? -1) + 1;
+		if (provisional && provisional.sortOrder <= sortOrder) {
+			await ctx.db.patch("learningPlanSessions", provisional._id, {
+				sortOrder: sortOrder + 1,
+				updatedAt: Date.now(),
+			});
+		}
 		const now = Date.now();
 		const newSessionId = await ctx.db.insert("learningPlanSessions", {
 			ownerTokenIdentifier,
@@ -2083,6 +2244,17 @@ export const adjustMissedSession = mutation({
 			tasks: session.tasks.slice(0, 2),
 			expectedOutcome: session.expectedOutcome,
 			adjustedFromSessionId: session._id,
+			...(plan.rollingPlanEnabled
+				? {
+						contentGenerationStatus: "queued" as const,
+						planningStatus: "committed" as const,
+						targetTopicIds: session.targetTopicIds,
+						targetEvidenceDimension: session.targetEvidenceDimension,
+						selectionReason:
+							"Neu geplant: Du startest den verpassten Lernblock kleiner, bevor der nächste Schwerpunkt festgelegt wird.",
+						adaptationRevision: plan.adaptationRevision,
+					}
+				: {}),
 			sortOrder,
 			createdAt: now,
 			updatedAt: now,
@@ -2097,6 +2269,13 @@ export const adjustMissedSession = mutation({
 		const newSession = await ctx.db.get("learningPlanSessions", newSessionId);
 		if (newSession && plan.status === "accepted") {
 			await syncSessionDayEntry(ctx, plan, newSession);
+		}
+		if (plan.rollingPlanEnabled) {
+			await ctx.db.patch("learningPlans", plan._id, {
+				contentGenerationStage: "content",
+				contentGenerationStartedAt: now,
+				updatedAt: now,
+			});
 		}
 
 		return {
@@ -2127,6 +2306,9 @@ export const setSessionCompleted = mutation({
 			outcomeAt: args.completed ? now : undefined,
 			missedReason: undefined,
 		});
+		if (args.completed) {
+			await advanceOwnedRollingLearningPlan(ctx, plan);
+		}
 
 		return args.completed;
 	},
@@ -2179,6 +2361,7 @@ export const acceptPlan = mutation({
 			plan.contentGenerationStage &&
 			sessions.some(
 				(session) =>
+					session.planningStatus !== "provisional" &&
 					session.contentGenerationStatus !== undefined &&
 					session.contentGenerationStatus !== "ready",
 			)
@@ -2204,7 +2387,9 @@ export const acceptPlan = mutation({
 		}
 
 		for (const session of sessions) {
-			await syncSessionDayEntry(ctx, plan, session);
+			if (session.planningStatus !== "provisional") {
+				await syncSessionDayEntry(ctx, plan, session);
+			}
 		}
 
 		await ctx.db.patch("learningPlans", args.learningPlanId, {

--- a/convex/scheduleConflicts.ts
+++ b/convex/scheduleConflicts.ts
@@ -72,7 +72,16 @@ const getConflictMessage = (
 ) =>
 	`Dieser Zeitraum überschneidet sich mit "${entry.title}" am ${getConflictDateLabel(entry)} von ${timeFromMinutes(interval.start)} bis ${timeFromMinutes(interval.end)}.`;
 
-export const assertNoScheduleConflict = async (
+type ScheduleConflictArgs = {
+	ownerTokenIdentifier: string;
+	dayKey: string;
+	time?: string;
+	durationMinutes?: number;
+	excludeDayEntryId?: Id<"dayEntries">;
+	excludeLearningPlanSessionId?: Id<"learningPlanSessions">;
+};
+
+export const getScheduleConflictMessage = async (
 	ctx: MutationCtx,
 	{
 		ownerTokenIdentifier,
@@ -81,17 +90,10 @@ export const assertNoScheduleConflict = async (
 		durationMinutes,
 		excludeDayEntryId,
 		excludeLearningPlanSessionId,
-	}: {
-		ownerTokenIdentifier: string;
-		dayKey: string;
-		time?: string;
-		durationMinutes?: number;
-		excludeDayEntryId?: Id<"dayEntries">;
-		excludeLearningPlanSessionId?: Id<"learningPlanSessions">;
-	},
+	}: ScheduleConflictArgs,
 ) => {
 	const newInterval = getInterval({ time, durationMinutes });
-	if (!newInterval) return;
+	if (!newInterval) return null;
 
 	const existingEntries = [];
 	for (const queryDayKey of getDayKeyQueryVariants(dayKey)) {
@@ -123,7 +125,7 @@ export const assertNoScheduleConflict = async (
 
 		const existingInterval = getInterval(entry);
 		if (existingInterval && overlaps(newInterval, existingInterval)) {
-			throwUserFacingError(getConflictMessage(entry, existingInterval));
+			return getConflictMessage(entry, existingInterval);
 		}
 	}
 
@@ -138,9 +140,16 @@ export const assertNoScheduleConflict = async (
 			durationMinutes: getTimetableLessonDuration(lesson) ?? undefined,
 		});
 		if (lessonInterval && overlaps(newInterval, lessonInterval)) {
-			throwUserFacingError(
-				`Dieser Zeitraum überschneidet sich mit "${lesson.subject}" von ${timeFromMinutes(lessonInterval.start)} bis ${timeFromMinutes(lessonInterval.end)}.`,
-			);
+			return `Dieser Zeitraum überschneidet sich mit "${lesson.subject}" von ${timeFromMinutes(lessonInterval.start)} bis ${timeFromMinutes(lessonInterval.end)}.`;
 		}
 	}
+	return null;
+};
+
+export const assertNoScheduleConflict = async (
+	ctx: MutationCtx,
+	args: ScheduleConflictArgs,
+) => {
+	const conflictMessage = await getScheduleConflictMessage(ctx, args);
+	if (conflictMessage) throwUserFacingError(conflictMessage);
 };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,6 +1,9 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { learningTopicValidator } from "./learningTopicMap";
+import {
+	learningEvidenceDimensionValidator,
+	learningTopicValidator,
+} from "./learningTopicMap";
 import { theoryContentValidator } from "./theoryContent";
 
 const planQuestionValidator = v.object({
@@ -98,6 +101,11 @@ const contentGenerationStageValidator = v.union(
 	v.literal("validating"),
 	v.literal("ready"),
 	v.literal("failed"),
+);
+
+const learningPlanSessionPlanningStatusValidator = v.union(
+	v.literal("committed"),
+	v.literal("provisional"),
 );
 
 const sessionContentItemKindValidator = v.union(
@@ -395,6 +403,8 @@ export default defineSchema({
 		topicReadiness: v.optional(v.array(topicReadinessValidator)),
 		insight: v.optional(planInsightValidator),
 		planningHint: v.optional(v.string()),
+		rollingPlanEnabled: v.optional(v.boolean()),
+		adaptationRevision: v.optional(v.number()),
 		contentGenerationStage: v.optional(contentGenerationStageValidator),
 		contentGenerationId: v.optional(v.string()),
 		contentGenerationStartedAt: v.optional(v.number()),
@@ -525,6 +535,11 @@ export default defineSchema({
 		),
 		missedReason: v.optional(missedReasonValidator),
 		adjustedFromSessionId: v.optional(v.id("learningPlanSessions")),
+		planningStatus: v.optional(learningPlanSessionPlanningStatusValidator),
+		targetTopicIds: v.optional(v.array(v.string())),
+		targetEvidenceDimension: v.optional(learningEvidenceDimensionValidator),
+		selectionReason: v.optional(v.string()),
+		adaptationRevision: v.optional(v.number()),
 		sortOrder: v.number(),
 		dayEntryId: v.optional(v.id("dayEntries")),
 		createdAt: v.number(),

--- a/src/app/learning-plans/[planId]/index.tsx
+++ b/src/app/learning-plans/[planId]/index.tsx
@@ -48,6 +48,11 @@ import {
 	type LearningPathNodeState,
 	type LearningPathNodeTone,
 } from "~/features/learning-plans/learning-path-node-presentation";
+import {
+	getCommittedSessionIndex,
+	getDefaultLearningPlanSession,
+	isLearningPlanSessionHistory,
+} from "~/features/learning-plans/rolling-learning-window";
 import type {
 	LearningPlanSnapshot,
 	PlanSession,
@@ -89,7 +94,7 @@ const LEARNING_PATH_ICON_COMPONENT = {
 } satisfies Record<LearningPathNodeIcon, typeof Dumbbell>;
 
 const screenContentStyle = { rowGap: 28 } satisfies ViewStyle;
-const SESSION_PREVIEW_CARD_HEIGHT = 174;
+const SESSION_PREVIEW_CARD_HEIGHT = 218;
 const SESSION_PREVIEW_TRANSITION_DURATION_MS = 160;
 
 const getSessionRoute = (
@@ -113,8 +118,21 @@ function SessionPreviewCard({
 		LEARNING_PATH_ICON_COMPONENT[LEARNING_PATH_PHASE_ICON[session.phase]];
 	const title = formatGermanUiText(session.title);
 	const description = formatGermanUiText(session.goal);
+	const hasRecordedOutcome = isLearningPlanSessionHistory(session);
+	const horizonLabel = hasRecordedOutcome
+		? "Bearbeitet"
+		: session.planningStatus === "provisional"
+			? "Danach · Vorschau"
+			: "Als Nächstes";
 	const content = (
 		<View className="gap-2">
+			<View className="flex-row">
+				<View className="rounded-full bg-system-subtle px-3 py-1.5">
+					<Text className="font-poppins font-semibold text-body-5 text-primary">
+						{horizonLabel}
+					</Text>
+				</View>
+			</View>
 			<View className="flex-row items-start justify-between gap-3">
 				<Text
 					className="min-w-0 flex-1 pr-2 font-poppins font-semibold text-body-2 text-text"
@@ -158,6 +176,14 @@ function SessionPreviewCard({
 			>
 				{description}
 			</Text>
+			{session.selectionReason ? (
+				<Text
+					className="font-medium font-poppins text-body-5 text-primary"
+					numberOfLines={2}
+				>
+					{formatGermanUiText(session.selectionReason)}
+				</Text>
+			) : null}
 		</View>
 	);
 
@@ -224,7 +250,7 @@ function SessionPreviewCard({
 const PATH_NODE_STATE_LABEL: Record<LearningPathNodeState, string> = {
 	completed: "abgeschlossen",
 	current: "verfügbar",
-	locked: "gesperrt",
+	locked: "Vorschau",
 };
 
 type PathNodeFrame = {
@@ -290,13 +316,8 @@ const getFigmaPathHeight = (sessionCount: number) => {
 	return Math.max(FIGMA_PATH_HEIGHT, lastFrame.top + lastFrame.height + 20);
 };
 
-const getCurrentSessionIndex = (sessions: PlanSession[]) => {
-	const firstOpenIndex = sessions.findIndex((session) => !session.completed);
-	return firstOpenIndex === -1 ? null : firstOpenIndex;
-};
-
 const getActiveSegmentLimit = (sessions: PlanSession[]) => {
-	const currentIndex = getCurrentSessionIndex(sessions);
+	const currentIndex = getCommittedSessionIndex(sessions);
 	return currentIndex ?? Math.max(sessions.length - 1, 0);
 };
 
@@ -305,7 +326,8 @@ const getPathNodeState = (
 	index: number,
 	currentIndex: number | null,
 ): LearningPathNodeState => {
-	if (session.completed) return "completed";
+	if (isLearningPlanSessionHistory(session)) return "completed";
+	if (session.planningStatus === "provisional") return "locked";
 	if (currentIndex !== null && index === currentIndex) return "current";
 	return "locked";
 };
@@ -577,7 +599,7 @@ function PathNode({
 			accessibilityLabel={`${title}, ${PHASE_LABEL[session.phase]}, ${session.dateLabel}, ${stateLabel}`}
 			accessibilityHint={
 				isLocked
-					? "Wählt diesen gesperrten Lernblock aus und zeigt die Vorschau. Gesperrte Lernblöcke können noch nicht geöffnet werden."
+					? "Zeigt den voraussichtlich folgenden Lernblock. Er kann sich nach der nächsten Session noch ändern."
 					: "Wählt diesen Lernblock aus und zeigt die Vorschau. Öffnen kannst du ihn danach über die Pfeiltaste in der Vorschau."
 			}
 			accessibilityRole="button"
@@ -618,7 +640,7 @@ function LearningPath({
 	selectedSessionId: Id<"learningPlanSessions"> | null;
 	sessions: PlanSession[];
 }) {
-	const currentIndex = getCurrentSessionIndex(sessions);
+	const currentIndex = getCommittedSessionIndex(sessions);
 	const activeSegmentLimit = getActiveSegmentLimit(sessions);
 	const pathHeight = getFigmaPathHeight(sessions.length);
 	const segments = sessions.slice(1).map((_, index) => ({
@@ -692,16 +714,27 @@ export default function LearningPlanSessionsScreen() {
 		api.learningPlanAi.ensureSessionContent,
 	);
 	const preparingSessionIdRef = useRef<Id<"learningPlanSessions"> | null>(null);
+	const preparingProvisionalSessionIdRef =
+		useRef<Id<"learningPlanSessions"> | null>(null);
 	const snapshot = (useQuery(
 		api.learningPlans.getSnapshot,
 		user && isConvexAuthenticated && planId ? { id: planId } : "skip",
 	) ?? null) as LearningPlanSnapshot | null;
+	const generationPolicy = useQuery(
+		api.learningPlanAiUsage.getPlanGenerationPolicy,
+		user && isConvexAuthenticated && planId
+			? { learningPlanId: planId }
+			: "skip",
+	);
 	const [selectedSessionId, setSelectedSessionId] =
 		useState<Id<"learningPlanSessions"> | null>(null);
-	const defaultSession =
-		snapshot?.sessions.find((session) => !session.completed) ??
-		snapshot?.sessions.at(-1) ??
-		null;
+	const defaultSession = snapshot
+		? getDefaultLearningPlanSession(snapshot.sessions)
+		: null;
+	const provisionalSession =
+		snapshot?.sessions.find(
+			(session) => session.planningStatus === "provisional",
+		) ?? null;
 	const selectedSession =
 		snapshot?.sessions.find((session) => session.id === selectedSessionId) ??
 		defaultSession;
@@ -716,11 +749,13 @@ export default function LearningPlanSessionsScreen() {
 			? getPathNodeState(
 					selectedSession,
 					selectedSessionIndex,
-					getCurrentSessionIndex(snapshot.sessions),
+					getCommittedSessionIndex(snapshot.sessions),
 				)
 			: null;
 	const canOpenSelectedSession =
-		selectedSessionState !== null && selectedSessionState !== "locked";
+		selectedSessionState !== null &&
+		selectedSessionState !== "locked" &&
+		selectedSession?.planningStatus !== "provisional";
 
 	useEffect(() => {
 		if (
@@ -743,6 +778,39 @@ export default function LearningPlanSessionsScreen() {
 				}
 			});
 	}, [defaultSession, ensureSessionContent]);
+
+	useEffect(() => {
+		if (
+			!provisionalSession ||
+			generationPolicy?.speculativeGenerationAllowed !== true ||
+			defaultSession?.contentGenerationStatus !== "ready" ||
+			provisionalSession.contentGenerationStatus === "ready" ||
+			provisionalSession.contentGenerationStatus === "generating" ||
+			provisionalSession.contentGenerationStatus === "failed" ||
+			preparingProvisionalSessionIdRef.current === provisionalSession.id
+		) {
+			return;
+		}
+
+		preparingProvisionalSessionIdRef.current = provisionalSession.id;
+		void ensureSessionContent({ sessionId: provisionalSession.id })
+			.catch(() => {
+				// Speculative preparation is best-effort. The promoted session owns
+				// its visible retry state if this background attempt cannot finish.
+			})
+			.finally(() => {
+				if (
+					preparingProvisionalSessionIdRef.current === provisionalSession.id
+				) {
+					preparingProvisionalSessionIdRef.current = null;
+				}
+			});
+	}, [
+		defaultSession?.contentGenerationStatus,
+		ensureSessionContent,
+		generationPolicy?.speculativeGenerationAllowed,
+		provisionalSession,
+	]);
 
 	const goBack = () => {
 		dismissToOrReplace(router, "/learning-plans");

--- a/src/features/learning-plans/rolling-learning-window.test.ts
+++ b/src/features/learning-plans/rolling-learning-window.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import {
+	getCommittedSessionIndex,
+	getDefaultLearningPlanSession,
+	isLearningPlanSessionHistory,
+} from "~/features/learning-plans/rolling-learning-window";
+import type { PlanSession } from "~/features/learning-plans/types";
+
+const session = (
+	id: string,
+	overrides: Partial<PlanSession> = {},
+): PlanSession => ({
+	id: id as PlanSession["id"],
+	phase: "practice",
+	title: id,
+	dateKey: "2026-06-01",
+	dateLabel: "1. Juni 2026",
+	startTime: "17:00",
+	durationMinutes: 15,
+	goal: "Üben",
+	tasks: ["Aufgabe lösen"],
+	expectedOutcome: "Aufgabe gelöst",
+	sortOrder: 0,
+	completed: false,
+	executionStatus: "notStarted",
+	...overrides,
+});
+
+describe("rolling learning window", () => {
+	test("selects the committed session instead of its provisional preview", () => {
+		const sessions = [
+			session("history", {
+				completed: true,
+				executionStatus: "completed",
+				planningStatus: "committed",
+			}),
+			session("committed", { planningStatus: "committed" }),
+			session("preview", { planningStatus: "provisional" }),
+		];
+
+		expect(getCommittedSessionIndex(sessions)).toBe(1);
+		expect(getDefaultLearningPlanSession(sessions)?.id).toBe("committed");
+	});
+
+	test("treats partial and missed outcomes as history", () => {
+		expect(
+			isLearningPlanSessionHistory(
+				session("partial", { executionStatus: "partiallyCompleted" }),
+			),
+		).toBe(true);
+		expect(
+			isLearningPlanSessionHistory(
+				session("missed", { executionStatus: "missed" }),
+			),
+		).toBe(true);
+	});
+});

--- a/src/features/learning-plans/rolling-learning-window.ts
+++ b/src/features/learning-plans/rolling-learning-window.ts
@@ -1,0 +1,27 @@
+import type { PlanSession } from "~/features/learning-plans/types";
+
+const historyStatuses = new Set<PlanSession["executionStatus"]>([
+	"completed",
+	"partiallyCompleted",
+	"missed",
+	"adjusted",
+]);
+
+export const isLearningPlanSessionHistory = (session: PlanSession) =>
+	session.completed || historyStatuses.has(session.executionStatus);
+
+export const getCommittedSessionIndex = (sessions: PlanSession[]) => {
+	const index = sessions.findIndex(
+		(session) =>
+			["notStarted", "started"].includes(session.executionStatus) &&
+			session.planningStatus !== "provisional",
+	);
+	return index === -1 ? null : index;
+};
+
+export const getDefaultLearningPlanSession = (sessions: PlanSession[]) => {
+	const committedIndex = getCommittedSessionIndex(sessions);
+	return committedIndex === null
+		? (sessions.at(-1) ?? null)
+		: (sessions[committedIndex] ?? null);
+};

--- a/src/features/learning-plans/types.ts
+++ b/src/features/learning-plans/types.ts
@@ -45,6 +45,11 @@ export type PlanSession = {
 	outcomeAt?: number;
 	missedReason?: MissedReason;
 	adjustedFromSessionId?: Id<"learningPlanSessions">;
+	planningStatus?: "committed" | "provisional";
+	targetTopicIds?: string[];
+	targetEvidenceDimension?: "understanding" | "problemSolving" | "independent";
+	selectionReason?: string;
+	adaptationRevision?: number;
 };
 
 type SessionContentItemKind =
@@ -205,6 +210,8 @@ export type LearningPlanSnapshot = {
 			gaps: string[];
 		};
 		planningHint?: string;
+		rollingPlanEnabled?: boolean;
+		adaptationRevision?: number;
 		sessionCompositionVariant?: "control" | "split";
 		contentGeneration?: {
 			stage: "content" | "validating" | "ready" | "failed";


### PR DESCRIPTION
## Summary
- replace the fully pre-generated schedule with one committed next session and one provisional preview
- select each next target from topic-level evidence across Verstehen, Problemlösen, and selbstständiges Lösen
- promote, revise, or reschedule the preview after outcomes and missed sessions without rebuilding the whole plan
- prefetch preview content only when the AI budget permits speculative generation
- keep provisional sessions out of the calendar and explain why each next step was selected

## Validation
- pnpm typecheck
- pnpm test:unit (90 files, 538 tests before the additional recovery assertion)
- pnpm exec vitest run convex/learningPlans.test.ts (32 tests)
- focused adaptive policy, budget policy, and rolling-window tests
- scoped ESLint, Biome, Tailwind class sorting, and git diff --check

## Stack
- depends on #378 for atomic AI budget enforcement
- Linear: DAY-244

## Visual smoke check
- Expo dev-client bundle completed in the iOS simulator; the isolated worktree then showed the expected missing Clerk/Convex runtime configuration guard, so authenticated screen inspection remains for an environment with those public values.