### PR TITLE
Prevent learning plans without free study time

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -22,6 +22,7 @@ import type * as learningContentPlan from "../learningContentPlan.js";
 import type * as learningPlanAi from "../learningPlanAi.js";
 import type * as learningPlanAiCost from "../learningPlanAiCost.js";
 import type * as learningPlanAiUsage from "../learningPlanAiUsage.js";
+import type * as learningPlanAvailability from "../learningPlanAvailability.js";
 import type * as learningPlanPlanningHints from "../learningPlanPlanningHints.js";
 import type * as learningPlans from "../learningPlans.js";
 import type * as learningPreparationPolicy from "../learningPreparationPolicy.js";
@@ -69,6 +70,7 @@ declare const fullApi: ApiFromModules<{
   learningPlanAi: typeof learningPlanAi;
   learningPlanAiCost: typeof learningPlanAiCost;
   learningPlanAiUsage: typeof learningPlanAiUsage;
+  learningPlanAvailability: typeof learningPlanAvailability;
   learningPlanPlanningHints: typeof learningPlanPlanningHints;
   learningPlans: typeof learningPlans;
   learningPreparationPolicy: typeof learningPreparationPolicy;

--- a/convex/learningPlanAvailability.test.ts
+++ b/convex/learningPlanAvailability.test.ts
@@ -1,0 +1,92 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+const user = { tokenIdentifier: "test:user" };
+const availabilityArgs = {
+	fromDateKey: "2026-06-01",
+	fromTimeMinutes: 0,
+	examDateKey: "2026-06-03",
+};
+
+test("reports saved learning time as occupied after an appointment fills it", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	await t.mutation(api.learningTimes.upsertMine, {
+		dayOfWeek: 2,
+		startTime: "17:00",
+		endTime: "18:00",
+	});
+
+	await expect(
+		t.query(api.learningPlans.getSchedulingAvailability, availabilityArgs),
+	).resolves.toEqual({
+		availableStudyMinutes: 60,
+		status: "available",
+	});
+
+	await t.mutation(api.dayEntries.create, {
+		dayKey: "2026-06-02",
+		title: "Englisch lernen",
+		time: "17:00",
+		durationMinutes: 60,
+	});
+
+	await expect(
+		t.query(api.learningPlans.getSchedulingAvailability, availabilityArgs),
+	).resolves.toEqual({
+		availableStudyMinutes: 0,
+		status: "occupied",
+	});
+});
+
+test("subtracts active timetable lessons from learning-plan availability", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	await t.mutation(api.learningTimes.upsertMine, {
+		dayOfWeek: 2,
+		startTime: "08:00",
+		endTime: "09:00",
+	});
+	const timetableId = await t.mutation(api.timetables.createDraft, {});
+	await t.mutation(api.timetables.saveAndActivate, {
+		timetableId,
+		lessons: [
+			{
+				dayOfWeek: 2,
+				subject: "Mathematik",
+				startTime: "08:00",
+				endTime: "09:00",
+			},
+		],
+	});
+
+	await expect(
+		t.query(api.learningPlans.getSchedulingAvailability, availabilityArgs),
+	).resolves.toEqual({
+		availableStudyMinutes: 0,
+		status: "occupied",
+	});
+});
+
+test("does not report a learning window that has already started today", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	await t.mutation(api.learningTimes.upsertMine, {
+		dayOfWeek: 2,
+		startTime: "17:00",
+		endTime: "18:00",
+	});
+
+	await expect(
+		t.query(api.learningPlans.getSchedulingAvailability, {
+			fromDateKey: "2026-06-02",
+			fromTimeMinutes: 17 * 60,
+			examDateKey: "2026-06-03",
+		}),
+	).resolves.toEqual({
+		availableStudyMinutes: 0,
+		status: "missing",
+	});
+});

