### PR TITLE
Show evidence-based topic readiness on dashboard

### DIFF
--- a/src/features/dashboard/dashboard-agenda.test.ts
+++ b/src/features/dashboard/dashboard-agenda.test.ts
@@ -8,8 +8,6 @@ import {
 	getDashboardCalendarDayKeys,
 	getDashboardRelevantDayKeys,
 	getDashboardWeekDayKeys,
-	getDashboardWeekProgress,
-	getDashboardWeekProgressFooter,
 	isDashboardAgendaItemPast,
 	sortDashboardAgendaItems,
 	toDashboardAgendaItem,
@@ -98,116 +96,6 @@ describe("dashboard agenda", () => {
 		expect(keys).toContain("2027-08-12");
 		expect(keys).toContain("2027-08-13");
 		expect(keys).toContain("2026-07-29");
-	});
-
-	it("summarizes completed learning sessions in the current week", () => {
-		const items = [
-			toDashboardAgendaItem(
-				"2026-07-27",
-				entry({
-					id: "completed-before-today" as DayEntry["id"],
-					kind: "Lernen",
-					completed: true,
-					durationMinutes: 25,
-				}),
-			),
-			toDashboardAgendaItem(
-				"2026-07-29",
-				entry({
-					id: "completed-today" as DayEntry["id"],
-					kind: "Lernen",
-					executionStatus: "completed",
-					durationMinutes: 35,
-				}),
-			),
-			toDashboardAgendaItem(
-				"2026-07-30",
-				entry({
-					id: "upcoming" as DayEntry["id"],
-					kind: "Lernen",
-					durationMinutes: 20,
-				}),
-			),
-			toDashboardAgendaItem(
-				"2026-07-29",
-				entry({
-					id: "homework" as DayEntry["id"],
-					kind: "Hausaufgabe",
-					completed: true,
-					durationMinutes: 90,
-				}),
-			),
-			toDashboardAgendaItem(
-				"2026-08-03",
-				entry({
-					id: "next-week" as DayEntry["id"],
-					kind: "Lernen",
-					completed: true,
-					durationMinutes: 45,
-				}),
-			),
-		];
-
-		expect(
-			getDashboardWeekProgress({
-				items,
-				todayKey: "2026-07-29",
-			}),
-		).toEqual({
-			completedLearningSessions: 2,
-			completionPercent: 67,
-			remainingLearningSessions: 1,
-			totalLearningSessions: 3,
-		});
-	});
-
-	it("describes the remaining weekly work instead of elapsed minutes", () => {
-		const progress = {
-			completedLearningSessions: 2,
-			completionPercent: 67,
-			remainingLearningSessions: 1,
-			totalLearningSessions: 3,
-		};
-
-		expect(getDashboardWeekProgressFooter({ isLoading: false, progress })).toBe(
-			"Noch 1 Lernschritt",
-		);
-		expect(
-			getDashboardWeekProgressFooter({
-				isLoading: false,
-				progress: {
-					...progress,
-					completedLearningSessions: 1,
-					completionPercent: 33,
-					remainingLearningSessions: 2,
-				},
-			}),
-		).toBe("Noch 2 Lernschritte");
-		expect(
-			getDashboardWeekProgressFooter({
-				isLoading: false,
-				progress: {
-					...progress,
-					completedLearningSessions: 3,
-					completionPercent: 100,
-					remainingLearningSessions: 0,
-				},
-			}),
-		).toBe("Wochenziel erreicht");
-		expect(
-			getDashboardWeekProgressFooter({
-				isLoading: false,
-				progress: {
-					completedLearningSessions: 0,
-					completionPercent: 0,
-					remainingLearningSessions: 0,
-					totalLearningSessions: 0,
-				},
-			}),
-		).toBe("Lernplan öffnen");
-		expect(getDashboardWeekProgressFooter({ isLoading: true, progress })).toBe(
-			"Diese Woche",
-		);
 	});
 
 	it("keeps passive lessons distinct from Dayova learning sessions", () => {

--- a/src/features/dashboard/dashboard-agenda.test.ts
+++ b/src/features/dashboard/dashboard-agenda.test.ts
@@ -9,6 +9,7 @@ import {
 	getDashboardRelevantDayKeys,
 	getDashboardWeekDayKeys,
 	getDashboardWeekProgress,
+	getDashboardWeekProgressFooter,
 	isDashboardAgendaItemPast,
 	sortDashboardAgendaItems,
 	toDashboardAgendaItem,
@@ -154,11 +155,59 @@ describe("dashboard agenda", () => {
 			}),
 		).toEqual({
 			completedLearningSessions: 2,
-			completedMinutesToday: 35,
 			completionPercent: 67,
 			remainingLearningSessions: 1,
 			totalLearningSessions: 3,
 		});
+	});
+
+	it("describes the remaining weekly work instead of elapsed minutes", () => {
+		const progress = {
+			completedLearningSessions: 2,
+			completionPercent: 67,
+			remainingLearningSessions: 1,
+			totalLearningSessions: 3,
+		};
+
+		expect(getDashboardWeekProgressFooter({ isLoading: false, progress })).toBe(
+			"Noch 1 Lernschritt",
+		);
+		expect(
+			getDashboardWeekProgressFooter({
+				isLoading: false,
+				progress: {
+					...progress,
+					completedLearningSessions: 1,
+					completionPercent: 33,
+					remainingLearningSessions: 2,
+				},
+			}),
+		).toBe("Noch 2 Lernschritte");
+		expect(
+			getDashboardWeekProgressFooter({
+				isLoading: false,
+				progress: {
+					...progress,
+					completedLearningSessions: 3,
+					completionPercent: 100,
+					remainingLearningSessions: 0,
+				},
+			}),
+		).toBe("Wochenziel erreicht");
+		expect(
+			getDashboardWeekProgressFooter({
+				isLoading: false,
+				progress: {
+					completedLearningSessions: 0,
+					completionPercent: 0,
+					remainingLearningSessions: 0,
+					totalLearningSessions: 0,
+				},
+			}),
+		).toBe("Lernplan öffnen");
+		expect(getDashboardWeekProgressFooter({ isLoading: true, progress })).toBe(
+			"Diese Woche",
+		);
 	});
 
 	it("keeps passive lessons distinct from Dayova learning sessions", () => {

--- a/src/features/dashboard/dashboard-agenda.ts
+++ b/src/features/dashboard/dashboard-agenda.ts
@@ -15,29 +15,6 @@ export type DashboardAgendaItem = {
 	endMinutes: number | null;
 };
 
-export type DashboardWeekProgress = {
-	completedLearningSessions: number;
-	completionPercent: number;
-	remainingLearningSessions: number;
-	totalLearningSessions: number;
-};
-
-export const getDashboardWeekProgressFooter = ({
-	isLoading,
-	progress,
-}: {
-	isLoading: boolean;
-	progress: DashboardWeekProgress;
-}) => {
-	if (isLoading) return "Diese Woche";
-	if (progress.totalLearningSessions === 0) return "Lernplan öffnen";
-	if (progress.remainingLearningSessions === 0) return "Wochenziel erreicht";
-
-	return `Noch ${progress.remainingLearningSessions} ${
-		progress.remainingLearningSessions === 1 ? "Lernschritt" : "Lernschritte"
-	}`;
-};
-
 export const getAdjacentDashboardDayKey = ({
 	selectedDayKey,
 	direction,
@@ -116,36 +93,6 @@ export const getDashboardRelevantDayKeys = ({
 	}
 
 	return [...keys].sort();
-};
-
-export const getDashboardWeekProgress = ({
-	items,
-	todayKey,
-}: {
-	items: DashboardAgendaItem[];
-	todayKey: string;
-}): DashboardWeekProgress => {
-	const weekDayKeys = new Set(getDashboardWeekDayKeys(todayKey));
-	const learningSessions = items.filter(
-		(item) => item.kind === "learningSession" && weekDayKeys.has(item.dayKey),
-	);
-	const completedLearningSessions = learningSessions.filter(
-		(item) =>
-			item.entry.completed === true ||
-			item.entry.executionStatus === "completed",
-	);
-	const totalLearningSessions = learningSessions.length;
-	const completedCount = completedLearningSessions.length;
-
-	return {
-		completedLearningSessions: completedCount,
-		completionPercent:
-			totalLearningSessions === 0
-				? 0
-				: Math.round((completedCount / totalLearningSessions) * 100),
-		remainingLearningSessions: totalLearningSessions - completedCount,
-		totalLearningSessions,
-	};
 };
 
 const SCHOOL_LESSON_PATTERN =

--- a/src/features/dashboard/dashboard-agenda.ts
+++ b/src/features/dashboard/dashboard-agenda.ts
@@ -17,10 +17,25 @@ export type DashboardAgendaItem = {
 
 export type DashboardWeekProgress = {
 	completedLearningSessions: number;
-	completedMinutesToday: number;
 	completionPercent: number;
 	remainingLearningSessions: number;
 	totalLearningSessions: number;
+};
+
+export const getDashboardWeekProgressFooter = ({
+	isLoading,
+	progress,
+}: {
+	isLoading: boolean;
+	progress: DashboardWeekProgress;
+}) => {
+	if (isLoading) return "Diese Woche";
+	if (progress.totalLearningSessions === 0) return "Lernplan öffnen";
+	if (progress.remainingLearningSessions === 0) return "Wochenziel erreicht";
+
+	return `Noch ${progress.remainingLearningSessions} ${
+		progress.remainingLearningSessions === 1 ? "Lernschritt" : "Lernschritte"
+	}`;
 };
 
 export const getAdjacentDashboardDayKey = ({
@@ -119,15 +134,11 @@ export const getDashboardWeekProgress = ({
 			item.entry.completed === true ||
 			item.entry.executionStatus === "completed",
 	);
-	const completedMinutesToday = completedLearningSessions
-		.filter((item) => item.dayKey === todayKey)
-		.reduce((total, item) => total + (item.entry.durationMinutes ?? 0), 0);
 	const totalLearningSessions = learningSessions.length;
 	const completedCount = completedLearningSessions.length;
 
 	return {
 		completedLearningSessions: completedCount,
-		completedMinutesToday,
 		completionPercent:
 			totalLearningSessions === 0
 				? 0

--- a/src/features/dashboard/dashboard-knowledge-progress.test.ts
+++ b/src/features/dashboard/dashboard-knowledge-progress.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { getDashboardKnowledgeProgressViewModel } from "./dashboard-knowledge-progress";
+
+describe("dashboard knowledge progress", () => {
+	it("shows the number of topics backed by secure evidence", () => {
+		expect(
+			getDashboardKnowledgeProgressViewModel({
+				hasKnowledgeEvidence: true,
+				hasLearningPlan: true,
+				isLoading: false,
+				secureTopics: 3,
+				totalTopics: 5,
+			}),
+		).toEqual({
+			accessibilityLabel:
+				"Wissensstand: 3 von 5 Themen sicher. Details ansehen.",
+			footer: "Details ansehen",
+			progressPercent: 60,
+			ringLabel: "Themen sicher",
+			ringValue: "3 / 5",
+		});
+	});
+
+	it("does not present missing evidence as zero ability", () => {
+		expect(
+			getDashboardKnowledgeProgressViewModel({
+				hasKnowledgeEvidence: false,
+				hasLearningPlan: true,
+				isLoading: false,
+				secureTopics: 0,
+				totalTopics: 5,
+			}),
+		).toMatchObject({
+			accessibilityLabel: "Wissensstand: Noch keine Wissensbelege",
+			footer: "Noch keine Belege",
+			ringValue: "–",
+		});
+	});
+
+	it("handles loading, empty, singular, and complete states", () => {
+		expect(
+			getDashboardKnowledgeProgressViewModel({
+				hasKnowledgeEvidence: false,
+				hasLearningPlan: false,
+				isLoading: true,
+				secureTopics: 0,
+				totalTopics: 0,
+			}),
+		).toMatchObject({
+			footer: "Wissensstand",
+			ringLabel: "wird geladen",
+			ringValue: "–",
+		});
+
+		expect(
+			getDashboardKnowledgeProgressViewModel({
+				hasKnowledgeEvidence: false,
+				hasLearningPlan: false,
+				isLoading: false,
+				secureTopics: 0,
+				totalTopics: 0,
+			}),
+		).toMatchObject({
+			footer: "Lernplan öffnen",
+			ringValue: "–",
+		});
+
+		expect(
+			getDashboardKnowledgeProgressViewModel({
+				hasKnowledgeEvidence: true,
+				hasLearningPlan: true,
+				isLoading: false,
+				secureTopics: 1,
+				totalTopics: 1,
+			}),
+		).toMatchObject({
+			footer: "Alle Themen sicher",
+			progressPercent: 100,
+			ringLabel: "Thema sicher",
+			ringValue: "1 / 1",
+		});
+	});
+});

--- a/src/features/dashboard/dashboard-knowledge-progress.ts
+++ b/src/features/dashboard/dashboard-knowledge-progress.ts
@@ -1,0 +1,67 @@
+export type DashboardKnowledgeProgressInput = {
+	hasKnowledgeEvidence: boolean;
+	hasLearningPlan: boolean;
+	isLoading: boolean;
+	secureTopics: number;
+	totalTopics: number;
+};
+
+export type DashboardKnowledgeProgressViewModel = {
+	accessibilityLabel: string;
+	footer: string;
+	progressPercent: number;
+	ringLabel: string;
+	ringValue: string;
+};
+
+export const getDashboardKnowledgeProgressViewModel = ({
+	hasKnowledgeEvidence,
+	hasLearningPlan,
+	isLoading,
+	secureTopics,
+	totalTopics,
+}: DashboardKnowledgeProgressInput): DashboardKnowledgeProgressViewModel => {
+	if (isLoading) {
+		return {
+			accessibilityLabel: "Wissensstand wird geladen",
+			footer: "Wissensstand",
+			progressPercent: 0,
+			ringLabel: "wird geladen",
+			ringValue: "–",
+		};
+	}
+
+	if (!hasLearningPlan || totalTopics <= 0) {
+		return {
+			accessibilityLabel: "Wissensstand: Noch kein persönlicher Lernplan",
+			footer: "Lernplan öffnen",
+			progressPercent: 0,
+			ringLabel: "Themen",
+			ringValue: "–",
+		};
+	}
+
+	if (!hasKnowledgeEvidence) {
+		return {
+			accessibilityLabel: "Wissensstand: Noch keine Wissensbelege",
+			footer: "Noch keine Belege",
+			progressPercent: 0,
+			ringLabel: "Themen",
+			ringValue: "–",
+		};
+	}
+
+	const safeTotal = Math.max(0, totalTopics);
+	const safeSecure = Math.min(Math.max(0, secureTopics), safeTotal);
+	const topicLabel = safeTotal === 1 ? "Thema sicher" : "Themen sicher";
+	const allTopicsSecure = safeSecure === safeTotal;
+	const footer = allTopicsSecure ? "Alle Themen sicher" : "Details ansehen";
+
+	return {
+		accessibilityLabel: `Wissensstand: ${safeSecure} von ${safeTotal} ${topicLabel}. ${footer}.`,
+		footer,
+		progressPercent: Math.round((safeSecure / safeTotal) * 100),
+		ringLabel: topicLabel,
+		ringValue: `${safeSecure} / ${safeTotal}`,
+	};
+};

--- a/src/features/dashboard/dashboard-screen.tsx
+++ b/src/features/dashboard/dashboard-screen.tsx
@@ -16,6 +16,7 @@ import { scheduleOnRN } from "react-native-worklets";
 import { api } from "#convex/_generated/api";
 import { NotificationButton } from "~/components/notification-button";
 import {
+	Analytics,
 	ArrowRight,
 	ArrowUpRight,
 	Backpack,
@@ -25,7 +26,6 @@ import {
 	Clock3,
 	Dumbbell,
 	ScanImage,
-	TimeManagement,
 } from "~/components/ui/icon";
 import { Text } from "~/components/ui/text";
 import { ThemedStatusBar } from "~/components/ui/themed-status-bar";
@@ -33,24 +33,23 @@ import { useAuthSession } from "~/context/AuthContext";
 import { getDayKey, parseDayKey, useCurrentLocalDay } from "~/lib/day-key";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 import { formatGermanUiText } from "~/lib/german-ui-text";
+import { ROUTES } from "~/lib/routes";
 import { triggerSelectionHaptic } from "~/lib/safe-haptics";
 import { useDayovaTheme } from "~/lib/theme";
 import { cn } from "~/lib/utils";
 import type { DayEntry } from "~/types/dayEntries";
 import {
 	type DashboardAgendaItem,
-	type DashboardWeekProgress,
 	findNextActionableAgendaItem,
 	getAgendaEntryTitle,
 	getDashboardCalendarDayKeys,
 	getDashboardRelevantDayKeys,
 	getDashboardWeekDayKeys,
-	getDashboardWeekProgress,
-	getDashboardWeekProgressFooter,
 	isDashboardAgendaItemPast,
 	sortDashboardAgendaItems,
 	toDashboardAgendaItem,
 } from "./dashboard-agenda";
+import { getDashboardKnowledgeProgressViewModel } from "./dashboard-knowledge-progress";
 
 const triggerDaySelectionHaptic = () => {
 	void triggerSelectionHaptic({
@@ -191,12 +190,12 @@ const getNextStepFooter = (item: DashboardAgendaItem, todayKey: string) => {
 	return "Lernschritt öffnen";
 };
 
-const WEEK_PROGRESS_RING_SIZE = 112;
-const WEEK_PROGRESS_RING_STROKE_WIDTH = 9;
-const WEEK_PROGRESS_RING_RADIUS =
-	(WEEK_PROGRESS_RING_SIZE - WEEK_PROGRESS_RING_STROKE_WIDTH) / 2;
-const WEEK_PROGRESS_RING_CIRCUMFERENCE =
-	2 * Math.PI * WEEK_PROGRESS_RING_RADIUS;
+const KNOWLEDGE_PROGRESS_RING_SIZE = 112;
+const KNOWLEDGE_PROGRESS_RING_STROKE_WIDTH = 9;
+const KNOWLEDGE_PROGRESS_RING_RADIUS =
+	(KNOWLEDGE_PROGRESS_RING_SIZE - KNOWLEDGE_PROGRESS_RING_STROKE_WIDTH) / 2;
+const KNOWLEDGE_PROGRESS_RING_CIRCUMFERENCE =
+	2 * Math.PI * KNOWLEDGE_PROGRESS_RING_RADIUS;
 
 function WeekCalendar({
 	days,
@@ -509,55 +508,54 @@ function NextLearningStepCard({
 	);
 }
 
-function WeeklyProgressCard({
+function KnowledgeProgressCard({
+	hasKnowledgeEvidence,
+	hasLearningPlan,
 	isLoading,
-	progress,
-	onOpenLearningPlans,
+	onPress,
+	secureTopics,
+	totalTopics,
 }: {
+	hasKnowledgeEvidence: boolean;
+	hasLearningPlan: boolean;
 	isLoading: boolean;
-	progress: DashboardWeekProgress;
-	onOpenLearningPlans: () => void;
+	onPress: () => void;
+	secureTopics: number;
+	totalTopics: number;
 }) {
 	const { colors } = useDayovaTheme();
-	const hasPlannedSessions = progress.totalLearningSessions > 0;
-	const ringValue = isLoading
-		? "–"
-		: hasPlannedSessions
-			? `${progress.completedLearningSessions} / ${progress.totalLearningSessions}`
-			: "0";
-	const ringLabel = isLoading
-		? "wird geladen"
-		: hasPlannedSessions
-			? "geschafft"
-			: "geplant";
+	const viewModel = getDashboardKnowledgeProgressViewModel({
+		hasKnowledgeEvidence,
+		hasLearningPlan,
+		isLoading,
+		secureTopics,
+		totalTopics,
+	});
 	const progressOffset =
-		WEEK_PROGRESS_RING_CIRCUMFERENCE *
-		(1 - (isLoading ? 0 : progress.completionPercent) / 100);
-	const footer = getDashboardWeekProgressFooter({ isLoading, progress });
+		KNOWLEDGE_PROGRESS_RING_CIRCUMFERENCE *
+		(1 - viewModel.progressPercent / 100);
 
 	return (
 		<TouchableOpacity
 			activeOpacity={0.82}
 			accessibilityRole="button"
-			accessibilityLabel={
-				isLoading
-					? "Wochenfortschritt wird geladen"
-					: hasPlannedSessions
-						? `Wochenfortschritt: ${progress.completedLearningSessions} von ${progress.totalLearningSessions} Lernschritten geschafft. ${footer}.`
-						: "Wochenfortschritt: Noch keine Lernschritte geplant"
+			accessibilityLabel={viewModel.accessibilityLabel}
+			accessibilityHint={
+				hasLearningPlan
+					? "Öffnet deinen Wissensstand für den ausgewählten Lernplan."
+					: "Öffnet deine persönlichen Lernpläne."
 			}
-			accessibilityHint="Öffnet deine persönlichen Lernpläne."
-			onPress={onOpenLearningPlans}
+			onPress={onPress}
 			className="min-h-72 flex-1 overflow-hidden rounded-card border border-border bg-ueben-subtle px-4 pt-5 pb-4"
 			style={continuousBorderStyle}
 		>
 			<View className="flex-row items-start gap-1">
-				<TimeManagement size={14} color={colors.ueben} strokeWidth={2} />
+				<Analytics size={14} color={colors.ueben} strokeWidth={2} />
 				<Text
 					className="flex-1 font-poppins font-semibold text-body-5 text-ueben"
 					numberOfLines={2}
 				>
-					Wochenfortschritt
+					Wissensstand
 				</Text>
 			</View>
 			<View className="flex-1 items-center justify-center py-2">
@@ -566,38 +564,38 @@ function WeeklyProgressCard({
 					className="items-center justify-center"
 					// SVG ring geometry uses fixed native dimensions.
 					style={{
-						width: WEEK_PROGRESS_RING_SIZE,
-						height: WEEK_PROGRESS_RING_SIZE,
+						width: KNOWLEDGE_PROGRESS_RING_SIZE,
+						height: KNOWLEDGE_PROGRESS_RING_SIZE,
 					}}
 				>
 					<Svg
 						pointerEvents="none"
-						width={WEEK_PROGRESS_RING_SIZE}
-						height={WEEK_PROGRESS_RING_SIZE}
-						viewBox={`0 0 ${WEEK_PROGRESS_RING_SIZE} ${WEEK_PROGRESS_RING_SIZE}`}
+						width={KNOWLEDGE_PROGRESS_RING_SIZE}
+						height={KNOWLEDGE_PROGRESS_RING_SIZE}
+						viewBox={`0 0 ${KNOWLEDGE_PROGRESS_RING_SIZE} ${KNOWLEDGE_PROGRESS_RING_SIZE}`}
 						// SVG positioning is not expressible through NativeWind classes.
 						style={{ position: "absolute" }}
 					>
 						<Circle
-							cx={WEEK_PROGRESS_RING_SIZE / 2}
-							cy={WEEK_PROGRESS_RING_SIZE / 2}
-							r={WEEK_PROGRESS_RING_RADIUS}
+							cx={KNOWLEDGE_PROGRESS_RING_SIZE / 2}
+							cy={KNOWLEDGE_PROGRESS_RING_SIZE / 2}
+							r={KNOWLEDGE_PROGRESS_RING_RADIUS}
 							fill="none"
 							stroke={colors.ueben}
 							strokeOpacity={0.24}
-							strokeWidth={WEEK_PROGRESS_RING_STROKE_WIDTH}
+							strokeWidth={KNOWLEDGE_PROGRESS_RING_STROKE_WIDTH}
 						/>
 						<Circle
-							cx={WEEK_PROGRESS_RING_SIZE / 2}
-							cy={WEEK_PROGRESS_RING_SIZE / 2}
-							r={WEEK_PROGRESS_RING_RADIUS}
+							cx={KNOWLEDGE_PROGRESS_RING_SIZE / 2}
+							cy={KNOWLEDGE_PROGRESS_RING_SIZE / 2}
+							r={KNOWLEDGE_PROGRESS_RING_RADIUS}
 							fill="none"
 							stroke={colors.ueben}
-							strokeDasharray={`${WEEK_PROGRESS_RING_CIRCUMFERENCE} ${WEEK_PROGRESS_RING_CIRCUMFERENCE}`}
+							strokeDasharray={`${KNOWLEDGE_PROGRESS_RING_CIRCUMFERENCE} ${KNOWLEDGE_PROGRESS_RING_CIRCUMFERENCE}`}
 							strokeDashoffset={progressOffset}
 							strokeLinecap="round"
-							strokeWidth={WEEK_PROGRESS_RING_STROKE_WIDTH}
-							transform={`rotate(-90 ${WEEK_PROGRESS_RING_SIZE / 2} ${WEEK_PROGRESS_RING_SIZE / 2})`}
+							strokeWidth={KNOWLEDGE_PROGRESS_RING_STROKE_WIDTH}
+							transform={`rotate(-90 ${KNOWLEDGE_PROGRESS_RING_SIZE / 2} ${KNOWLEDGE_PROGRESS_RING_SIZE / 2})`}
 						/>
 					</Svg>
 					<Text
@@ -605,13 +603,15 @@ function WeeklyProgressCard({
 						numberOfLines={1}
 						style={tabularNumberStyle}
 					>
-						{ringValue}
+						{viewModel.ringValue}
 					</Text>
 					<Text
+						adjustsFontSizeToFit
 						className="font-poppins text-body-5 text-secondary-text"
+						minimumFontScale={0.8}
 						numberOfLines={1}
 					>
-						{ringLabel}
+						{viewModel.ringLabel}
 					</Text>
 				</View>
 			</View>
@@ -622,7 +622,7 @@ function WeeklyProgressCard({
 						numberOfLines={2}
 						style={tabularNumberStyle}
 					>
-						{footer}
+						{viewModel.footer}
 					</Text>
 				</View>
 				<View
@@ -954,6 +954,10 @@ export function DashboardScreen() {
 		api.timetables.getMine,
 		user && isConvexAuthenticated ? {} : "skip",
 	);
+	const knowledgeAnalysis = useQuery(
+		api.userAnalytics.getExamAnalysis,
+		user && isConvexAuthenticated ? { todayKey } : "skip",
+	);
 	const allRelevantAgendaItems = entriesByDay
 		? queriedDayKeys.flatMap((dayKey) =>
 				(entriesByDay[dayKey] ?? []).map((entry) =>
@@ -967,10 +971,18 @@ export function DashboardScreen() {
 		todayKey,
 		currentMinutes,
 	});
-	const weekProgress = getDashboardWeekProgress({
-		items: allRelevantAgendaItems,
-		todayKey,
-	});
+	const secureTopics = knowledgeAnalysis?.readiness.secure ?? 0;
+	const totalTopics = knowledgeAnalysis
+		? knowledgeAnalysis.readiness.secure +
+			knowledgeAnalysis.readiness.developing +
+			knowledgeAnalysis.readiness.unknown
+		: 0;
+	const hasKnowledgeEvidence = Boolean(
+		knowledgeAnalysis &&
+			totalTopics > 0 &&
+			knowledgeAnalysis.topics.some((topic) => topic.evidenceCount > 0),
+	);
+	const selectedKnowledgePlanId = knowledgeAnalysis?.selectedPlan?.id;
 	const nextActionableId = nextLearningStep?.entry.id;
 	const selectedWeekday = formatGermanUiText(
 		new Intl.DateTimeFormat("de-DE", { weekday: "long" }).format(selectedDate),
@@ -1048,6 +1060,17 @@ export function DashboardScreen() {
 		() => router.push("/learning-plans"),
 		[router],
 	);
+	const openKnowledgeProgress = useCallback(() => {
+		if (!selectedKnowledgePlanId) {
+			openLearningPlans();
+			return;
+		}
+
+		router.push({
+			pathname: ROUTES.analyticsKnowledge,
+			params: { planId: selectedKnowledgePlanId },
+		});
+	}, [openLearningPlans, router, selectedKnowledgePlanId]);
 	const openTimetable = useCallback(() => router.push("/timetable"), [router]);
 
 	return (
@@ -1103,10 +1126,13 @@ export function DashboardScreen() {
 						onOpenItem={openItem}
 						onOpenLearningPlans={openLearningPlans}
 					/>
-					<WeeklyProgressCard
-						isLoading={entriesByDay === undefined}
-						progress={weekProgress}
-						onOpenLearningPlans={openLearningPlans}
+					<KnowledgeProgressCard
+						hasKnowledgeEvidence={hasKnowledgeEvidence}
+						hasLearningPlan={Boolean(selectedKnowledgePlanId)}
+						isLoading={knowledgeAnalysis === undefined}
+						onPress={openKnowledgeProgress}
+						secureTopics={secureTopics}
+						totalTopics={totalTopics}
 					/>
 				</View>
 

--- a/src/features/dashboard/dashboard-screen.tsx
+++ b/src/features/dashboard/dashboard-screen.tsx
@@ -6,8 +6,8 @@ import {
 	ScrollView,
 	type TextStyle,
 	TouchableOpacity,
-	type ViewStyle,
 	View,
+	type ViewStyle,
 } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -46,6 +46,7 @@ import {
 	getDashboardRelevantDayKeys,
 	getDashboardWeekDayKeys,
 	getDashboardWeekProgress,
+	getDashboardWeekProgressFooter,
 	isDashboardAgendaItemPast,
 	sortDashboardAgendaItems,
 	toDashboardAgendaItem,
@@ -532,11 +533,7 @@ function WeeklyProgressCard({
 	const progressOffset =
 		WEEK_PROGRESS_RING_CIRCUMFERENCE *
 		(1 - (isLoading ? 0 : progress.completionPercent) / 100);
-	const footer = isLoading
-		? "Diese Woche"
-		: hasPlannedSessions
-			? `${progress.completedMinutesToday} Min. heute`
-			: "Lernplan öffnen";
+	const footer = getDashboardWeekProgressFooter({ isLoading, progress });
 
 	return (
 		<TouchableOpacity
@@ -546,7 +543,7 @@ function WeeklyProgressCard({
 				isLoading
 					? "Wochenfortschritt wird geladen"
 					: hasPlannedSessions
-						? `Wochenfortschritt: ${progress.completedLearningSessions} von ${progress.totalLearningSessions} Lernschritten geschafft. ${progress.completedMinutesToday} Minuten heute`
+						? `Wochenfortschritt: ${progress.completedLearningSessions} von ${progress.totalLearningSessions} Lernschritten geschafft. ${footer}.`
 						: "Wochenfortschritt: Noch keine Lernschritte geplant"
 			}
 			accessibilityHint="Öffnet deine persönlichen Lernpläne."
@@ -619,10 +616,7 @@ function WeeklyProgressCard({
 				</View>
 			</View>
 			<View className="mt-4 flex-row items-end justify-between gap-2">
-				<View className="flex-1 flex-row items-center gap-2 pr-1">
-					{hasPlannedSessions && !isLoading ? (
-						<Clock3 size={16} color={colors.secondaryText} strokeWidth={1.9} />
-					) : null}
+				<View className="flex-1 pr-1">
 					<Text
 						className="flex-1 font-poppins font-semibold text-body-4 text-text"
 						numberOfLines={2}
@@ -635,7 +629,7 @@ function WeeklyProgressCard({
 					accessible={false}
 					className="h-12 w-12 items-center justify-center rounded-full bg-secondary"
 				>
-					<ArrowUpRight
+					<ArrowRight
 						size={22}
 						color={DAYOVA_DESIGN_SYSTEM.colors.light1}
 						strokeWidth={2}


### PR DESCRIPTION
## Was geändert

- ersetzt den sessionbasierten „Wochenfortschritt“ durch den evidenzbasierten „Wissensstand“
- zeigt die Zahl sicher belegter Themen als `x / y Themen sicher`
- verwendet dieselbe Topic-Readiness wie die Wissensanalyse; abgeschlossene Sessions allein zählen nicht als Sicherheit
- zeigt ohne Wissensbelege bewusst `–` statt eines irreführenden `0 / y`
- öffnet über „Details ansehen“ direkt die Wissensanalyse des ausgewählten Lernplans
- ergänzt getestete Lade-, Leer-, Evidenz-, Singular- und Abschlusszustände

## Warum

Die Karte soll eine unmittelbar verständliche Antwort geben: „Wie viele Prüfungsthemen kann ich bereits sicher?“ Der bisherige Wochenfortschritt beschrieb Aktivität, nicht Können. Die neue Darstellung nutzt deshalb ausschließlich vorhandene Wissensbelege.

## Validierung

- `vitest run src/features/dashboard/dashboard-agenda.test.ts src/features/dashboard/dashboard-knowledge-progress.test.ts` (13 Tests)
- `tsc --noEmit`
- Biome und ESLint auf allen geänderten Dateien
- iOS-Simulator-Render auf iPhone 17 / iOS 26.5 im Dark Mode mit realen Kontodaten geprüft (`0 / 4 Themen sicher`)