--- a/convex/learningPlanAvailability.ts
+++ b/convex/learningPlanAvailability.ts
@@ -1,0 +1,135 @@
+export type LearningTimeWindow = {
+	dayOfWeek: number;
+	startTime: string;
+	endTime: string;
+};
+
+export type OccupiedLearningTime = {
+	dayKey: string;
+	time?: string;
+	durationMinutes?: number;
+};
+
+const MIN_LEARNING_SLOT_MINUTES = 10;
+const MAX_WINDOW_MINUTES = 120;
+
+const parseTimeToMinutes = (time: string) => {
+	const [hours, minutes] = time.split(":").map(Number);
+	if (
+		!Number.isInteger(hours) ||
+		!Number.isInteger(minutes) ||
+		hours === undefined ||
+		minutes === undefined ||
+		hours < 0 ||
+		hours > 23 ||
+		minutes < 0 ||
+		minutes > 59
+	) {
+		return null;
+	}
+	return hours * 60 + minutes;
+};
+
+const getOccupiedIntervalsByDay = (occupiedEntries: OccupiedLearningTime[]) => {
+	const intervalsByDay = new Map<
+		string,
+		Array<{ start: number; end: number }>
+	>();
+
+	for (const entry of occupiedEntries) {
+		if (!entry.time || !entry.durationMinutes || entry.durationMinutes <= 0) {
+			continue;
+		}
+		const start = parseTimeToMinutes(entry.time);
+		if (start === null) continue;
+
+		const intervals = intervalsByDay.get(entry.dayKey) ?? [];
+		intervals.push({ start, end: start + entry.durationMinutes });
+		intervalsByDay.set(entry.dayKey, intervals);
+	}
+
+	return intervalsByDay;
+};
+
+const getFreeWindowMinutes = ({
+	start,
+	end,
+	occupiedIntervals,
+}: {
+	start: number;
+	end: number;
+	occupiedIntervals: Array<{ start: number; end: number }>;
+}) => {
+	let freeIntervals = [{ start, end }];
+
+	for (const occupied of occupiedIntervals) {
+		freeIntervals = freeIntervals.flatMap((free) => {
+			if (occupied.start >= free.end || occupied.end <= free.start) {
+				return [free];
+			}
+
+			return [
+				{ start: free.start, end: Math.max(free.start, occupied.start) },
+				{ start: Math.min(free.end, occupied.end), end: free.end },
+			];
+		});
+	}
+
+	const usableMinutes = freeIntervals.reduce(
+		(total, interval) =>
+			interval.end - interval.start >= MIN_LEARNING_SLOT_MINUTES
+				? total + interval.end - interval.start
+				: total,
+		0,
+	);
+	return Math.min(MAX_WINDOW_MINUTES, usableMinutes);
+};
+
+export const calculateAvailableStudyMinutes = ({
+	fromDateKey,
+	fromTimeMinutes,
+	examDateKey,
+	learningTimes,
+	occupiedEntries = [],
+}: {
+	fromDateKey: string;
+	fromTimeMinutes?: number;
+	examDateKey: string;
+	learningTimes: LearningTimeWindow[];
+	occupiedEntries?: OccupiedLearningTime[];
+}) => {
+	const cursor = new Date(`${fromDateKey}T00:00:00.000Z`);
+	const examDate = new Date(`${examDateKey}T00:00:00.000Z`);
+	if (Number.isNaN(cursor.getTime()) || Number.isNaN(examDate.getTime())) {
+		return 0;
+	}
+
+	const occupiedIntervalsByDay = getOccupiedIntervalsByDay(occupiedEntries);
+	let availableMinutes = 0;
+	while (cursor < examDate) {
+		const dayKey = cursor.toISOString().slice(0, 10);
+		const dayOfWeek = cursor.getUTCDay() || 7;
+		for (const learningTime of learningTimes) {
+			if (learningTime.dayOfWeek !== dayOfWeek) continue;
+			const start = parseTimeToMinutes(learningTime.startTime);
+			const end = parseTimeToMinutes(learningTime.endTime);
+			if (start === null || end === null || end - start < 10) continue;
+			if (
+				dayKey === fromDateKey &&
+				fromTimeMinutes !== undefined &&
+				start <= fromTimeMinutes
+			) {
+				continue;
+			}
+
+			availableMinutes += getFreeWindowMinutes({
+				start,
+				end,
+				occupiedIntervals: occupiedIntervalsByDay.get(dayKey) ?? [],
+			});
+		}
+		cursor.setUTCDate(cursor.getUTCDate() + 1);
+	}
+
+	return availableMinutes;
+};

--- a/convex/learningPlans.ts
+++ b/convex/learningPlans.ts
@@ -10,7 +10,7 @@ import {
 	type QueryCtx,
 	query,
 } from "./_generated/server";
-import { getDayKeyQueryVariants } from "./dayKeyVariants";
+import { getBerlinDayKey } from "./dayKeyVariants";
 import { deriveTopicReadiness } from "./diagnosticReadiness";
 import { throwUserFacingError } from "./errors";
 import {
@@ -19,6 +19,7 @@ import {
 	getR2ConfigOrThrow,
 } from "./fileStorage";
 import { normalizeGeneratedGermanText } from "./generatedGermanText";
+import { calculateAvailableStudyMinutes } from "./learningPlanAvailability";
 import { MISSING_LEARNING_TIMES_HINT } from "./learningPlanPlanningHints";
 import {
 	getDefaultPreparationDepth,
@@ -43,6 +44,8 @@ import {
 } from "./topicDescriptionValidation";
 
 const MAX_LEARNING_TIMES = 50;
+const MAX_SCHEDULING_DAY_ENTRIES = 500;
+const MAX_SCHEDULING_LOOKAHEAD_DAYS = 366;
 // Convex Node actions have a 10-minute platform ceiling. Allow one extra minute
 // before a later request may recover work left behind by a terminated action.
 const STALE_CONTENT_GENERATION_MS = 11 * 60_000;
@@ -412,6 +415,99 @@ const getLearningPlanCalendarDayKeys = (examDateKey: string) => {
 	return dayKeys;
 };
 
+const getAvailabilityDayKeys = (fromDateKey: string, examDateKey: string) => {
+	const cursor = new Date(`${fromDateKey}T00:00:00.000Z`);
+	const examDate = new Date(`${examDateKey}T00:00:00.000Z`);
+	if (Number.isNaN(cursor.getTime()) || Number.isNaN(examDate.getTime())) {
+		return [];
+	}
+
+	const dayCount = Math.ceil(
+		(examDate.getTime() - cursor.getTime()) / 86_400_000,
+	);
+	// The exam-date selector exposes one year. Fail closed for malformed route
+	// params beyond that range instead of starting an unbounded database read.
+	if (dayCount > MAX_SCHEDULING_LOOKAHEAD_DAYS) return [];
+	if (dayCount <= 0) return [];
+
+	const dayKeys: string[] = [];
+	while (cursor < examDate) {
+		dayKeys.push(cursor.toISOString().slice(0, 10));
+		cursor.setUTCDate(cursor.getUTCDate() + 1);
+	}
+	return dayKeys;
+};
+
+type SchedulingOccupiedEntry = {
+	dayKey: string;
+	time?: string;
+	durationMinutes?: number;
+};
+
+const getSchedulingOccupiedEntries = async (
+	ctx: QueryCtx,
+	{
+		ownerTokenIdentifier,
+		dayKeys,
+	}: {
+		ownerTokenIdentifier: string;
+		dayKeys: string[];
+	},
+) => {
+	if (dayKeys.length === 0) {
+		return {
+			entries: [] as SchedulingOccupiedEntry[],
+			wasTruncated: false,
+		};
+	}
+
+	const requestedDayKeys = new Set(dayKeys);
+	const queryStart = new Date(`${dayKeys[0]}T00:00:00.000Z`);
+	queryStart.setUTCDate(queryStart.getUTCDate() - 1);
+	const queryEnd = new Date(`${dayKeys.at(-1)}T00:00:00.000Z`);
+	queryEnd.setUTCDate(queryEnd.getUTCDate() + 1);
+	const dayEntries = await ctx.db
+		.query("dayEntries")
+		.withIndex("by_ownerTokenIdentifier_and_dayKey", (q) =>
+			q
+				.eq("ownerTokenIdentifier", ownerTokenIdentifier)
+				.gte("dayKey", queryStart.toISOString().slice(0, 10))
+				.lt("dayKey", queryEnd.toISOString().slice(0, 10)),
+		)
+		.take(MAX_SCHEDULING_DAY_ENTRIES + 1);
+	const wasTruncated = dayEntries.length > MAX_SCHEDULING_DAY_ENTRIES;
+	const entries: SchedulingOccupiedEntry[] = dayEntries
+		.slice(0, MAX_SCHEDULING_DAY_ENTRIES)
+		.flatMap((entry) => {
+			const dayKey = getBerlinDayKey(entry.dayKey);
+			if (!dayKey || !requestedDayKeys.has(dayKey)) return [];
+			return [
+				{
+					dayKey,
+					time: isExamEntry(entry) ? undefined : entry.time,
+					durationMinutes: entry.durationMinutes,
+				},
+			];
+		});
+	const timetableLessons = await getActiveTimetableLessons(
+		ctx,
+		ownerTokenIdentifier,
+	);
+	for (const dayKey of dayKeys) {
+		const dayOfWeek = getTimetableDayOfWeek(dayKey);
+		for (const lesson of timetableLessons) {
+			if (lesson.dayOfWeek !== dayOfWeek) continue;
+			entries.push({
+				dayKey,
+				time: lesson.startTime,
+				durationMinutes: getTimetableLessonDuration(lesson) ?? undefined,
+			});
+		}
+	}
+
+	return { entries, wasTruncated };
+};
+
 const getSessionDayEntryTitle = (
 	plan: Doc<"learningPlans">,
 	session: Pick<Doc<"learningPlanSessions">, "title">,
@@ -758,6 +854,68 @@ export const setTargetStudyMinutes = mutation({
 			updatedAt: Date.now(),
 		});
 		return args.targetStudyMinutes;
+	},
+});
+
+export const getSchedulingAvailability = query({
+	args: {
+		fromDateKey: v.string(),
+		fromTimeMinutes: v.number(),
+		examDateKey: v.string(),
+	},
+	handler: async (ctx, args) => {
+		const ownerTokenIdentifier = await requireOwnerTokenIdentifier(ctx);
+		const dayKeys = getAvailabilityDayKeys(args.fromDateKey, args.examDateKey);
+		const learningTimes = await ctx.db
+			.query("userLearningTimes")
+			.withIndex("by_ownerTokenIdentifier", (q) =>
+				q.eq("ownerTokenIdentifier", ownerTokenIdentifier),
+			)
+			.take(MAX_LEARNING_TIMES);
+		const publicLearningTimes = learningTimes.map((learningTime) => ({
+			dayOfWeek: learningTime.dayOfWeek,
+			startTime: learningTime.startTime,
+			endTime: learningTime.endTime,
+		}));
+		const nominalStudyMinutes = calculateAvailableStudyMinutes({
+			fromDateKey: args.fromDateKey,
+			fromTimeMinutes: args.fromTimeMinutes,
+			examDateKey: args.examDateKey,
+			learningTimes: publicLearningTimes,
+		});
+
+		if (dayKeys.length === 0 || nominalStudyMinutes < 10) {
+			return {
+				availableStudyMinutes: nominalStudyMinutes,
+				status: "missing" as const,
+			};
+		}
+
+		const occupied = await getSchedulingOccupiedEntries(ctx, {
+			ownerTokenIdentifier,
+			dayKeys,
+		});
+		if (occupied.wasTruncated) {
+			return {
+				availableStudyMinutes: 0,
+				status: "occupied" as const,
+			};
+		}
+
+		const availableStudyMinutes = calculateAvailableStudyMinutes({
+			fromDateKey: args.fromDateKey,
+			fromTimeMinutes: args.fromTimeMinutes,
+			examDateKey: args.examDateKey,
+			learningTimes: publicLearningTimes,
+			occupiedEntries: occupied.entries,
+		});
+		return {
+			availableStudyMinutes,
+			status:
+				availableStudyMinutes >= 10
+					? ("available" as const)
+					: ("occupied" as const),
+		};
 	},
 });
 
@@ -1272,54 +1430,16 @@ export const getAiContext = internalQuery({
 				q.eq("ownerTokenIdentifier", identity.tokenIdentifier),
 			)
 			.take(MAX_LEARNING_TIMES);
-		const occupiedEntries: Array<{
-			dayKey: string;
-			time?: string;
-			durationMinutes?: number;
-		}> = [];
-		const timetableLessons = await getActiveTimetableLessons(
-			ctx,
-			identity.tokenIdentifier,
-		);
-		const seenEntryIds = new Set<string>();
-		for (const dayKey of getLearningPlanCalendarDayKeys(plan.examDateKey)) {
-			for (const queryDayKey of getDayKeyQueryVariants(dayKey)) {
-				const entries = await ctx.db
-					.query("dayEntries")
-					.withIndex("by_ownerTokenIdentifier_and_dayKey", (q) =>
-						q
-							.eq("ownerTokenIdentifier", identity.tokenIdentifier)
-							.eq("dayKey", queryDayKey),
-					)
-					.take(50);
-
-				for (const entry of entries) {
-					if (seenEntryIds.has(entry._id)) continue;
-					seenEntryIds.add(entry._id);
-					occupiedEntries.push({
-						dayKey,
-						time: isExamEntry(entry) ? undefined : entry.time,
-						durationMinutes: entry.durationMinutes,
-					});
-				}
-			}
-			const dayOfWeek = getTimetableDayOfWeek(dayKey);
-			for (const lesson of timetableLessons.filter(
-				(item) => item.dayOfWeek === dayOfWeek,
-			)) {
-				occupiedEntries.push({
-					dayKey,
-					time: lesson.startTime,
-					durationMinutes: getTimetableLessonDuration(lesson) ?? undefined,
-				});
-			}
-		}
+		const occupied = await getSchedulingOccupiedEntries(ctx, {
+			ownerTokenIdentifier: identity.tokenIdentifier,
+			dayKeys: getLearningPlanCalendarDayKeys(plan.examDateKey),
+		});
 
 		return {
 			plan,
 			documents,
 			learningTimes,
-			occupiedEntries,
+			occupiedEntries: occupied.entries,
 			accessKey: buildPlanAccessKey(args.learningPlanId),
 		};
 	},

--- a/src/app/(creation)/entry/new.tsx
+++ b/src/app/(creation)/entry/new.tsx
@@ -1,10 +1,9 @@
-import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { useConvex, useConvexAuth, useMutation, useQuery } from "convex/react";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import {
 	type ReactNode,
 	useCallback,
 	useEffect,
-	useMemo,
 	useRef,
 	useState,
 } from "react";
@@ -23,6 +22,7 @@ import Animated, { FadeIn } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { api } from "#convex/_generated/api";
 import type { Id } from "#convex/_generated/dataModel";
+import { ExamCreationActions } from "~/components/entry/exam-creation-actions";
 import {
 	ExamDateSelector,
 	ExamTypePicker,
@@ -65,13 +65,13 @@ import { Textarea } from "~/components/ui/textarea";
 import { useAuthSession } from "~/context/AuthContext";
 import { getExamEntryCreationProgress } from "~/features/learning-plans/creation-progress";
 import { useLearningPlanCreationProgress } from "~/features/learning-plans/creation-progress-shell";
-import { LearningAvailabilityStep } from "~/features/learning-plans/learning-availability-step";
 import {
-	calculateAvailableStudyMinutes,
-	shouldShowLearningTimeValidation,
-} from "~/features/learning-plans/plan-workload";
+	LearningAvailabilityAction,
+	LearningAvailabilityStep,
+} from "~/features/learning-plans/learning-availability-step";
+import { shouldShowLearningTimeValidation } from "~/features/learning-plans/plan-workload";
 import { getErrorMessage } from "~/features/learning-plans/utils";
-import { useValidationAnalytics } from "~/lib/use-validation-analytics";
+import { createAsyncActionGate } from "~/lib/async-action-gate";
 import { getDayKey, parseDayKey, startOfLocalDay } from "~/lib/day-key";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 import { EXAM_TYPE_OPTIONS } from "~/lib/entry-options";
@@ -85,6 +85,7 @@ import {
 import { goBackOrReplace, useBackIntent } from "~/lib/navigation";
 import { ROUTES, withReturnTo } from "~/lib/routes";
 import { useDayovaTheme } from "~/lib/theme";
+import { useValidationAnalytics } from "~/lib/use-validation-analytics";
 import { cn } from "~/lib/utils";
 
 type EntryType = "homework" | "exam";
@@ -163,6 +164,14 @@ const formatCompactDate = (date: Date) =>
 		month: "long",
 		year: "numeric",
 	}).format(date);
+
+const getAvailabilityCheckTime = () => {
+	const now = new Date();
+	return {
+		dayKey: getDayKey(now),
+		timeMinutes: now.getHours() * 60 + now.getMinutes(),
+	};
+};
 
 const homeworkSuccessPath = ({
 	dayKey,
@@ -272,6 +281,7 @@ function StickyActionFooter({
 
 export default function NewEntryScreen() {
 	const router = useRouter();
+	const convex = useConvex();
 	const insets = useSafeAreaInsets();
 	const { colors } = useDayovaTheme();
 	const fieldIconColor = colors.secondaryText;
@@ -288,10 +298,6 @@ export default function NewEntryScreen() {
 	}>();
 	const entryType: EntryType = params.type === "exam" ? "exam" : "homework";
 	const isHomework = entryType === "homework";
-	const learningTimes = useQuery(
-		api.learningTimes.listMine,
-		user && isConvexAuthenticated && !isHomework ? {} : "skip",
-	);
 	const [initialDate] = useState(() => parseDateKey(params.dayKey));
 
 	const [step, setStep] = useState<EntryStep>(() =>
@@ -317,6 +323,13 @@ export default function NewEntryScreen() {
 		return next;
 	});
 	const [isCreating, setIsCreating] = useState(false);
+	const [
+		isCheckingLearningPlanAvailability,
+		setIsCheckingLearningPlanAvailability,
+	] = useState(false);
+	const [availabilityCheckTime, setAvailabilityCheckTime] = useState(
+		getAvailabilityCheckTime,
+	);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [pickerTarget, setPickerTarget] = useState<PickerTarget | null>(null);
 	const [selectTarget, setSelectTarget] = useState<SelectTarget | null>(null);
@@ -331,6 +344,7 @@ export default function NewEntryScreen() {
 	const keyboardDismissFrameRef = useRef<ReturnType<
 		typeof requestAnimationFrame
 	> | null>(null);
+	const entryCreationGateRef = useRef(createAsyncActionGate());
 
 	const trimmedSubject = subject.trim();
 	const trimmedExamType = examTypeLabel.trim();
@@ -346,24 +360,22 @@ export default function NewEntryScreen() {
 	const canCreateHomework = trimmedSubject.length > 0;
 	const canCreateExam = trimmedSubject.length > 0 && Boolean(selectedExamType);
 	const canWriteEntries = Boolean(user && isConvexAuthenticated);
-	const todayDayKey = getDayKey(new Date());
+	const todayDayKey = availabilityCheckTime.dayKey;
 	const examDayKey = getDayKey(plannedDate);
-	const availableStudyMinutes = useMemo(
-		() =>
-			learningTimes === undefined
-				? null
-				: calculateAvailableStudyMinutes({
-						fromDateKey: todayDayKey,
-						examDateKey: examDayKey,
-						learningTimes,
-					}),
-		[examDayKey, learningTimes, todayDayKey],
+	const schedulingAvailability = useQuery(
+		api.learningPlans.getSchedulingAvailability,
+		user && isConvexAuthenticated && !isHomework
+			? {
+					fromDateKey: todayDayKey,
+					fromTimeMinutes: availabilityCheckTime.timeMinutes,
+					examDateKey: examDayKey,
+				}
+			: "skip",
 	);
 	const isFutureExam = examDayKey > todayDayKey;
 	const isLearningTimeCheckLoading =
-		isFutureExam && learningTimes === undefined;
-	const hasUsableLearningTime =
-		availableStudyMinutes !== null && availableStudyMinutes >= 10;
+		isFutureExam && schedulingAvailability === undefined;
+	const hasUsableLearningTime = schedulingAvailability?.status === "available";
 	const examStepTitle =
 		step === "basics"
 			? "Wann findet die Prüfung statt?"
@@ -388,6 +400,33 @@ export default function NewEntryScreen() {
 	}, []);
 
 	useEffect(() => clearPendingModalOpen, [clearPendingModalOpen]);
+
+	useEffect(() => {
+		if (isHomework) return;
+
+		let refreshInterval: ReturnType<typeof setInterval> | null = null;
+		const refresh = () => {
+			setAvailabilityCheckTime((current) => {
+				const next = getAvailabilityCheckTime();
+				return current.dayKey === next.dayKey &&
+					current.timeMinutes === next.timeMinutes
+					? current
+					: next;
+			});
+		};
+		const refreshTimeout = setTimeout(
+			() => {
+				refresh();
+				refreshInterval = setInterval(refresh, 60_000);
+			},
+			60_000 - (Date.now() % 60_000),
+		);
+
+		return () => {
+			clearTimeout(refreshTimeout);
+			if (refreshInterval) clearInterval(refreshInterval);
+		};
+	}, [isHomework]);
 
 	const openAfterKeyboardDismiss = useCallback(
 		(open: () => void) => {
@@ -483,7 +522,7 @@ export default function NewEntryScreen() {
 		}
 	};
 
-	const createEntry = async ({
+	const createEntryWithinGate = async ({
 		redirectToHome = true,
 	}: {
 		redirectToHome?: boolean;
@@ -567,23 +606,71 @@ export default function NewEntryScreen() {
 		return result;
 	};
 
+	const createEntry = async (options: { redirectToHome?: boolean } = {}) => {
+		const result = await entryCreationGateRef.current.run(() =>
+			createEntryWithinGate(options),
+		);
+		return result.status === "completed" ? result.value : undefined;
+	};
+
 	const createLearningPlan = async () => {
-		if (!canCreateExam || isCreating || !canWriteEntries) return;
+		if (
+			!canCreateExam ||
+			!hasUsableLearningTime ||
+			isCreating ||
+			isCheckingLearningPlanAvailability ||
+			!canWriteEntries
+		) {
+			return;
+		}
 
-		const createdExam = await createEntry({ redirectToHome: false });
-		if (!createdExam?.createdEntryId) return;
+		await entryCreationGateRef.current.run(async () => {
+			setIsCheckingLearningPlanAvailability(true);
+			setErrorMessage(null);
+			try {
+				const latestCheckTime = getAvailabilityCheckTime();
+				const latestAvailability = await convex.query(
+					api.learningPlans.getSchedulingAvailability,
+					{
+						fromDateKey: latestCheckTime.dayKey,
+						fromTimeMinutes: latestCheckTime.timeMinutes,
+						examDateKey: getDayKey(plannedDate),
+					},
+				);
+				if (latestAvailability.status !== "available") {
+					setAvailabilityCheckTime(latestCheckTime);
+					setDidShowLearningAvailability(true);
+					goToStep("learningAvailability");
+					return;
+				}
 
-		const query = [
-			["examDayEntryId", createdExam.createdEntryId],
-			["subject", trimmedSubject],
-			["examTypeLabel", trimmedExamType],
-			["examDateKey", getDayKey(plannedDate)],
-			["examDateLabel", formatDate(plannedDate)],
-			["durationMinutes", `${scheduledDurationMinutes}`],
-		]
-			.map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
-			.join("&");
-		router.push(`${ROUTES.createLearningPlan}?${query}`);
+				const createdExam = await createEntryWithinGate({
+					redirectToHome: false,
+				});
+				if (!createdExam?.createdEntryId) return;
+
+				const query = [
+					["examDayEntryId", createdExam.createdEntryId],
+					["subject", trimmedSubject],
+					["examTypeLabel", trimmedExamType],
+					["examDateKey", getDayKey(plannedDate)],
+					["examDateLabel", formatDate(plannedDate)],
+					["durationMinutes", `${scheduledDurationMinutes}`],
+				]
+					.map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+					.join("&");
+				router.push(`${ROUTES.createLearningPlan}?${query}`);
+			} catch (error) {
+				setErrorMessage(
+					getErrorMessage(
+						error,
+						"Deine freie Lernzeit konnte nicht geprüft werden. Bitte versuche es erneut.",
+					),
+				);
+			} finally {
+				setIsCheckingLearningPlanAvailability(false);
+			}
+		});
 	};
 
 	const goToStep = useCallback((nextStep: EntryStep) => {
@@ -592,7 +679,7 @@ export default function NewEntryScreen() {
 	}, []);
 
 	const continueFromExamDate = () => {
-		if (learningTimes === undefined && isFutureExam) return;
+		if (schedulingAvailability === undefined && isFutureExam) return;
 		if (
 			shouldShowLearningTimeValidation({
 				fromDateKey: todayDayKey,
@@ -888,7 +975,7 @@ export default function NewEntryScreen() {
 								/>
 							) : step === "learningAvailability" ? (
 								<LearningAvailabilityStep
-									availableStudyMinutes={availableStudyMinutes}
+									availabilityStatus={schedulingAvailability?.status ?? null}
 									examDateLabel={formatCompactDate(plannedDate)}
 								/>
 							) : step === "examType" ? (
@@ -961,54 +1048,38 @@ export default function NewEntryScreen() {
 								{errorMessage}
 							</Text>
 						) : null}
-						<View className="flex-row gap-3">
-							<Button
-								className="flex-1"
-								variant="neutral"
-								disabled={!canCreateExam || isCreating || !canWriteEntries}
-								onPress={() => {
-									void createEntry();
-								}}
-							>
-								<Text>Eintragen</Text>
-							</Button>
-							<Button
-								className="flex-1"
-								disabled={!canCreateExam || isCreating || !canWriteEntries}
-								onPress={() => {
-									void createLearningPlan();
-								}}
-							>
-								<Text>Lernplan</Text>
-							</Button>
-						</View>
+						<ExamCreationActions
+							canCreateExam={canCreateExam && canWriteEntries}
+							canCreateLearningPlan={
+								canCreateExam && hasUsableLearningTime && canWriteEntries
+							}
+							isCheckingLearningPlanAvailability={
+								isCheckingLearningPlanAvailability
+							}
+							isCreating={isCreating}
+							onCreateExam={() => {
+								void createEntry();
+							}}
+							onCreateLearningPlan={() => {
+								void createLearningPlan();
+							}}
+						/>
 					</StickyActionFooter>
 				) : step === "learningAvailability" ? (
 					<StickyActionFooter bottomInset={insets.bottom}>
-						<Button
-							className="w-full"
-							disabled={availableStudyMinutes === null}
-							onPress={() => {
-								if (hasUsableLearningTime) {
-									goToStep("examType");
-									return;
-								}
-								openLearningTimes();
-							}}
-						>
-							{availableStudyMinutes === null ? (
-								<ActivityIndicator color="#FFFFFF" />
-							) : (
-								<Text>
-									{hasUsableLearningTime ? "Weiter" : "Lernzeit eintragen"}
-								</Text>
-							)}
-						</Button>
+						<LearningAvailabilityAction
+							availabilityStatus={schedulingAvailability?.status ?? null}
+							onContinue={() => goToStep("examType")}
+							onEditLearningTimes={openLearningTimes}
+						/>
 					</StickyActionFooter>
 				) : (
 					<StickyActionFooter bottomInset={insets.bottom}>
 						<Button
 							className="w-full"
+							accessibilityState={{
+								busy: step === "basics" && isLearningTimeCheckLoading,
+							}}
 							disabled={
 								(step === "examType" && !trimmedExamType) ||
 								(step === "basics" && isLearningTimeCheckLoading)

--- a/src/components/entry/exam-creation-actions.tsx
+++ b/src/components/entry/exam-creation-actions.tsx
@@ -1,0 +1,58 @@
+import { ActivityIndicator, View } from "react-native";
+import { Button } from "~/components/ui/button";
+import { Text } from "~/components/ui/text";
+
+export function ExamCreationActions({
+	canCreateExam,
+	canCreateLearningPlan,
+	isCheckingLearningPlanAvailability,
+	isCreating,
+	onCreateExam,
+	onCreateLearningPlan,
+}: {
+	canCreateExam: boolean;
+	canCreateLearningPlan: boolean;
+	isCheckingLearningPlanAvailability: boolean;
+	isCreating: boolean;
+	onCreateExam: () => void;
+	onCreateLearningPlan: () => void;
+}) {
+	const isBusy = isCreating || isCheckingLearningPlanAvailability;
+
+	return (
+		<View className="flex-row gap-3">
+			<Button
+				accessibilityState={{
+					busy: isBusy,
+					disabled: !canCreateExam || isBusy,
+				}}
+				className="flex-1"
+				variant="neutral"
+				disabled={!canCreateExam || isBusy}
+				onPress={onCreateExam}
+			>
+				<Text>Eintragen</Text>
+			</Button>
+			<Button
+				accessibilityLabel={
+					isCheckingLearningPlanAvailability
+						? "Lernplan, Lernzeit wird geprüft"
+						: "Lernplan"
+				}
+				accessibilityState={{
+					busy: isBusy,
+					disabled: !canCreateLearningPlan || isBusy,
+				}}
+				className="flex-1"
+				disabled={!canCreateLearningPlan || isBusy}
+				onPress={onCreateLearningPlan}
+			>
+				{isCheckingLearningPlanAvailability ? (
+					<ActivityIndicator color="#FFFFFF" />
+				) : (
+					<Text>Lernplan</Text>
+				)}
+			</Button>
+		</View>
+	);
+}

--- a/src/components/entry/exam-creation-actions.ui.test.tsx
+++ b/src/components/entry/exam-creation-actions.ui.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { fireEvent, render } from "@testing-library/react-native";
+import { ExamCreationActions } from "./exam-creation-actions";
+
+describe("ExamCreationActions", () => {
+	test("blocks both creation paths while learning-plan availability is checked", async () => {
+		const onCreateExam = jest.fn();
+		const onCreateLearningPlan = jest.fn();
+		const screen = await render(
+			<ExamCreationActions
+				canCreateExam
+				canCreateLearningPlan
+				isCheckingLearningPlanAvailability
+				isCreating={false}
+				onCreateExam={onCreateExam}
+				onCreateLearningPlan={onCreateLearningPlan}
+			/>,
+		);
+
+		fireEvent.press(screen.getByRole("button", { name: "Eintragen" }));
+		fireEvent.press(
+			screen.getByRole("button", {
+				name: "Lernplan, Lernzeit wird geprüft",
+			}),
+		);
+
+		expect(onCreateExam).not.toHaveBeenCalled();
+		expect(onCreateLearningPlan).not.toHaveBeenCalled();
+	});
+});

--- a/src/features/learning-plans/learning-availability-step.tsx
+++ b/src/features/learning-plans/learning-availability-step.tsx
@@ -1,24 +1,26 @@
 import { ActivityIndicator, View } from "react-native";
+import { Button } from "~/components/ui/button";
 import { Check, Clock3 } from "~/components/ui/icon";
 import { Surface } from "~/components/ui/surface";
 import { Text } from "~/components/ui/text";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 
 export function LearningAvailabilityStep({
-	availableStudyMinutes,
+	availabilityStatus,
 	examDateLabel,
 }: {
-	availableStudyMinutes: number | null;
+	availabilityStatus: "available" | "missing" | "occupied" | null;
 	examDateLabel: string;
 }) {
-	const hasUsableLearningTime =
-		availableStudyMinutes !== null && availableStudyMinutes >= 10;
+	const isLoading = availabilityStatus === null;
+	const hasUsableLearningTime = availabilityStatus === "available";
+	const isOccupied = availabilityStatus === "occupied";
 
 	return (
 		<View className="flex-1 pt-2">
 			<Surface className="rounded-[32px] px-6 py-7" variant="soft">
 				<View className="h-14 w-14 items-center justify-center rounded-[20px] bg-system-subtle">
-					{availableStudyMinutes === null ? (
+					{isLoading ? (
 						<ActivityIndicator color={DAYOVA_DESIGN_SYSTEM.colors.primary} />
 					) : hasUsableLearningTime ? (
 						<Check size={27} color="#34C759" strokeWidth={2.5} />
@@ -31,26 +33,59 @@ export function LearningAvailabilityStep({
 					)}
 				</View>
 				<Text className="mt-5 font-poppins font-semibold text-body-2 text-text">
-					{availableStudyMinutes === null
+					{isLoading
 						? "Wir prüfen deine Lernzeiten"
 						: hasUsableLearningTime
 							? "Lernzeit gefunden"
-							: "Ein Zeitfenster reicht für den Anfang"}
+							: isOccupied
+								? "Deine Lernzeiten sind schon belegt"
+								: "Noch keine freie Lernzeit"}
 				</Text>
 				<Text className="mt-2 font-poppins text-body-3 text-secondary-text">
-					{availableStudyMinutes === null
+					{isLoading
 						? "Das dauert nur einen Moment."
 						: hasUsableLearningTime
 							? `Dayova kann deinen Lernweg vor dem ${examDateLabel} in deine gespeicherten Zeiten einplanen.`
-							: `Lege mindestens ein Zeitfenster vor dem ${examDateLabel} fest. Dayova plant später nur innerhalb dieser Zeiten.`}
+							: isOccupied
+								? `Bis zum ${examDateLabel} ist kein freies Zeitfenster von mindestens 10 Minuten mehr verfügbar.`
+								: `Lege mindestens ein Zeitfenster vor dem ${examDateLabel} fest. Dayova plant später nur innerhalb dieser Zeiten.`}
 				</Text>
-				{availableStudyMinutes !== null && !hasUsableLearningTime ? (
+				{!isLoading && !hasUsableLearningTime ? (
 					<Text className="mt-4 font-poppins text-body-4 text-secondary-text">
-						Du entscheidest hier nur, wann Lernen grundsätzlich möglich ist –
-						noch nicht, wie viel du schaffen musst.
+						{isOccupied
+							? "Verschiebe einen bestehenden Lerntermin oder füge eine zusätzliche Lernzeit hinzu."
+							: "Du entscheidest hier nur, wann Lernen grundsätzlich möglich ist – noch nicht, wie viel du schaffen musst."}
 					</Text>
 				) : null}
 			</Surface>
 		</View>
+	);
+}
+
+export function LearningAvailabilityAction({
+	availabilityStatus,
+	onContinue,
+	onEditLearningTimes,
+}: {
+	availabilityStatus: "available" | "missing" | "occupied" | null;
+	onContinue: () => void;
+	onEditLearningTimes: () => void;
+}) {
+	const isLoading = availabilityStatus === null;
+	const hasUsableLearningTime = availabilityStatus === "available";
+
+	return (
+		<Button
+			accessibilityState={{ busy: isLoading, disabled: isLoading }}
+			className="w-full"
+			disabled={isLoading}
+			onPress={hasUsableLearningTime ? onContinue : onEditLearningTimes}
+		>
+			{isLoading ? (
+				<ActivityIndicator color="#FFFFFF" />
+			) : (
+				<Text>{hasUsableLearningTime ? "Weiter" : "Lernzeit eintragen"}</Text>
+			)}
+		</Button>
 	);
 }

--- a/src/features/learning-plans/learning-availability-step.ui.test.tsx
+++ b/src/features/learning-plans/learning-availability-step.ui.test.tsx
@@ -1,19 +1,20 @@
-import { describe, expect, test } from "@jest/globals";
-import { render } from "@testing-library/react-native";
-import { LearningAvailabilityStep } from "./learning-availability-step";
+import { describe, expect, jest, test } from "@jest/globals";
+import { fireEvent, render } from "@testing-library/react-native";
+import {
+	LearningAvailabilityAction,
+	LearningAvailabilityStep,
+} from "./learning-availability-step";
 
 describe("LearningAvailabilityStep", () => {
 	test("asks for a calm scheduling prerequisite without assigning workload", async () => {
 		const screen = await render(
 			<LearningAvailabilityStep
-				availableStudyMinutes={0}
+				availabilityStatus="missing"
 				examDateLabel="12. August 2026"
 			/>,
 		);
 
-		expect(
-			screen.getByText("Ein Zeitfenster reicht für den Anfang"),
-		).toBeOnTheScreen();
+		expect(screen.getByText("Noch keine freie Lernzeit")).toBeOnTheScreen();
 		expect(
 			screen.getByText(/noch nicht, wie viel du schaffen musst/),
 		).toBeOnTheScreen();
@@ -22,12 +23,46 @@ describe("LearningAvailabilityStep", () => {
 	test("confirms that an existing learning window can be used", async () => {
 		const screen = await render(
 			<LearningAvailabilityStep
-				availableStudyMinutes={30}
+				availabilityStatus="available"
 				examDateLabel="12. August 2026"
 			/>,
 		);
 
 		expect(screen.getByText("Lernzeit gefunden")).toBeOnTheScreen();
 		expect(screen.queryByText(/noch nicht, wie viel/)).not.toBeOnTheScreen();
+	});
+
+	test("explains how to recover when every saved learning time is occupied", async () => {
+		const screen = await render(
+			<LearningAvailabilityStep
+				availabilityStatus="occupied"
+				examDateLabel="12. August 2026"
+			/>,
+		);
+
+		expect(
+			screen.getByText("Deine Lernzeiten sind schon belegt"),
+		).toBeOnTheScreen();
+		expect(
+			screen.getByText(/bestehenden Lerntermin.*zusätzliche Lernzeit/),
+		).toBeOnTheScreen();
+		expect(screen.queryByText("Lernzeit gefunden")).not.toBeOnTheScreen();
+	});
+
+	test("opens learning-time editing instead of continuing when time is occupied", async () => {
+		const onContinue = jest.fn();
+		const onEditLearningTimes = jest.fn();
+		const screen = await render(
+			<LearningAvailabilityAction
+				availabilityStatus="occupied"
+				onContinue={onContinue}
+				onEditLearningTimes={onEditLearningTimes}
+			/>,
+		);
+
+		fireEvent.press(screen.getByRole("button", { name: "Lernzeit eintragen" }));
+
+		expect(onEditLearningTimes).toHaveBeenCalledTimes(1);
+		expect(onContinue).not.toHaveBeenCalled();
 	});
 });

--- a/src/features/learning-plans/plan-workload.test.ts
+++ b/src/features/learning-plans/plan-workload.test.ts
@@ -55,6 +55,34 @@ describe("total study workload suggestion", () => {
 		).toBe(170);
 	});
 
+	test("does not count a saved Lernzeit that is already fully occupied", () => {
+		expect(
+			calculateAvailableStudyMinutes({
+				fromDateKey: "2026-06-01",
+				examDateKey: "2026-06-03",
+				learningTimes: [{ dayOfWeek: 2, startTime: "17:00", endTime: "18:00" }],
+				occupiedEntries: [
+					{
+						dayKey: "2026-06-02",
+						time: "17:00",
+						durationMinutes: 60,
+					},
+				],
+			}),
+		).toBe(0);
+	});
+
+	test("does not count a learning window that has already started today", () => {
+		expect(
+			calculateAvailableStudyMinutes({
+				fromDateKey: "2026-06-02",
+				fromTimeMinutes: 17 * 60,
+				examDateKey: "2026-06-03",
+				learningTimes: [{ dayOfWeek: 2, startTime: "17:00", endTime: "18:00" }],
+			}),
+		).toBe(0);
+	});
+
 	test("requests learning time only when a future exam has no usable window", () => {
 		expect(
 			shouldRequestLearningTimeBeforeExam({

--- a/src/features/learning-plans/plan-workload.ts
+++ b/src/features/learning-plans/plan-workload.ts
@@ -1,53 +1,16 @@
+import { calculateAvailableStudyMinutes } from "#convex/learningPlanAvailability";
 import {
 	getDefaultPreparationDepth,
-	recommendLearningPreparation,
 	type PreparationDepth,
+	recommendLearningPreparation,
 } from "#convex/learningPreparationPolicy";
+
+export { calculateAvailableStudyMinutes };
 
 const MIN_TOTAL_STUDY_MINUTES = 30;
 const MAX_TOTAL_STUDY_MINUTES = 180;
 
 const roundToTen = (minutes: number) => Math.round(minutes / 10) * 10;
-
-const parseTimeToMinutes = (time: string) => {
-	const [hours, minutes] = time.split(":").map(Number);
-	if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return null;
-	return (hours ?? 0) * 60 + (minutes ?? 0);
-};
-
-export const calculateAvailableStudyMinutes = ({
-	fromDateKey,
-	examDateKey,
-	learningTimes,
-}: {
-	fromDateKey: string;
-	examDateKey: string;
-	learningTimes: Array<{
-		dayOfWeek: number;
-		startTime: string;
-		endTime: string;
-	}>;
-}) => {
-	const cursor = new Date(`${fromDateKey}T00:00:00.000Z`);
-	const examDate = new Date(`${examDateKey}T00:00:00.000Z`);
-	if (Number.isNaN(cursor.getTime()) || Number.isNaN(examDate.getTime()))
-		return 0;
-
-	let availableMinutes = 0;
-	while (cursor < examDate) {
-		const dayOfWeek = cursor.getUTCDay() || 7;
-		for (const learningTime of learningTimes) {
-			if (learningTime.dayOfWeek !== dayOfWeek) continue;
-			const start = parseTimeToMinutes(learningTime.startTime);
-			const end = parseTimeToMinutes(learningTime.endTime);
-			if (start === null || end === null || end - start < 10) continue;
-			availableMinutes += Math.min(120, end - start);
-		}
-		cursor.setUTCDate(cursor.getUTCDate() + 1);
-	}
-
-	return availableMinutes;
-};
 
 export const shouldRequestLearningTimeBeforeExam = ({
 	fromDateKey,


### PR DESCRIPTION
## Summary

- calculate learning-plan availability from free recurring windows after appointments, active timetable lessons, and elapsed windows
- block the creation flow when no schedulable interval of at least 10 minutes remains, and recheck immediately before plan creation
- add actionable occupied-state copy plus regression coverage for backend availability and both creation actions

## Root cause

The early availability check counted saved recurring learning windows but did not subtract occupied entries or elapsed windows, while the backend scheduler did. This allowed the flow to display “Lernzeit gefunden” and continue even though generation could not schedule anything.

## Validation

- `pnpm test:unit` — 87 files, 520 tests passed
- focused UI Jest suites — 2 suites, 5 tests passed
- `pnpm typecheck`
- scoped Biome and ESLint checks
- independent standards and specification reviews — no remaining findings
- current branch deployed successfully to `resilient-pika-316`
- directly verified `learningPlans:getSchedulingAvailability` against the deployed backend

## Notes

- Repository-wide `pnpm check` reaches two pre-existing ESLint failures in the unchanged learning-session screen; all changed files pass their scoped checks.
- The development deployment had forward-schema data and writers from the adaptive-learning-plan and AI-budget branches. At the user's request, it was aligned to this branch with a temporary widen–migrate–narrow sequence: branch-only fields were stripped from affected usage, plan, and session records, eight obsolete budget-reservation records were deleted, and the clean current schema was deployed. Production was not touched.