### PR TITLE
Add frontier AI model benchmark overview

### DIFF
--- a/prototypes/ai-model-frontier/app.js
+++ b/prototypes/ai-model-frontier/app.js
@@ -1,0 +1,328 @@
+const models = [
+	{
+		id: "opus",
+		name: "Opus 5",
+		fullName: "Claude Opus 5",
+		maker: "Anthropic",
+		monogram: "O5",
+		color: "#d8ff3e",
+		copy: "The current long-horizon leader, with Fable-level results at a markedly lower run cost.",
+		scores: {
+			deepswe: { score: 74, display: "74%", cost: 11.84, effort: "Max", margin: "±4%" },
+			frontier: { score: 53.4, display: "53.4%", cost: 4.3, effort: "Medium" },
+			cursor: { score: 70, display: "70.0%", cost: 8.23, effort: "Max" },
+		},
+	},
+	{
+		id: "fable",
+		name: "Fable 5",
+		fullName: "Claude Fable 5",
+		maker: "Anthropic",
+		monogram: "F5",
+		color: "#ff9d79",
+		copy: "The raw-ceiling choice: first on mergeability and Cursor’s real-session benchmark, at the highest run cost.",
+		scores: {
+			deepswe: { score: 70, display: "70%", cost: 21.63, effort: "Max", margin: "±4%" },
+			frontier: { score: 53.5, display: "53.5%", cost: 13.09, effort: "Extra high" },
+			cursor: { score: 70.5, display: "70.5%", cost: 17.32, effort: "Max" },
+		},
+	},
+	{
+		id: "sol",
+		name: "GPT‑5.6 Sol",
+		fullName: "GPT‑5.6 Sol",
+		maker: "OpenAI",
+		monogram: "SO",
+		color: "#8dc9ff",
+		copy: "One point from the DeepSWE lead and consistently near the top, with a stronger cost profile than the leading Claudes.",
+		scores: {
+			deepswe: { score: 73, display: "73%", cost: 8.39, effort: "Max", margin: "±3%" },
+			frontier: { score: 47.5, display: "47.5%", cost: 6.3, effort: "Max" },
+			cursor: { score: 67.2, display: "67.2%", cost: 5.69, effort: "Max" },
+		},
+	},
+	{
+		id: "terra",
+		name: "GPT‑5.6 Terra",
+		fullName: "GPT‑5.6 Terra",
+		maker: "OpenAI",
+		monogram: "TR",
+		color: "#b9a6ff",
+		copy: "The balance point: tied with Fable on DeepSWE for a fraction of the run cost, while staying competitive elsewhere.",
+		scores: {
+			deepswe: { score: 70, display: "70%", cost: 3.96, effort: "Max", margin: "±3%" },
+			frontier: { score: 41.3, display: "41.3%", cost: 1.81, effort: "Max" },
+			cursor: { score: 64.9, display: "64.9%", cost: 2.31, effort: "Max" },
+		},
+	},
+	{
+		id: "kimi",
+		name: "Kimi K3",
+		fullName: "Kimi K3",
+		maker: "Moonshot AI",
+		monogram: "K3",
+		color: "#ffcf66",
+		copy: "A top-tier DeepSWE contender with a solid FrontierCode result; its CursorBench showing is more modest.",
+		scores: {
+			deepswe: { score: 69, display: "69%", cost: 4.65, effort: "Max", margin: "±5%" },
+			frontier: { score: 44.2, display: "44.2%", cost: 3.82, effort: "Default" },
+			cursor: { score: 60.8, display: "60.8%", cost: 2.7, effort: "Max" },
+		},
+	},
+	{
+		id: "luna",
+		name: "GPT‑5.6 Luna",
+		fullName: "GPT‑5.6 Luna",
+		maker: "OpenAI",
+		monogram: "LU",
+		color: "#7de3c1",
+		copy: "The throughput choice: materially lower run cost with enough capability to remain in the frontier pack.",
+		scores: {
+			deepswe: { score: 67, display: "67%", cost: 0.61, effort: "Max", margin: "±4%" },
+			frontier: { score: 39.8, display: "39.8%", cost: 0.36, effort: "Max" },
+			cursor: { score: 61.1, display: "61.1%", cost: 0.39, effort: "Max" },
+		},
+	},
+	{
+		id: "gemini",
+		name: "Gemini 3.6 Flash",
+		fullName: "Gemini 3.6 Flash",
+		maker: "Google",
+		monogram: "GF",
+		color: "#d7d9d4",
+		copy: "The fast-model baseline in this field. It trails on two published runs, while FrontierCode coverage is still missing.",
+		scores: {
+			deepswe: { score: 49, display: "49%", cost: 3.53, effort: "High", margin: "±5%" },
+			frontier: null,
+			cursor: { score: 53.5, display: "53.5%", cost: 1.56, effort: "High" },
+		},
+	},
+];
+
+const benchmarks = {
+	deepswe: {
+		version: "DEEPSWE V1.1",
+		title: "Original, long-horizon engineering",
+		description: "113 tasks · mini-swe-agent · higher is better",
+	},
+	frontier: {
+		version: "FRONTIERCODE 1.1 / MAIN",
+		title: "Would a maintainer merge the PR?",
+		description: "100 tasks · model-native harnesses · higher is better",
+	},
+	cursor: {
+		version: "CURSORBENCH 3.2",
+		title: "Ambiguous, multi-file session work",
+		description: "real Cursor sessions · agent runs · higher is better",
+	},
+};
+
+let activeBenchmark = "deepswe";
+let selectedModelId = "opus";
+
+const ranking = document.getElementById("ranking");
+const panel = document.getElementById("benchmark-panel");
+const tabs = [...document.querySelectorAll(".benchmark-tab")];
+const version = document.getElementById("benchmark-version");
+const title = document.getElementById("benchmark-title");
+const description = document.getElementById("benchmark-description");
+const matrixBody = document.getElementById("matrix-body");
+
+const spotlight = {
+	monogram: document.getElementById("spotlight-monogram"),
+	rank: document.getElementById("spotlight-rank"),
+	maker: document.getElementById("spotlight-maker"),
+	name: document.getElementById("spotlight-name"),
+	copy: document.getElementById("spotlight-copy"),
+	score: document.getElementById("spotlight-score"),
+	cost: document.getElementById("spotlight-cost"),
+	effort: document.getElementById("spotlight-effort"),
+	miniScores: document.getElementById("mini-scores"),
+};
+
+function sortedModels(benchmark) {
+	return [...models].sort((a, b) => {
+		const aScore = a.scores[benchmark]?.score ?? -1;
+		const bScore = b.scores[benchmark]?.score ?? -1;
+		return bScore - aScore;
+	});
+}
+
+function formatCost(cost) {
+	return `$${cost.toFixed(cost < 1 ? 2 : 2)}`;
+}
+
+function renderRanking() {
+	const ranked = sortedModels(activeBenchmark);
+	const benchmark = benchmarks[activeBenchmark];
+
+	version.textContent = benchmark.version;
+	title.textContent = benchmark.title;
+	description.textContent = benchmark.description;
+	panel.setAttribute("aria-labelledby", `tab-${activeBenchmark}`);
+	ranking.replaceChildren();
+
+	ranked.forEach((model, index) => {
+		const result = model.scores[activeBenchmark];
+		const row = document.createElement("button");
+		row.type = "button";
+		row.className = "rank-row";
+		row.dataset.modelId = model.id;
+
+		if (!result) {
+			row.classList.add("is-missing");
+			row.disabled = true;
+			row.setAttribute("aria-label", `${model.fullName}: no result reported`);
+		} else {
+			row.setAttribute(
+				"aria-label",
+				`${model.fullName}, rank ${index + 1}, ${result.display}, average run cost ${formatCost(result.cost)}`,
+			);
+		}
+
+		if (model.id === selectedModelId && result) row.classList.add("is-selected");
+
+		const rankNumber = document.createElement("span");
+		rankNumber.className = "rank-number";
+		rankNumber.textContent = result ? String(index + 1).padStart(2, "0") : "—";
+
+		const name = document.createElement("span");
+		name.className = "rank-name";
+		name.textContent = model.name;
+
+		const barTrack = document.createElement("span");
+		barTrack.className = "bar-track";
+		if (result) {
+			const barFill = document.createElement("span");
+			barFill.className = "bar-fill";
+			barFill.style.setProperty("--bar-width", `${(result.score / 80) * 100}%`);
+			barFill.style.setProperty("--bar-color", model.color);
+			barFill.style.animationDelay = `${index * 45}ms`;
+			barTrack.append(barFill);
+		}
+
+		const score = document.createElement("span");
+		score.className = "rank-score";
+		score.textContent = result ? `${result.display}${result.margin ? ` ${result.margin}` : ""}` : "N/R";
+
+		row.append(rankNumber, name, barTrack, score);
+		if (result) {
+			row.addEventListener("click", () => {
+				selectedModelId = model.id;
+				renderRanking();
+				renderSpotlight();
+			});
+		}
+
+		ranking.append(row);
+	});
+}
+
+function renderSpotlight() {
+	const ranked = sortedModels(activeBenchmark);
+	let model = models.find((candidate) => candidate.id === selectedModelId);
+
+	if (!model?.scores[activeBenchmark]) {
+		model = ranked.find((candidate) => candidate.scores[activeBenchmark]);
+		selectedModelId = model.id;
+	}
+
+	const result = model.scores[activeBenchmark];
+	const rank = ranked.filter((candidate) => candidate.scores[activeBenchmark]).indexOf(model) + 1;
+
+	spotlight.monogram.textContent = model.monogram;
+	spotlight.rank.textContent = `RANK ${String(rank).padStart(2, "0")}`;
+	spotlight.maker.textContent = model.maker;
+	spotlight.name.textContent = model.fullName;
+	spotlight.copy.textContent = model.copy;
+	spotlight.score.textContent = `${result.display}${result.margin ? ` ${result.margin}` : ""}`;
+	spotlight.cost.textContent = formatCost(result.cost);
+	spotlight.effort.textContent = result.effort;
+	spotlight.miniScores.replaceChildren();
+
+	for (const [key, label] of [
+		["deepswe", "Deep"],
+		["frontier", "Frontier"],
+		["cursor", "Cursor"],
+	]) {
+		const score = model.scores[key];
+		const item = document.createElement("div");
+		item.className = "mini-score";
+
+		const value = document.createElement("b");
+		value.textContent = score ? score.score.toFixed(score.score % 1 ? 1 : 0) : "N/R";
+
+		const caption = document.createElement("span");
+		caption.textContent = label;
+
+		item.append(value, caption);
+		spotlight.miniScores.append(item);
+	}
+}
+
+function renderMatrix() {
+	const winners = {
+		deepswe: Math.max(...models.map((model) => model.scores.deepswe?.score ?? -1)),
+		frontier: Math.max(...models.map((model) => model.scores.frontier?.score ?? -1)),
+		cursor: Math.max(...models.map((model) => model.scores.cursor?.score ?? -1)),
+	};
+
+	matrixBody.replaceChildren();
+
+	for (const model of models) {
+		const row = document.createElement("tr");
+		const modelCell = document.createElement("th");
+		modelCell.scope = "row";
+		modelCell.innerHTML = `<span class="table-model"><span class="table-monogram">${model.monogram}</span>${model.fullName}</span>`;
+		row.append(modelCell);
+
+		for (const key of ["deepswe", "frontier", "cursor"]) {
+			const cell = document.createElement("td");
+			const result = model.scores[key];
+			const value = document.createElement("span");
+			value.className = "table-value";
+
+			if (result) {
+				if (result.score === winners[key]) value.classList.add("is-winner");
+				const score = document.createElement("strong");
+				score.textContent = result.display;
+				const cost = document.createElement("small");
+				cost.textContent = formatCost(result.cost);
+				value.append(score, cost);
+			} else {
+				const score = document.createElement("strong");
+				score.textContent = "N/R";
+				const cost = document.createElement("small");
+				cost.textContent = "not reported";
+				value.append(score, cost);
+			}
+
+			cell.append(value);
+			row.append(cell);
+		}
+
+		matrixBody.append(row);
+	}
+}
+
+tabs.forEach((tab) => {
+	tab.addEventListener("click", () => {
+		activeBenchmark = tab.dataset.benchmark;
+		selectedModelId = sortedModels(activeBenchmark).find(
+			(model) => model.scores[activeBenchmark],
+		).id;
+
+		tabs.forEach((candidate) => {
+			const isActive = candidate === tab;
+			candidate.classList.toggle("is-active", isActive);
+			candidate.setAttribute("aria-selected", String(isActive));
+		});
+
+		renderRanking();
+		renderSpotlight();
+	});
+});
+
+renderRanking();
+renderSpotlight();
+renderMatrix();

--- a/prototypes/ai-model-frontier/app.js
+++ b/prototypes/ai-model-frontier/app.js
@@ -117,47 +117,212 @@ const benchmarks = {
 	},
 };
 
-const terraEfforts = {
-	high: {
-		label: "High",
-		copy: "Best for scoped fixes, familiar code, and fast iteration when tests give you a strong safety net.",
-		title: "Move quickly, keep review close.",
-		status: "HIGH / SELECTED",
-		cursorScore: "54.2%",
-		cursorCost: "$0.71 / task",
-		frontierScore: "36.9%",
-		frontierCost: "$1.10 / task",
-		retained: "84–89%",
-		retainedNote: "of Max scores",
+const effortLabels = {
+	low: "Low",
+	medium: "Medium",
+	high: "High",
+	xhigh: "Extra High",
+	max: "Max",
+};
+
+const modeLabels = {
+	economy: { answer: "Cheaper alternative", chip: "CHEAPER ALTERNATIVE" },
+	recommended: { answer: "Recommended default", chip: "RECOMMENDED DEFAULT" },
+	ceiling: { answer: "Capability ceiling", chip: "CAPABILITY CEILING" },
+};
+
+const effortModels = {
+	opus: {
+		choices: {
+			economy: {
+				effort: "low",
+				title: "The economical flagship run.",
+				copy: "Use Low for scoped, well-tested work when you still want Opus-level judgment but do not need its full search budget.",
+			},
+			recommended: {
+				effort: "medium",
+				title: "The strongest cross-benchmark trade-off.",
+				copy: "Medium is the evidence-led default: it posts Opus 5’s best FrontierCode score and remains within 5.7 points of its CursorBench ceiling.",
+			},
+			ceiling: {
+				effort: "max",
+				title: "Cursor ceiling, not a universal win.",
+				copy: "Max reaches Opus 5’s highest CursorBench score. FrontierCode is non-monotonic, so more effort did not outperform Medium there.",
+			},
+		},
+		note: "Opus 5 has complete ladders, but FrontierCode peaks at Medium and then regresses. Treat Max as a Cursor-heavy choice, not an automatic upgrade.",
+		efforts: {
+			low: { cursor: { score: 62.8, cost: 2.55 }, frontier: { score: 41.9, cost: 2.7 } },
+			medium: { cursor: { score: 64.3, cost: 3.29 }, frontier: { score: 53.4, cost: 4.3 } },
+			high: { cursor: { score: 66.7, cost: 3.91 }, frontier: { score: 48.0, cost: 7.2 } },
+			xhigh: { cursor: { score: 69.3, cost: 7.35 }, frontier: { score: 43.6, cost: 9.1 } },
+			max: { cursor: { score: 70.0, cost: 8.23 }, frontier: { score: 48.0, cost: 11.4 } },
+		},
 	},
-	xhigh: {
-		label: "Extra High",
-		copy: "The practical sweet spot for substantial feature work, refactors, and bug investigations. You keep most of Max’s score without paying Max’s full premium.",
-		title: "Most of Max, for much less.",
-		status: "XHIGH / SELECTED",
-		cursorScore: "59.2%",
-		cursorCost: "$1.15 / task",
-		frontierScore: "38.7%",
-		frontierCost: "$1.30 / task",
-		retained: "91–94%",
-		retainedNote: "across both benchmarks",
+	fable: {
+		choices: {
+			economy: {
+				effort: "medium",
+				title: "Spend less without leaving the frontier.",
+				copy: "Medium keeps Fable above 65 on CursorBench while cutting the published run cost sharply versus its highest settings.",
+			},
+			recommended: {
+				effort: "high",
+				title: "The balanced Fable run.",
+				copy: "High is the practical default: it is close to Fable’s best result on both ladders without paying Extra High or Max pricing.",
+			},
+			ceiling: {
+				effort: "max",
+				title: "The Cursor ceiling carries a warning.",
+				copy: "Max wins CursorBench, but FrontierCode peaks at Extra High and slips at Max. Use it when real-session capability matters most.",
+			},
+		},
+		note: "Fable 5 has complete ladders. CursorBench rises steadily to Max; FrontierCode peaks at Extra High, so the final setting is not universally best.",
+		efforts: {
+			low: { cursor: { score: 62.1, cost: 4.46 }, frontier: { score: 48.0, cost: 4.9232 } },
+			medium: { cursor: { score: 65.2, cost: 6.8 }, frontier: { score: 49.8, cost: 7.1539 } },
+			high: { cursor: { score: 66.5, cost: 8.77 }, frontier: { score: 52.7, cost: 9.4805 } },
+			xhigh: { cursor: { score: 68.4, cost: 11.73 }, frontier: { score: 53.5, cost: 13.0938 } },
+			max: { cursor: { score: 70.5, cost: 17.32 }, frontier: { score: 51.6, cost: 19.0696 } },
+		},
 	},
-	max: {
-		label: "Max",
-		copy: "Reserve Max for ambiguous, high-blast-radius changes, unfamiliar systems, and final passes where a missed edge case costs more than extra inference.",
-		title: "Pay for the last few points.",
-		status: "MAX / SELECTED",
-		cursorScore: "64.9%",
-		cursorCost: "$2.31 / task",
-		frontierScore: "41.3%",
-		frontierCost: "$1.81 / task",
-		retained: "100%",
-		retainedNote: "Terra’s published ceiling",
+	sol: {
+		choices: {
+			economy: {
+				effort: "high",
+				title: "A strong flagship run on a leash.",
+				copy: "High is the cheaper serious-work setting: it clears 63 on CursorBench and stays within 2.4 points of Sol’s FrontierCode maximum.",
+			},
+			recommended: {
+				effort: "xhigh",
+				title: "Near the ceiling, below Max cost.",
+				copy: "Extra High is the best everyday balance for ambiguous repository work, landing close to Max on both published ladders.",
+			},
+			ceiling: {
+				effort: "max",
+				title: "Pay for Sol’s last few points.",
+				copy: "Max is justified for high-blast-radius changes, unfamiliar systems, and final passes where a missed edge case costs more than the run.",
+			},
+		},
+		note: "Sol has complete, monotonic effort ladders on both benchmarks. The main question is how much the final few points are worth to your task.",
+		efforts: {
+			low: { cursor: { score: 52.6, cost: 1.01 }, frontier: { score: 35.4, cost: 2.1 } },
+			medium: { cursor: { score: 60.0, cost: 1.95 }, frontier: { score: 39.9, cost: 3.1 } },
+			high: { cursor: { score: 63.5, cost: 2.79 }, frontier: { score: 45.1, cost: 4.1 } },
+			xhigh: { cursor: { score: 64.5, cost: 3.88 }, frontier: { score: 46.8, cost: 5.0 } },
+			max: { cursor: { score: 67.2, cost: 5.69 }, frontier: { score: 47.5, cost: 6.3 } },
+		},
+	},
+	terra: {
+		choices: {
+			economy: {
+				effort: "high",
+				title: "Move quickly, keep review close.",
+				copy: "High fits scoped fixes, familiar code, and fast iteration when tests provide a strong safety net.",
+			},
+			recommended: {
+				effort: "xhigh",
+				title: "Most of Max, for much less.",
+				copy: "Extra High is the practical sweet spot for substantial feature work and investigations: most of Max’s score without Max’s full premium.",
+			},
+			ceiling: {
+				effort: "max",
+				title: "Pay for Terra’s last few points.",
+				copy: "Reserve Max for ambiguous, high-blast-radius changes and final passes where a missed edge case costs more than extra inference.",
+			},
+		},
+		note: "Terra has complete CursorBench and FrontierCode effort ladders; both improve steadily as effort rises.",
+		efforts: {
+			low: { cursor: { score: 46.9, cost: 0.42 }, frontier: { score: 24.1, cost: 0.413 } },
+			medium: { cursor: { score: 50.3, cost: 0.49 }, frontier: { score: 33.9, cost: 0.728 } },
+			high: { cursor: { score: 54.2, cost: 0.71 }, frontier: { score: 36.9, cost: 1.099 } },
+			xhigh: { cursor: { score: 59.2, cost: 1.15 }, frontier: { score: 38.7, cost: 1.296 } },
+			max: { cursor: { score: 64.9, cost: 2.31 }, frontier: { score: 41.3, cost: 1.806 } },
+		},
+	},
+	luna: {
+		choices: {
+			economy: {
+				effort: "high",
+				title: "Serious work at throughput pricing.",
+				copy: "High makes the large jump from Medium on both ladders while keeping average benchmark costs below a quarter per task.",
+			},
+			recommended: {
+				effort: "xhigh",
+				title: "Luna’s efficiency sweet spot.",
+				copy: "Extra High lands within 3.4 points of Max on CursorBench and within 0.9 on FrontierCode, while remaining exceptionally inexpensive.",
+			},
+			ceiling: {
+				effort: "max",
+				title: "The cheapest published ceiling here.",
+				copy: "Max is reasonable when you need every point: even Luna’s highest effort remains far below the field’s flagship benchmark costs.",
+			},
+		},
+		note: "Luna has complete, monotonic ladders. Extra High nearly reaches its FrontierCode ceiling; Max adds more on CursorBench than on FrontierCode.",
+		efforts: {
+			low: { cursor: { score: 37.6, cost: 0.03 }, frontier: { score: 15.4, cost: 0.044 } },
+			medium: { cursor: { score: 47.7, cost: 0.08 }, frontier: { score: 25.7, cost: 0.11 } },
+			high: { cursor: { score: 56.8, cost: 0.16 }, frontier: { score: 35.9, cost: 0.215 } },
+			xhigh: { cursor: { score: 57.7, cost: 0.23 }, frontier: { score: 38.9, cost: 0.299 } },
+			max: { cursor: { score: 61.1, cost: 0.39 }, frontier: { score: 39.8, cost: 0.361 } },
+		},
+	},
+	kimi: {
+		choices: {
+			economy: {
+				effort: "low",
+				title: "The low-cost Kimi pass.",
+				copy: "Low suits triage and tightly bounded edits. CursorBench shows a meaningful capability jump when you move to High.",
+			},
+			recommended: {
+				effort: "high",
+				title: "The clear Kimi balance point.",
+				copy: "High gains 9.2 CursorBench points over Low; Max adds only another 1.1 points for a further $0.81 per benchmark task.",
+			},
+			ceiling: {
+				effort: "max",
+				title: "A small final lift.",
+				copy: "Use Max when the last CursorBench point matters. FrontierCode only reports a default Kimi run, so it cannot confirm an effort-level gain.",
+			},
+		},
+		note: "Kimi K3 has a three-step CursorBench ladder. FrontierCode reports one default-only run—44.2% at $3.82—so it is not mapped to Low, High, or Max.",
+		efforts: {
+			low: { cursor: { score: 50.5, cost: 0.99 }, frontier: null },
+			high: { cursor: { score: 59.7, cost: 1.89 }, frontier: null },
+			max: { cursor: { score: 60.8, cost: 2.7 }, frontier: null },
+		},
+	},
+	gemini: {
+		choices: {
+			economy: {
+				effort: "medium",
+				title: "A small saving, a modest score trade.",
+				copy: "Medium saves little versus High, but it is the lower-cost option when the task is routine and tightly constrained.",
+			},
+			recommended: {
+				effort: "high",
+				title: "Use the highest tested setting.",
+				copy: "High is both the recommended default and the published ceiling: it adds 2.3 CursorBench points over Medium for only $0.08 more per task.",
+			},
+			ceiling: {
+				effort: "high",
+				title: "High is the current ceiling.",
+				copy: "No higher Gemini 3.6 Flash setting is published in CursorBench, and FrontierCode has not reported this model yet.",
+			},
+		},
+		note: "Gemini 3.6 Flash has a three-step CursorBench ladder and no FrontierCode result. The recommendation therefore rests on one benchmark family.",
+		efforts: {
+			low: { cursor: { score: 47.4, cost: 1.13 }, frontier: null },
+			medium: { cursor: { score: 51.2, cost: 1.48 }, frontier: null },
+			high: { cursor: { score: 53.5, cost: 1.56 }, frontier: null },
+		},
 	},
 };
 
 let activeBenchmark = "deepswe";
 let selectedModelId = "opus";
+let selectedEffortModelId = "terra";
+let selectedEffortChoice = "recommended";
 
 const ranking = document.getElementById("ranking");
 const panel = document.getElementById("benchmark-panel");
@@ -167,9 +332,14 @@ const title = document.getElementById("benchmark-title");
 const description = document.getElementById("benchmark-description");
 const matrixBody = document.getElementById("matrix-body");
 const effortControls = [...document.querySelectorAll(".effort-control")];
-const effortRows = [...document.querySelectorAll(".effort-ladder-row")];
+const effortModelSelect = document.getElementById("effort-model-select");
+const effortLadderBody = document.getElementById("effort-ladder-body");
 
 const effortGuide = {
+	advisor: document.getElementById("effort-advisor"),
+	modelMonogram: document.getElementById("effort-model-monogram"),
+	modeChip: document.getElementById("effort-mode-chip"),
+	answerLabel: document.getElementById("effort-answer-label"),
 	answer: document.getElementById("effort-answer"),
 	copy: document.getElementById("effort-answer-copy"),
 	title: document.getElementById("effort-evidence-title"),
@@ -178,8 +348,9 @@ const effortGuide = {
 	cursorCost: document.getElementById("effort-cursor-cost"),
 	frontierScore: document.getElementById("effort-frontier-score"),
 	frontierCost: document.getElementById("effort-frontier-cost"),
-	retained: document.getElementById("effort-retained"),
-	retainedNote: document.getElementById("effort-retained-note"),
+	coverage: document.getElementById("effort-coverage"),
+	coverageNote: document.getElementById("effort-coverage-note"),
+	modelNote: document.getElementById("effort-model-note"),
 };
 
 const spotlight = {
@@ -359,29 +530,79 @@ function renderMatrix() {
 	}
 }
 
-function renderEffortGuide(effort) {
-	const recommendation = terraEfforts[effort];
+function setEffortMetric(metric, scoreElement, costElement) {
+	if (metric) {
+		scoreElement.textContent = `${metric.score.toFixed(1)}%`;
+		costElement.textContent = `${formatCost(metric.cost)} / task`;
+		return;
+	}
 
-	effortGuide.answer.textContent = recommendation.label;
+	scoreElement.textContent = "N/R";
+	costElement.textContent = "no matched effort run";
+}
+
+function createEffortMetric(metric) {
+	const cell = document.createElement("span");
+	const cost = document.createElement("small");
+
+	if (metric) {
+		cell.append(document.createTextNode(`${metric.score.toFixed(1)}%`));
+		cost.textContent = formatCost(metric.cost);
+	} else {
+		cell.append(document.createTextNode("N/R"));
+		cost.textContent = "not reported";
+	}
+
+	cell.append(cost);
+	return cell;
+}
+
+function renderEffortGuide(modelId = selectedEffortModelId, choice = selectedEffortChoice) {
+	const model = models.find((candidate) => candidate.id === modelId);
+	const guide = effortModels[modelId];
+	const recommendation = guide.choices[choice];
+	const effort = recommendation.effort;
+	const metrics = guide.efforts[effort];
+	const mode = modeLabels[choice];
+	const coverage = Number(Boolean(metrics.cursor)) + Number(Boolean(metrics.frontier));
+
+	selectedEffortModelId = modelId;
+	selectedEffortChoice = choice;
+	effortModelSelect.value = modelId;
+	effortGuide.advisor.style.setProperty("--advisor-accent", model.color);
+	effortGuide.modelMonogram.textContent = model.monogram;
+	effortGuide.modeChip.textContent = mode.chip;
+	effortGuide.answerLabel.textContent = mode.answer;
+	effortGuide.answer.textContent = effortLabels[effort];
 	effortGuide.copy.textContent = recommendation.copy;
 	effortGuide.title.textContent = recommendation.title;
-	effortGuide.status.textContent = recommendation.status;
-	effortGuide.cursorScore.textContent = recommendation.cursorScore;
-	effortGuide.cursorCost.textContent = recommendation.cursorCost;
-	effortGuide.frontierScore.textContent = recommendation.frontierScore;
-	effortGuide.frontierCost.textContent = recommendation.frontierCost;
-	effortGuide.retained.textContent = recommendation.retained;
-	effortGuide.retainedNote.textContent = recommendation.retainedNote;
+	effortGuide.status.textContent = `${effortLabels[effort].toUpperCase()} / SELECTED`;
+	effortGuide.coverage.textContent = `${coverage} / 2`;
+	effortGuide.coverageNote.textContent = coverage === 2 ? "matched effort ladders" : "matched effort ladder";
+	effortGuide.modelNote.textContent = guide.note;
+
+	setEffortMetric(metrics.cursor, effortGuide.cursorScore, effortGuide.cursorCost);
+	setEffortMetric(metrics.frontier, effortGuide.frontierScore, effortGuide.frontierCost);
 
 	effortControls.forEach((control) => {
-		const isActive = control.dataset.effort === effort;
+		const controlChoice = control.dataset.choice;
+		const isActive = controlChoice === choice;
+		control.querySelector("small").textContent = effortLabels[guide.choices[controlChoice].effort];
 		control.classList.toggle("is-active", isActive);
 		control.setAttribute("aria-pressed", String(isActive));
 	});
 
-	effortRows.forEach((row) => {
-		row.classList.toggle("is-selected", row.dataset.effortRow === effort);
-	});
+	effortLadderBody.replaceChildren();
+	for (const [effortKey, effortMetrics] of Object.entries(guide.efforts)) {
+		const row = document.createElement("div");
+		row.className = "effort-ladder-row";
+		if (effortKey === effort) row.classList.add("is-selected");
+
+		const label = document.createElement("strong");
+		label.textContent = effortLabels[effortKey];
+		row.append(label, createEffortMetric(effortMetrics.cursor), createEffortMetric(effortMetrics.frontier));
+		effortLadderBody.append(row);
+	}
 }
 
 tabs.forEach((tab) => {
@@ -404,11 +625,15 @@ tabs.forEach((tab) => {
 
 effortControls.forEach((control) => {
 	control.addEventListener("click", () => {
-		renderEffortGuide(control.dataset.effort);
+		renderEffortGuide(selectedEffortModelId, control.dataset.choice);
 	});
+});
+
+effortModelSelect.addEventListener("change", () => {
+	renderEffortGuide(effortModelSelect.value, "recommended");
 });
 
 renderRanking();
 renderSpotlight();
 renderMatrix();
-renderEffortGuide("xhigh");
+renderEffortGuide();

--- a/prototypes/ai-model-frontier/app.js
+++ b/prototypes/ai-model-frontier/app.js
@@ -117,6 +117,45 @@ const benchmarks = {
 	},
 };
 
+const terraEfforts = {
+	high: {
+		label: "High",
+		copy: "Best for scoped fixes, familiar code, and fast iteration when tests give you a strong safety net.",
+		title: "Move quickly, keep review close.",
+		status: "HIGH / SELECTED",
+		cursorScore: "54.2%",
+		cursorCost: "$0.71 / task",
+		frontierScore: "36.9%",
+		frontierCost: "$1.10 / task",
+		retained: "84–89%",
+		retainedNote: "of Max scores",
+	},
+	xhigh: {
+		label: "Extra High",
+		copy: "The practical sweet spot for substantial feature work, refactors, and bug investigations. You keep most of Max’s score without paying Max’s full premium.",
+		title: "Most of Max, for much less.",
+		status: "XHIGH / SELECTED",
+		cursorScore: "59.2%",
+		cursorCost: "$1.15 / task",
+		frontierScore: "38.7%",
+		frontierCost: "$1.30 / task",
+		retained: "91–94%",
+		retainedNote: "across both benchmarks",
+	},
+	max: {
+		label: "Max",
+		copy: "Reserve Max for ambiguous, high-blast-radius changes, unfamiliar systems, and final passes where a missed edge case costs more than extra inference.",
+		title: "Pay for the last few points.",
+		status: "MAX / SELECTED",
+		cursorScore: "64.9%",
+		cursorCost: "$2.31 / task",
+		frontierScore: "41.3%",
+		frontierCost: "$1.81 / task",
+		retained: "100%",
+		retainedNote: "Terra’s published ceiling",
+	},
+};
+
 let activeBenchmark = "deepswe";
 let selectedModelId = "opus";
 
@@ -127,6 +166,21 @@ const version = document.getElementById("benchmark-version");
 const title = document.getElementById("benchmark-title");
 const description = document.getElementById("benchmark-description");
 const matrixBody = document.getElementById("matrix-body");
+const effortControls = [...document.querySelectorAll(".effort-control")];
+const effortRows = [...document.querySelectorAll(".effort-ladder-row")];
+
+const effortGuide = {
+	answer: document.getElementById("effort-answer"),
+	copy: document.getElementById("effort-answer-copy"),
+	title: document.getElementById("effort-evidence-title"),
+	status: document.getElementById("effort-evidence-status"),
+	cursorScore: document.getElementById("effort-cursor-score"),
+	cursorCost: document.getElementById("effort-cursor-cost"),
+	frontierScore: document.getElementById("effort-frontier-score"),
+	frontierCost: document.getElementById("effort-frontier-cost"),
+	retained: document.getElementById("effort-retained"),
+	retainedNote: document.getElementById("effort-retained-note"),
+};
 
 const spotlight = {
 	monogram: document.getElementById("spotlight-monogram"),
@@ -305,6 +359,31 @@ function renderMatrix() {
 	}
 }
 
+function renderEffortGuide(effort) {
+	const recommendation = terraEfforts[effort];
+
+	effortGuide.answer.textContent = recommendation.label;
+	effortGuide.copy.textContent = recommendation.copy;
+	effortGuide.title.textContent = recommendation.title;
+	effortGuide.status.textContent = recommendation.status;
+	effortGuide.cursorScore.textContent = recommendation.cursorScore;
+	effortGuide.cursorCost.textContent = recommendation.cursorCost;
+	effortGuide.frontierScore.textContent = recommendation.frontierScore;
+	effortGuide.frontierCost.textContent = recommendation.frontierCost;
+	effortGuide.retained.textContent = recommendation.retained;
+	effortGuide.retainedNote.textContent = recommendation.retainedNote;
+
+	effortControls.forEach((control) => {
+		const isActive = control.dataset.effort === effort;
+		control.classList.toggle("is-active", isActive);
+		control.setAttribute("aria-pressed", String(isActive));
+	});
+
+	effortRows.forEach((row) => {
+		row.classList.toggle("is-selected", row.dataset.effortRow === effort);
+	});
+}
+
 tabs.forEach((tab) => {
 	tab.addEventListener("click", () => {
 		activeBenchmark = tab.dataset.benchmark;
@@ -323,6 +402,13 @@ tabs.forEach((tab) => {
 	});
 });
 
+effortControls.forEach((control) => {
+	control.addEventListener("click", () => {
+		renderEffortGuide(control.dataset.effort);
+	});
+});
+
 renderRanking();
 renderSpotlight();
 renderMatrix();
+renderEffortGuide("xhigh");

--- a/prototypes/ai-model-frontier/index.html
+++ b/prototypes/ai-model-frontier/index.html
@@ -52,7 +52,7 @@
 						<p>
 							<strong>Opus 5</strong> wins the deepest engineering test.
 							<strong>Fable 5</strong> owns the other two—but by a hair. For the practical
-							middle, <strong>Terra</strong> is the efficiency story.
+							middle, <strong>Terra at Extra High</strong> is the efficiency story.
 						</p>
 						<a href="#scoreboard">See the evidence <span aria-hidden="true">↘</span></a>
 					</aside>
@@ -184,10 +184,119 @@
 				</div>
 			</section>
 
+			<section class="decision-desk shell" id="effort-guide">
+				<div class="section-heading compact">
+					<div>
+						<span class="section-number">02 / DECISION DESK</span>
+						<h2>How hard should Terra think?</h2>
+					</div>
+					<p>
+						For serious repository work, start at Extra High. Move down when the task is
+						narrow and well tested; move up when a missed edge case costs more than the run.
+					</p>
+				</div>
+
+				<div class="effort-board">
+					<div class="effort-advisor">
+						<div class="effort-advisor-topline">
+							<span>GPT‑5.6 TERRA</span>
+							<span class="recommendation-chip">RECOMMENDED DEFAULT</span>
+						</div>
+
+						<div class="effort-answer" aria-live="polite">
+							<span class="effort-answer-label">Run it at</span>
+							<strong id="effort-answer">Extra High</strong>
+							<p id="effort-answer-copy">
+								The practical sweet spot for substantial feature work, refactors, and bug
+								investigations. You keep most of Max’s score without paying Max’s full premium.
+							</p>
+						</div>
+
+						<div class="effort-controls" role="group" aria-label="Choose your priority">
+							<button type="button" class="effort-control" data-effort="high" aria-pressed="false">
+								<span>Ship faster</span><small>High</small>
+							</button>
+							<button
+								type="button"
+								class="effort-control is-active"
+								data-effort="xhigh"
+								aria-pressed="true"
+							>
+								<span>Best balance</span><small>Extra High</small>
+							</button>
+							<button type="button" class="effort-control" data-effort="max" aria-pressed="false">
+								<span>Max quality</span><small>Max</small>
+							</button>
+						</div>
+
+						<p class="economy-note">
+							Low and Medium are economy modes: useful for triage, boilerplate, and tightly
+							scoped chores—but not the default for ambiguous repository work.
+						</p>
+					</div>
+
+					<div class="effort-evidence">
+						<div class="effort-evidence-head">
+							<div>
+								<span>THE TRADE-OFF</span>
+								<h3 id="effort-evidence-title">Most of Max, for much less.</h3>
+							</div>
+							<span class="evidence-status" id="effort-evidence-status">XHIGH / SELECTED</span>
+						</div>
+
+						<div class="effort-stat-grid">
+							<div>
+								<span>Cursor score</span>
+								<strong id="effort-cursor-score">59.2%</strong>
+								<small id="effort-cursor-cost">$1.15 / task</small>
+							</div>
+							<div>
+								<span>Frontier score</span>
+								<strong id="effort-frontier-score">38.7%</strong>
+								<small id="effort-frontier-cost">$1.30 / task</small>
+							</div>
+							<div>
+								<span>Max score retained</span>
+								<strong id="effort-retained">91–94%</strong>
+								<small id="effort-retained-note">across both benchmarks</small>
+							</div>
+						</div>
+
+						<div
+							class="effort-ladder"
+							role="group"
+							aria-label="Terra effort-level score and cost comparison"
+						>
+							<div class="effort-ladder-head" aria-hidden="true">
+								<span>Effort</span><span>CursorBench</span><span>FrontierCode</span>
+							</div>
+							<div class="effort-ladder-row" data-effort-row="high">
+								<strong>High</strong><span>54.2% <small>$0.71</small></span
+								><span>36.9% <small>$1.10</small></span>
+							</div>
+							<div class="effort-ladder-row is-selected" data-effort-row="xhigh">
+								<strong>Extra High</strong><span>59.2% <small>$1.15</small></span
+								><span>38.7% <small>$1.30</small></span>
+							</div>
+							<div class="effort-ladder-row" data-effort-row="max">
+								<strong>Max</strong><span>64.9% <small>$2.31</small></span
+								><span>41.3% <small>$1.81</small></span>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<p class="effort-source-note">
+					Recommendation derived from GPT‑5.6 Terra’s published CursorBench 3.2 and
+					FrontierCode 1.1 Main effort ladders. Costs are benchmark averages, not a quote
+					for your own workload.
+				</p>
+			</section>
+
 			<section class="field-notes shell" id="models">
 				<div class="section-heading compact">
 					<div>
-						<span class="section-number">02 / FIELD NOTES</span>
+						<span class="section-number">03 / FIELD NOTES</span>
 						<h2>Pick for the work, not the logo.</h2>
 					</div>
 					<p>
@@ -287,7 +396,7 @@
 				<div class="shell">
 					<div class="section-heading compact">
 						<div>
-							<span class="section-number">03 / EVIDENCE MATRIX</span>
+							<span class="section-number">04 / EVIDENCE MATRIX</span>
 							<h2>The numbers, without the theater.</h2>
 						</div>
 						<p>Best reported effort per model. Average cost is per benchmark task/run.</p>
@@ -315,7 +424,7 @@
 
 			<section class="method shell" id="method">
 				<div class="method-title">
-					<span class="section-number">04 / READ THE FINE PRINT</span>
+					<span class="section-number">05 / READ THE FINE PRINT</span>
 					<h2>Benchmarks are lenses,<br>not verdicts.</h2>
 				</div>
 				<div class="method-grid">

--- a/prototypes/ai-model-frontier/index.html
+++ b/prototypes/ai-model-frontier/index.html
@@ -188,50 +188,66 @@
 				<div class="section-heading compact">
 					<div>
 						<span class="section-number">02 / DECISION DESK</span>
-						<h2>How hard should Terra think?</h2>
+						<h2>Which model. How much effort.</h2>
 					</div>
 					<p>
-						For serious repository work, start at Extra High. Move down when the task is
-						narrow and well tested; move up when a missed edge case costs more than the run.
+						Choose any model in the field. The desk turns its published effort ladder into
+						three practical modes: cheaper, recommended, and capability ceiling.
 					</p>
 				</div>
 
 				<div class="effort-board">
-					<div class="effort-advisor">
+					<div class="effort-advisor" id="effort-advisor">
 						<div class="effort-advisor-topline">
-							<span>GPT‑5.6 TERRA</span>
-							<span class="recommendation-chip">RECOMMENDED DEFAULT</span>
+							<div class="effort-model-picker">
+								<label for="effort-model-select">Choose a model</label>
+								<div class="effort-model-select-row">
+									<span class="effort-model-monogram" id="effort-model-monogram" aria-hidden="true"
+										>TR</span
+									>
+									<select id="effort-model-select" aria-label="Choose a model for effort guidance">
+										<option value="opus">Claude Opus 5</option>
+										<option value="fable">Claude Fable 5</option>
+										<option value="sol">GPT‑5.6 Sol</option>
+										<option value="terra" selected>GPT‑5.6 Terra</option>
+										<option value="luna">GPT‑5.6 Luna</option>
+										<option value="kimi">Kimi K3</option>
+										<option value="gemini">Gemini 3.6 Flash</option>
+									</select>
+								</div>
+							</div>
+							<span class="recommendation-chip" id="effort-mode-chip">RECOMMENDED DEFAULT</span>
 						</div>
 
 						<div class="effort-answer" aria-live="polite">
-							<span class="effort-answer-label">Run it at</span>
+							<span class="effort-answer-label" id="effort-answer-label">Recommended default</span>
 							<strong id="effort-answer">Extra High</strong>
 							<p id="effort-answer-copy">
-								The practical sweet spot for substantial feature work, refactors, and bug
-								investigations. You keep most of Max’s score without paying Max’s full premium.
+								The practical sweet spot for substantial feature work and investigations: most
+								of Max’s published performance without Max’s full premium.
 							</p>
 						</div>
 
-						<div class="effort-controls" role="group" aria-label="Choose your priority">
-							<button type="button" class="effort-control" data-effort="high" aria-pressed="false">
-								<span>Ship faster</span><small>High</small>
+						<div class="effort-controls" role="group" aria-label="Choose a decision mode">
+							<button type="button" class="effort-control" data-choice="economy" aria-pressed="false">
+								<span>Cheaper</span><small>High</small>
 							</button>
 							<button
 								type="button"
 								class="effort-control is-active"
-								data-effort="xhigh"
+								data-choice="recommended"
 								aria-pressed="true"
 							>
-								<span>Best balance</span><small>Extra High</small>
+								<span>Recommended</span><small>Extra High</small>
 							</button>
-							<button type="button" class="effort-control" data-effort="max" aria-pressed="false">
-								<span>Max quality</span><small>Max</small>
+							<button type="button" class="effort-control" data-choice="ceiling" aria-pressed="false">
+								<span>Ceiling</span><small>Max</small>
 							</button>
 						</div>
 
-						<p class="economy-note">
-							Low and Medium are economy modes: useful for triage, boilerplate, and tightly
-							scoped chores—but not the default for ambiguous repository work.
+						<p class="economy-note" id="effort-model-note">
+							Terra has complete CursorBench and FrontierCode effort ladders; both improve
+							steadily as effort rises.
 						</p>
 					</div>
 
@@ -256,40 +272,30 @@
 								<small id="effort-frontier-cost">$1.30 / task</small>
 							</div>
 							<div>
-								<span>Max score retained</span>
-								<strong id="effort-retained">91–94%</strong>
-								<small id="effort-retained-note">across both benchmarks</small>
+								<span>Evidence coverage</span>
+								<strong id="effort-coverage">2 / 2</strong>
+								<small id="effort-coverage-note">published effort ladders</small>
 							</div>
 						</div>
 
 						<div
 							class="effort-ladder"
 							role="group"
-							aria-label="Terra effort-level score and cost comparison"
+							aria-label="Selected model effort-level score and cost comparison"
+							aria-live="polite"
 						>
 							<div class="effort-ladder-head" aria-hidden="true">
 								<span>Effort</span><span>CursorBench</span><span>FrontierCode</span>
 							</div>
-							<div class="effort-ladder-row" data-effort-row="high">
-								<strong>High</strong><span>54.2% <small>$0.71</small></span
-								><span>36.9% <small>$1.10</small></span>
-							</div>
-							<div class="effort-ladder-row is-selected" data-effort-row="xhigh">
-								<strong>Extra High</strong><span>59.2% <small>$1.15</small></span
-								><span>38.7% <small>$1.30</small></span>
-							</div>
-							<div class="effort-ladder-row" data-effort-row="max">
-								<strong>Max</strong><span>64.9% <small>$2.31</small></span
-								><span>41.3% <small>$1.81</small></span>
-							</div>
+							<div id="effort-ladder-body"></div>
 						</div>
 					</div>
 				</div>
 
 				<p class="effort-source-note">
-					Recommendation derived from GPT‑5.6 Terra’s published CursorBench 3.2 and
-					FrontierCode 1.1 Main effort ladders. Costs are benchmark averages, not a quote
-					for your own workload.
+					Recommendations are our inference from official CursorBench 3.2 and
+					FrontierCode 1.1 Main results—not provider guidance. Costs are benchmark
+					averages, not a quote for your own workload; N/R means no matched effort run.
 				</p>
 			</section>
 

--- a/prototypes/ai-model-frontier/index.html
+++ b/prototypes/ai-model-frontier/index.html
@@ -1,0 +1,377 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta
+			name="description"
+			content="A sourced August 2026 field guide to frontier coding models across DeepSWE, FrontierCode, and CursorBench."
+		>
+		<meta name="theme-color" content="#111713">
+		<title>Frontier Index — Coding Models, August 2026</title>
+		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+		<link
+			href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&amp;family=Manrope:wght@400;500;600;700&amp;family=Newsreader:opsz,wght@6..72,400;6..72,500&amp;display=swap"
+			rel="stylesheet"
+		>
+		<link rel="stylesheet" href="./styles.css">
+		<script src="./app.js" defer></script>
+	</head>
+	<body>
+		<div class="noise" aria-hidden="true"></div>
+		<header class="masthead shell">
+			<a class="wordmark" href="#top" aria-label="Frontier Index home">
+				<span class="wordmark-mark" aria-hidden="true">FI</span>
+				<span>Frontier Index</span>
+			</a>
+			<div class="masthead-meta">
+				<span>Independent field notes</span>
+				<span class="live-dot"><i aria-hidden="true"></i> 04 Aug 2026</span>
+			</div>
+		</header>
+
+		<main id="top">
+			<section class="hero shell">
+				<div class="eyebrow-row">
+					<span class="eyebrow">Coding intelligence / issue 01</span>
+					<span class="edition">Berlin · Summer ’26</span>
+				</div>
+
+				<div class="hero-grid">
+					<div class="hero-copy">
+						<h1>The frontier has <em>seven seats.</em></h1>
+						<p class="hero-deck">
+							A clean read on the models that matter—measured on long-horizon engineering,
+							mergeable code, and messy real-world repository work.
+						</p>
+					</div>
+
+					<aside class="hero-note" aria-label="Current benchmark read">
+						<p class="note-kicker">The 30-second read</p>
+						<p>
+							<strong>Opus 5</strong> wins the deepest engineering test.
+							<strong>Fable 5</strong> owns the other two—but by a hair. For the practical
+							middle, <strong>Terra</strong> is the efficiency story.
+						</p>
+						<a href="#scoreboard">See the evidence <span aria-hidden="true">↘</span></a>
+					</aside>
+				</div>
+
+				<section class="winner-strip" aria-label="Benchmark leaders">
+					<article>
+						<span class="winner-index">01</span>
+						<div>
+							<p>DeepSWE v1.1</p>
+							<strong>Opus 5 <b>74%</b></strong>
+						</div>
+					</article>
+					<article>
+						<span class="winner-index">02</span>
+						<div>
+							<p>FrontierCode 1.1</p>
+							<strong>Fable 5 <b>53.5%</b></strong>
+						</div>
+					</article>
+					<article>
+						<span class="winner-index">03</span>
+						<div>
+							<p>CursorBench 3.2</p>
+							<strong>Fable 5 <b>70.5%</b></strong>
+						</div>
+					</article>
+				</section>
+			</section>
+
+			<section class="scoreboard-section" id="scoreboard">
+				<div class="shell">
+					<div class="section-heading">
+						<div>
+							<span class="section-number">01 / SCOREBOARD</span>
+							<h2>One field. Three different games.</h2>
+						</div>
+						<p>
+							Choose a benchmark to see its shape. Scores use each model’s best published
+							configuration—not a blended or invented “overall” number.
+						</p>
+					</div>
+
+					<div class="benchmark-tabs" role="tablist" aria-label="Select a benchmark">
+						<button
+							class="benchmark-tab is-active"
+							type="button"
+							role="tab"
+							aria-selected="true"
+							aria-controls="benchmark-panel"
+							id="tab-deepswe"
+							data-benchmark="deepswe"
+						>
+							<span>DeepSWE</span><small>Long-horizon</small>
+						</button>
+						<button
+							class="benchmark-tab"
+							type="button"
+							role="tab"
+							aria-selected="false"
+							aria-controls="benchmark-panel"
+							id="tab-frontier"
+							data-benchmark="frontier"
+						>
+							<span>FrontierCode</span><small>Mergeability</small>
+						</button>
+						<button
+							class="benchmark-tab"
+							type="button"
+							role="tab"
+							aria-selected="false"
+							aria-controls="benchmark-panel"
+							id="tab-cursor"
+							data-benchmark="cursor"
+						>
+							<span>CursorBench</span><small>Real sessions</small>
+						</button>
+					</div>
+
+					<div
+						class="benchmark-stage"
+						id="benchmark-panel"
+						role="tabpanel"
+						aria-labelledby="tab-deepswe"
+					>
+						<div class="chart-area">
+							<div class="chart-meta">
+								<div>
+									<span id="benchmark-version">DEEPSWE V1.1</span>
+									<strong id="benchmark-title">Original, long-horizon engineering</strong>
+								</div>
+								<p id="benchmark-description">
+									113 tasks · mini-swe-agent · higher is better
+								</p>
+							</div>
+							<div class="scale" aria-hidden="true">
+								<span>0</span><span>20</span><span>40</span><span>60</span><span>80%</span>
+							</div>
+							<div class="ranking" id="ranking" aria-live="polite"></div>
+						</div>
+
+						<aside
+							class="spotlight"
+							id="spotlight"
+							aria-label="Selected model details"
+							aria-live="polite"
+						>
+							<div class="spotlight-head">
+								<span class="model-monogram" id="spotlight-monogram">O5</span>
+								<span class="spotlight-rank" id="spotlight-rank">RANK 01</span>
+							</div>
+							<p class="spotlight-kicker" id="spotlight-maker">ANTHROPIC</p>
+							<h3 id="spotlight-name">Claude Opus 5</h3>
+							<p class="spotlight-copy" id="spotlight-copy">
+								The current long-horizon leader, with Fable-level results at a markedly lower
+								run cost.
+							</p>
+							<dl class="spotlight-stats">
+								<div><dt>Score</dt><dd id="spotlight-score">74%</dd></div>
+								<div><dt>Avg. run</dt><dd id="spotlight-cost">$11.84</dd></div>
+								<div><dt>Effort</dt><dd id="spotlight-effort">Max</dd></div>
+							</dl>
+							<div class="spotlight-foot">
+								<span>Across all three</span>
+								<div id="mini-scores" class="mini-scores"></div>
+							</div>
+						</aside>
+					</div>
+				</div>
+			</section>
+
+			<section class="field-notes shell" id="models">
+				<div class="section-heading compact">
+					<div>
+						<span class="section-number">02 / FIELD NOTES</span>
+						<h2>Pick for the work, not the logo.</h2>
+					</div>
+					<p>
+						The most useful choice is usually one constraint away from “the best.” Here’s
+						what the published runs actually suggest.
+					</p>
+				</div>
+
+				<div class="notes-grid">
+					<article class="note-card note-card-featured">
+						<div class="card-topline"><span>01</span><span>CAPABILITY PICK</span></div>
+						<div class="card-model"><i>O5</i><span>Anthropic</span></div>
+						<h3>Opus 5</h3>
+						<p>
+							First on DeepSWE, 0.1 points off FrontierCode’s lead, and 0.5 off CursorBench.
+							The strongest all-round showing in this snapshot.
+						</p>
+						<div class="card-scores"><span>74</span><span>53.4</span><span>70.0</span></div>
+						<div class="card-labels"><span>Deep</span><span>Frontier</span><span>Cursor</span></div>
+					</article>
+
+					<article class="note-card">
+						<div class="card-topline"><span>02</span><span>CEILING PICK</span></div>
+						<div class="card-model"><i>F5</i><span>Anthropic</span></div>
+						<h3>Fable 5</h3>
+						<p>
+							Wins FrontierCode and CursorBench outright. Its final few points carry the
+							highest run costs in the group.
+						</p>
+						<div class="card-scores"><span>70</span><span>53.5</span><span>70.5</span></div>
+						<div class="card-labels"><span>Deep</span><span>Frontier</span><span>Cursor</span></div>
+					</article>
+
+					<article class="note-card">
+						<div class="card-topline"><span>03</span><span>BALANCE PICK</span></div>
+						<div class="card-model"><i>TR</i><span>OpenAI</span></div>
+						<h3>GPT‑5.6 Terra</h3>
+						<p>
+							Ties Fable on DeepSWE at roughly one-fifth the run cost and stays competitive
+							on both repository benchmarks.
+						</p>
+						<div class="card-scores"><span>70</span><span>41.3</span><span>64.9</span></div>
+						<div class="card-labels"><span>Deep</span><span>Frontier</span><span>Cursor</span></div>
+					</article>
+
+					<article class="note-card">
+						<div class="card-topline"><span>04</span><span>FLAGSHIP PICK</span></div>
+						<div class="card-model"><i>SO</i><span>OpenAI</span></div>
+						<h3>GPT‑5.6 Sol</h3>
+						<p>
+							One point from DeepSWE’s lead, third on FrontierCode among this field, and a
+							stronger cost profile than either top Claude.
+						</p>
+						<div class="card-scores"><span>73</span><span>47.5</span><span>67.2</span></div>
+						<div class="card-labels"><span>Deep</span><span>Frontier</span><span>Cursor</span></div>
+					</article>
+
+					<article class="note-card">
+						<div class="card-topline"><span>05</span><span>VALUE PICK</span></div>
+						<div class="card-model"><i>LU</i><span>OpenAI</span></div>
+						<h3>GPT‑5.6 Luna</h3>
+						<p>
+							A 67 on DeepSWE for $0.61 per run and the lowest reported cost in the other
+							two tests. The throughput choice.
+						</p>
+						<div class="card-scores"><span>67</span><span>39.8</span><span>61.1</span></div>
+						<div class="card-labels"><span>Deep</span><span>Frontier</span><span>Cursor</span></div>
+					</article>
+
+					<article class="note-card">
+						<div class="card-topline"><span>06</span><span>CONTENDER</span></div>
+						<div class="card-model"><i>K3</i><span>Moonshot AI</span></div>
+						<h3>Kimi K3</h3>
+						<p>
+							A genuine top-tier DeepSWE result and fifth place on FrontierCode. More uneven
+							on CursorBench, but firmly in the conversation.
+						</p>
+						<div class="card-scores"><span>69</span><span>44.2</span><span>60.8</span></div>
+						<div class="card-labels"><span>Deep</span><span>Frontier</span><span>Cursor</span></div>
+					</article>
+
+					<article class="note-card">
+						<div class="card-topline"><span>07</span><span>FAST-MODEL PICK</span></div>
+						<div class="card-model"><i>GF</i><span>Google</span></div>
+						<h3>Gemini 3.6 Flash</h3>
+						<p>
+							Behind this frontier pack on the two reported tests. FrontierCode has not
+							published a run, so the evidence is incomplete.
+						</p>
+						<div class="card-scores"><span>49</span><span class="na">N/R</span><span>53.5</span></div>
+						<div class="card-labels"><span>Deep</span><span>Frontier</span><span>Cursor</span></div>
+					</article>
+				</div>
+			</section>
+
+			<section class="matrix-section">
+				<div class="shell">
+					<div class="section-heading compact">
+						<div>
+							<span class="section-number">03 / EVIDENCE MATRIX</span>
+							<h2>The numbers, without the theater.</h2>
+						</div>
+						<p>Best reported effort per model. Average cost is per benchmark task/run.</p>
+					</div>
+
+					<div class="matrix-wrap">
+						<table>
+							<caption class="sr-only">
+								Best published scores and costs for seven AI models on three coding
+								benchmarks
+							</caption>
+							<thead>
+								<tr>
+									<th scope="col">Model</th>
+									<th scope="col">DeepSWE <small>score / cost</small></th>
+									<th scope="col">FrontierCode <small>score / cost</small></th>
+									<th scope="col">CursorBench <small>score / cost</small></th>
+								</tr>
+							</thead>
+							<tbody id="matrix-body"></tbody>
+						</table>
+					</div>
+				</div>
+			</section>
+
+			<section class="method shell" id="method">
+				<div class="method-title">
+					<span class="section-number">04 / READ THE FINE PRINT</span>
+					<h2>Benchmarks are lenses,<br>not verdicts.</h2>
+				</div>
+				<div class="method-grid">
+					<article>
+						<span>DEEPSWE V1.1</span>
+						<h3>Can it finish a deep build?</h3>
+						<p>
+							113 original tasks across 91 repositories and five languages. All models run
+							on the same mini-swe-agent harness; confidence intervals matter.
+						</p>
+						<a href="https://deepswe.datacurve.ai/" target="_blank" rel="noreferrer"
+							>Official leaderboard ↗</a
+						>
+					</article>
+					<article>
+						<span>FRONTIERCODE 1.1 / MAIN</span>
+						<h3>Would a maintainer merge it?</h3>
+						<p>
+							100 maintainer-written tasks scored for correctness, tests, scope discipline,
+							style, and codebase standards. Harnesses differ by model family.
+						</p>
+						<a href="https://cognition.com/frontiercode" target="_blank" rel="noreferrer"
+							>Official leaderboard ↗</a
+						>
+					</article>
+					<article>
+						<span>CURSORBENCH 3.2</span>
+						<h3>Can it navigate messy intent?</h3>
+						<p>
+							Ambiguous, multi-file tasks from real Cursor sessions, including instruction
+							following and advanced tool use. Small score gaps may be noise.
+						</p>
+						<a href="https://cursor.com/cursorbench" target="_blank" rel="noreferrer"
+							>Official leaderboard ↗</a
+						>
+					</article>
+				</div>
+
+				<div class="method-note">
+					<p>
+						<strong>Snapshot:</strong> 04 August 2026. DeepSWE updated 25 July; CursorBench
+						reporting updated 30 July; FrontierCode data retrieved 04 August. “N/R” means
+						no result was reported—not a zero. Scores across benchmarks are not directly
+						interchangeable.
+					</p>
+				</div>
+			</section>
+		</main>
+
+		<footer class="footer shell">
+			<div class="wordmark footer-wordmark">
+				<span class="wordmark-mark" aria-hidden="true">FI</span>
+				<span>Frontier Index</span>
+			</div>
+			<p>Choose with evidence. Re-test on your own codebase.</p>
+			<a href="#top">Back to top ↑</a>
+		</footer>
+	</body>
+</html>

--- a/prototypes/ai-model-frontier/styles.css
+++ b/prototypes/ai-model-frontier/styles.css
@@ -1,0 +1,1293 @@
+:root {
+	--ink: #131814;
+	--paper: #f1efe7;
+	--paper-deep: #e5e1d4;
+	--line: rgba(19, 24, 20, 0.18);
+	--line-strong: rgba(19, 24, 20, 0.54);
+	--muted: #62665f;
+	--acid: #d8ff3e;
+	--acid-dark: #bfdc36;
+	--apricot: #ff9d79;
+	--blue: #8dc9ff;
+	--violet: #b9a6ff;
+	--white: #fbfaf6;
+	--radius: 22px;
+	--mono: "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+	--sans: "Manrope", system-ui, sans-serif;
+	--serif: "Newsreader", Georgia, serif;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+html {
+	scroll-behavior: smooth;
+}
+
+body {
+	margin: 0;
+	background: var(--paper);
+	color: var(--ink);
+	font-family: var(--sans);
+	font-size: 16px;
+	line-height: 1.55;
+	-webkit-font-smoothing: antialiased;
+}
+
+button,
+a {
+	-webkit-tap-highlight-color: transparent;
+}
+
+button {
+	font: inherit;
+}
+
+a {
+	color: inherit;
+}
+
+.noise {
+	position: fixed;
+	inset: 0;
+	pointer-events: none;
+	z-index: 100;
+	opacity: 0.038;
+	background-image:
+		repeating-radial-gradient(circle at 17% 32%, currentColor 0 0.4px, transparent 0.5px 3px),
+		repeating-radial-gradient(circle at 73% 61%, currentColor 0 0.35px, transparent 0.45px 4px);
+	background-size: 7px 9px, 11px 13px;
+}
+
+.shell {
+	width: min(1380px, calc(100% - 64px));
+	margin-inline: auto;
+}
+
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.masthead {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	min-height: 88px;
+	border-bottom: 1px solid var(--line-strong);
+}
+
+.wordmark {
+	display: inline-flex;
+	align-items: center;
+	gap: 12px;
+	font-size: 14px;
+	font-weight: 700;
+	letter-spacing: -0.02em;
+	text-decoration: none;
+}
+
+.wordmark-mark {
+	display: grid;
+	place-items: center;
+	width: 34px;
+	height: 34px;
+	border-radius: 50%;
+	background: var(--ink);
+	color: var(--acid);
+	font-family: var(--mono);
+	font-size: 11px;
+	font-weight: 500;
+}
+
+.masthead-meta {
+	display: flex;
+	align-items: center;
+	gap: 34px;
+	font-family: var(--mono);
+	font-size: 10px;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.live-dot {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.live-dot i {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--acid-dark);
+	box-shadow: 0 0 0 4px rgba(191, 220, 54, 0.18);
+}
+
+.hero {
+	padding: 28px 0 0;
+}
+
+.eyebrow-row {
+	display: flex;
+	justify-content: space-between;
+	gap: 24px;
+	padding-bottom: 22px;
+	font-family: var(--mono);
+	font-size: 10px;
+	letter-spacing: 0.07em;
+	text-transform: uppercase;
+}
+
+.edition {
+	color: var(--muted);
+}
+
+.hero-grid {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 365px;
+	gap: 72px;
+	align-items: end;
+	padding: 56px 0 58px;
+}
+
+h1,
+h2,
+h3,
+p {
+	margin-top: 0;
+}
+
+h1 {
+	max-width: 980px;
+	margin-bottom: 34px;
+	font-family: var(--serif);
+	font-size: clamp(74px, 8.7vw, 146px);
+	font-weight: 400;
+	letter-spacing: -0.065em;
+	line-height: 0.78;
+}
+
+h1 em {
+	display: block;
+	padding-left: clamp(20px, 9vw, 150px);
+	color: var(--muted);
+	font-weight: 400;
+}
+
+.hero-deck {
+	max-width: 660px;
+	margin: 0 0 0 clamp(20px, 9vw, 150px);
+	font-size: clamp(17px, 1.5vw, 21px);
+	letter-spacing: -0.025em;
+	line-height: 1.48;
+}
+
+.hero-note {
+	position: relative;
+	padding: 26px 26px 24px;
+	border: 1px solid var(--line-strong);
+	border-radius: var(--radius);
+	background: var(--acid);
+	transform: rotate(1.4deg);
+	box-shadow: 10px 12px 0 var(--ink);
+}
+
+.hero-note::before {
+	content: "";
+	position: absolute;
+	width: 9px;
+	height: 9px;
+	top: 18px;
+	right: 20px;
+	border-radius: 50%;
+	background: var(--ink);
+}
+
+.note-kicker {
+	margin-bottom: 22px;
+	font-family: var(--mono);
+	font-size: 10px;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.hero-note p:not(.note-kicker) {
+	font-family: var(--serif);
+	font-size: 25px;
+	letter-spacing: -0.025em;
+	line-height: 1.13;
+}
+
+.hero-note strong {
+	font-weight: 500;
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 3px;
+}
+
+.hero-note a {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding-top: 18px;
+	border-top: 1px solid var(--line-strong);
+	font-size: 12px;
+	font-weight: 700;
+	text-decoration: none;
+}
+
+.winner-strip {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	border-top: 1px solid var(--line-strong);
+	border-bottom: 1px solid var(--line-strong);
+}
+
+.winner-strip article {
+	display: grid;
+	grid-template-columns: 34px 1fr;
+	gap: 20px;
+	padding: 28px 30px;
+	border-right: 1px solid var(--line);
+}
+
+.winner-strip article:first-child {
+	padding-left: 0;
+}
+
+.winner-strip article:last-child {
+	border-right: 0;
+}
+
+.winner-index,
+.winner-strip p,
+.section-number,
+.spotlight-kicker,
+.card-topline,
+.card-model span,
+.method-grid article > span {
+	font-family: var(--mono);
+	font-size: 10px;
+	letter-spacing: 0.065em;
+	text-transform: uppercase;
+}
+
+.winner-index {
+	color: var(--muted);
+}
+
+.winner-strip p {
+	margin-bottom: 7px;
+	color: var(--muted);
+}
+
+.winner-strip strong {
+	display: flex;
+	justify-content: space-between;
+	gap: 20px;
+	font-size: 17px;
+	font-weight: 600;
+	letter-spacing: -0.025em;
+}
+
+.winner-strip b {
+	font-family: var(--mono);
+	font-size: 14px;
+	font-weight: 500;
+}
+
+.scoreboard-section {
+	margin-top: 108px;
+	padding: 100px 0 112px;
+	background: var(--ink);
+	color: var(--white);
+}
+
+.section-heading {
+	display: grid;
+	grid-template-columns: 1fr minmax(300px, 430px);
+	gap: 50px;
+	align-items: end;
+	margin-bottom: 62px;
+}
+
+.section-number {
+	display: block;
+	margin-bottom: 20px;
+	color: var(--muted);
+}
+
+.scoreboard-section .section-number,
+.scoreboard-section .section-heading > p {
+	color: #9ba199;
+}
+
+.section-heading h2,
+.method h2 {
+	max-width: 900px;
+	margin: 0;
+	font-family: var(--serif);
+	font-size: clamp(44px, 5.4vw, 80px);
+	font-weight: 400;
+	letter-spacing: -0.045em;
+	line-height: 0.96;
+}
+
+.section-heading > p {
+	margin: 0;
+	color: var(--muted);
+	font-size: 14px;
+	line-height: 1.7;
+}
+
+.benchmark-tabs {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	margin-bottom: 26px;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.benchmark-tab {
+	position: relative;
+	display: flex;
+	align-items: baseline;
+	gap: 12px;
+	padding: 0 12px 20px;
+	border: 0;
+	background: transparent;
+	color: #858c84;
+	cursor: pointer;
+	text-align: left;
+}
+
+.benchmark-tab:first-child {
+	padding-left: 0;
+}
+
+.benchmark-tab::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: -1px;
+	height: 3px;
+	background: transparent;
+	transform: scaleX(0.2);
+	transition: transform 220ms ease, background-color 220ms ease;
+}
+
+.benchmark-tab span {
+	font-size: 17px;
+	font-weight: 600;
+	letter-spacing: -0.03em;
+}
+
+.benchmark-tab small {
+	font-family: var(--mono);
+	font-size: 9px;
+	text-transform: uppercase;
+}
+
+.benchmark-tab.is-active {
+	color: var(--white);
+}
+
+.benchmark-tab.is-active::after {
+	background: var(--acid);
+	transform: scaleX(1);
+}
+
+.benchmark-tab:focus-visible,
+.rank-row:focus-visible,
+.hero-note a:focus-visible,
+.method a:focus-visible,
+.footer a:focus-visible {
+	outline: 2px solid var(--acid);
+	outline-offset: 4px;
+}
+
+.benchmark-stage {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 320px;
+	gap: 56px;
+	align-items: stretch;
+}
+
+.chart-area {
+	min-width: 0;
+}
+
+.chart-meta {
+	display: flex;
+	align-items: end;
+	justify-content: space-between;
+	gap: 30px;
+	padding: 8px 0 30px;
+}
+
+.chart-meta span,
+.chart-meta p {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.chart-meta span {
+	display: block;
+	margin-bottom: 7px;
+	color: var(--acid);
+}
+
+.chart-meta strong {
+	font-family: var(--serif);
+	font-size: 27px;
+	font-weight: 400;
+	letter-spacing: -0.025em;
+}
+
+.chart-meta p {
+	margin: 0;
+	color: #8c938b;
+	text-align: right;
+}
+
+.scale {
+	display: grid;
+	grid-template-columns: repeat(5, 1fr);
+	padding: 0 0 9px 178px;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+	color: #788078;
+	font-family: var(--mono);
+	font-size: 9px;
+}
+
+.scale span:last-child {
+	text-align: right;
+}
+
+.ranking {
+	display: flex;
+	flex-direction: column;
+}
+
+.rank-row {
+	display: grid;
+	grid-template-columns: 28px 134px minmax(0, 1fr) 62px;
+	gap: 8px;
+	align-items: center;
+	width: 100%;
+	min-height: 64px;
+	padding: 0;
+	border: 0;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+	background: transparent;
+	color: inherit;
+	cursor: pointer;
+	text-align: left;
+}
+
+.rank-row:hover .bar-fill,
+.rank-row.is-selected .bar-fill {
+	filter: saturate(1.15) brightness(1.12);
+}
+
+.rank-row.is-selected .rank-name {
+	color: var(--acid);
+}
+
+.rank-number {
+	color: #697069;
+	font-family: var(--mono);
+	font-size: 9px;
+}
+
+.rank-name {
+	overflow: hidden;
+	font-size: 12px;
+	font-weight: 600;
+	letter-spacing: -0.02em;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	transition: color 160ms ease;
+}
+
+.bar-track {
+	position: relative;
+	height: 15px;
+	background-image: linear-gradient(to right, rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+	background-size: 25% 100%;
+}
+
+.bar-fill {
+	position: absolute;
+	inset: 0 auto 0 0;
+	width: var(--bar-width);
+	background: var(--bar-color);
+	transform-origin: left center;
+	animation: reveal-bar 560ms cubic-bezier(0.22, 1, 0.36, 1) both;
+	transition: filter 160ms ease;
+}
+
+.bar-fill::after {
+	content: "";
+	position: absolute;
+	top: 0;
+	right: -1px;
+	bottom: 0;
+	width: 2px;
+	background: var(--white);
+	opacity: 0.8;
+}
+
+.rank-score {
+	font-family: var(--mono);
+	font-size: 12px;
+	font-weight: 500;
+	text-align: right;
+}
+
+.rank-row.is-missing {
+	cursor: default;
+	opacity: 0.44;
+}
+
+.rank-row.is-missing .bar-track {
+	height: 1px;
+	background: repeating-linear-gradient(
+		to right,
+		rgba(255, 255, 255, 0.35) 0 5px,
+		transparent 5px 11px
+	);
+}
+
+@keyframes reveal-bar {
+	from {
+		transform: scaleX(0);
+	}
+	to {
+		transform: scaleX(1);
+	}
+}
+
+.spotlight {
+	display: flex;
+	flex-direction: column;
+	min-height: 100%;
+	padding: 26px;
+	border-radius: var(--radius);
+	background: var(--acid);
+	color: var(--ink);
+}
+
+.spotlight-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 42px;
+}
+
+.model-monogram,
+.card-model i {
+	display: grid;
+	place-items: center;
+	width: 46px;
+	height: 46px;
+	border: 1px solid var(--line-strong);
+	border-radius: 50%;
+	font-family: var(--mono);
+	font-size: 11px;
+	font-style: normal;
+	font-weight: 500;
+}
+
+.spotlight-rank {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 0.06em;
+}
+
+.spotlight-kicker {
+	margin-bottom: 9px;
+}
+
+.spotlight h3 {
+	margin-bottom: 20px;
+	font-family: var(--serif);
+	font-size: 42px;
+	font-weight: 400;
+	letter-spacing: -0.04em;
+	line-height: 0.95;
+}
+
+.spotlight-copy {
+	margin-bottom: 28px;
+	font-size: 13px;
+	line-height: 1.65;
+}
+
+.spotlight-stats {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 12px;
+	margin: 0 0 34px;
+	padding: 18px 0;
+	border-top: 1px solid var(--line-strong);
+	border-bottom: 1px solid var(--line-strong);
+}
+
+.spotlight-stats div {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.spotlight-stats dt,
+.spotlight-foot > span {
+	font-family: var(--mono);
+	font-size: 8px;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.spotlight-stats dd {
+	margin: 0;
+	font-size: 12px;
+	font-weight: 700;
+}
+
+.spotlight-foot {
+	margin-top: auto;
+}
+
+.spotlight-foot > span {
+	display: block;
+	margin-bottom: 12px;
+}
+
+.mini-scores {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 4px;
+}
+
+.mini-score {
+	padding: 10px 5px;
+	border: 1px solid var(--line-strong);
+	text-align: center;
+}
+
+.mini-score b,
+.mini-score span {
+	display: block;
+}
+
+.mini-score b {
+	font-family: var(--mono);
+	font-size: 11px;
+	font-weight: 500;
+}
+
+.mini-score span {
+	margin-top: 4px;
+	font-family: var(--mono);
+	font-size: 7px;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+}
+
+.field-notes {
+	padding: 126px 0 118px;
+}
+
+.section-heading.compact {
+	margin-bottom: 54px;
+}
+
+.notes-grid {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	border-top: 1px solid var(--line-strong);
+	border-left: 1px solid var(--line-strong);
+}
+
+.note-card {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	min-height: 420px;
+	padding: 25px 24px 22px;
+	border-right: 1px solid var(--line-strong);
+	border-bottom: 1px solid var(--line-strong);
+	background: rgba(255, 255, 255, 0.12);
+}
+
+.note-card-featured {
+	grid-column: span 2;
+	background: var(--apricot);
+}
+
+.card-topline {
+	display: flex;
+	justify-content: space-between;
+	padding-bottom: 22px;
+	border-bottom: 1px solid var(--line);
+	color: var(--muted);
+}
+
+.card-model {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin: 26px 0 32px;
+}
+
+.card-model span {
+	color: var(--muted);
+}
+
+.note-card h3 {
+	margin-bottom: 14px;
+	font-family: var(--serif);
+	font-size: 36px;
+	font-weight: 400;
+	letter-spacing: -0.04em;
+	line-height: 1;
+}
+
+.note-card p {
+	margin-bottom: 30px;
+	color: #444a44;
+	font-size: 12px;
+	line-height: 1.7;
+}
+
+.card-scores,
+.card-labels {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 3px;
+	margin-top: auto;
+}
+
+.card-scores span {
+	padding: 10px 5px;
+	border: 1px solid var(--line);
+	font-family: var(--mono);
+	font-size: 13px;
+	font-weight: 500;
+	text-align: center;
+}
+
+.card-scores .na {
+	color: var(--muted);
+	font-size: 10px;
+}
+
+.card-labels {
+	margin-top: 5px;
+}
+
+.card-labels span {
+	font-family: var(--mono);
+	font-size: 7px;
+	letter-spacing: 0.04em;
+	text-align: center;
+	text-transform: uppercase;
+}
+
+.matrix-section {
+	padding: 106px 0 118px;
+	background: var(--paper-deep);
+}
+
+.matrix-wrap {
+	overflow-x: auto;
+	border-top: 1px solid var(--line-strong);
+	-webkit-overflow-scrolling: touch;
+}
+
+table {
+	width: 100%;
+	min-width: 780px;
+	border-collapse: collapse;
+}
+
+th,
+td {
+	padding: 18px 16px;
+	border-bottom: 1px solid var(--line);
+	text-align: left;
+}
+
+th:first-child,
+td:first-child {
+	padding-left: 0;
+}
+
+th {
+	font-family: var(--mono);
+	font-size: 9px;
+	font-weight: 500;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+th small {
+	display: block;
+	margin-top: 4px;
+	color: var(--muted);
+	font-size: 7px;
+}
+
+td {
+	font-size: 13px;
+}
+
+.table-model {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	font-weight: 700;
+}
+
+.table-monogram {
+	display: grid;
+	place-items: center;
+	width: 31px;
+	height: 31px;
+	border: 1px solid var(--line);
+	border-radius: 50%;
+	font-family: var(--mono);
+	font-size: 8px;
+}
+
+.table-value {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+}
+
+.table-value strong {
+	font-family: var(--mono);
+	font-size: 12px;
+	font-weight: 500;
+}
+
+.table-value small {
+	color: var(--muted);
+	font-family: var(--mono);
+	font-size: 8px;
+}
+
+.table-value.is-winner strong {
+	padding: 3px 6px;
+	background: var(--acid-dark);
+	color: var(--ink);
+}
+
+.method {
+	display: grid;
+	grid-template-columns: minmax(280px, 0.65fr) minmax(0, 1.35fr);
+	gap: 80px;
+	padding: 122px 0 112px;
+}
+
+.method-title h2 {
+	font-size: clamp(48px, 5.5vw, 76px);
+}
+
+.method-grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 0;
+	border-top: 1px solid var(--line-strong);
+}
+
+.method-grid article {
+	display: flex;
+	flex-direction: column;
+	min-height: 355px;
+	padding: 24px 24px 20px;
+	border-right: 1px solid var(--line);
+	border-bottom: 1px solid var(--line-strong);
+}
+
+.method-grid article:first-child {
+	padding-left: 0;
+}
+
+.method-grid article:last-child {
+	border-right: 0;
+}
+
+.method-grid article > span {
+	margin-bottom: 45px;
+	color: var(--muted);
+}
+
+.method-grid h3 {
+	margin-bottom: 16px;
+	font-family: var(--serif);
+	font-size: 25px;
+	font-weight: 400;
+	letter-spacing: -0.03em;
+	line-height: 1.05;
+}
+
+.method-grid p {
+	margin-bottom: 30px;
+	color: var(--muted);
+	font-size: 11px;
+	line-height: 1.75;
+}
+
+.method-grid a {
+	margin-top: auto;
+	font-size: 10px;
+	font-weight: 700;
+	text-underline-offset: 4px;
+}
+
+.method-note {
+	grid-column: 2;
+	padding: 22px 0 0;
+}
+
+.method-note p {
+	max-width: 920px;
+	margin: 0;
+	color: var(--muted);
+	font-family: var(--mono);
+	font-size: 9px;
+	line-height: 1.8;
+	text-transform: uppercase;
+}
+
+.method-note strong {
+	color: var(--ink);
+	font-weight: 500;
+}
+
+.footer {
+	display: grid;
+	grid-template-columns: 1fr auto 1fr;
+	align-items: center;
+	gap: 30px;
+	min-height: 126px;
+	border-top: 1px solid var(--line-strong);
+}
+
+.footer p,
+.footer a {
+	margin: 0;
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.footer p {
+	color: var(--muted);
+	text-align: center;
+}
+
+.footer a {
+	justify-self: end;
+	text-underline-offset: 4px;
+}
+
+@media (max-width: 1120px) {
+	.shell {
+		width: min(100% - 44px, 1080px);
+	}
+
+	.hero-grid {
+		grid-template-columns: minmax(0, 1fr) 310px;
+		gap: 40px;
+	}
+
+	.benchmark-stage {
+		grid-template-columns: minmax(0, 1fr) 285px;
+		gap: 36px;
+	}
+
+	.notes-grid {
+		grid-template-columns: repeat(3, 1fr);
+	}
+
+	.note-card-featured {
+		grid-column: span 2;
+	}
+
+	.method {
+		grid-template-columns: 1fr;
+		gap: 50px;
+	}
+
+	.method-note {
+		grid-column: 1;
+	}
+}
+
+@media (max-width: 860px) {
+	.masthead-meta span:first-child {
+		display: none;
+	}
+
+	.hero-grid {
+		grid-template-columns: 1fr;
+		padding-top: 38px;
+	}
+
+	h1 {
+		font-size: clamp(62px, 15vw, 112px);
+	}
+
+	.hero-note {
+		width: min(420px, calc(100% - 12px));
+		margin-left: auto;
+	}
+
+	.winner-strip {
+		grid-template-columns: 1fr;
+	}
+
+	.winner-strip article,
+	.winner-strip article:first-child {
+		padding: 22px 0;
+		border-right: 0;
+		border-bottom: 1px solid var(--line);
+	}
+
+	.winner-strip article:last-child {
+		border-bottom: 0;
+	}
+
+	.section-heading {
+		grid-template-columns: 1fr;
+		gap: 24px;
+	}
+
+	.section-heading > p {
+		max-width: 560px;
+	}
+
+	.benchmark-stage {
+		grid-template-columns: 1fr;
+	}
+
+	.spotlight {
+		min-height: 390px;
+	}
+
+	.notes-grid {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	.note-card-featured {
+		grid-column: span 2;
+	}
+
+	.method-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.method-grid article,
+	.method-grid article:first-child {
+		min-height: 0;
+		padding: 24px 0;
+		border-right: 0;
+	}
+
+	.method-grid article > span {
+		margin-bottom: 22px;
+	}
+
+	.footer {
+		grid-template-columns: 1fr auto;
+	}
+
+	.footer p {
+		display: none;
+	}
+}
+
+@media (max-width: 620px) {
+	.shell {
+		width: calc(100% - 30px);
+	}
+
+	.masthead {
+		min-height: 70px;
+	}
+
+	.masthead-meta {
+		font-size: 8px;
+	}
+
+	.wordmark > span:last-child {
+		display: none;
+	}
+
+	.hero {
+		padding-top: 20px;
+	}
+
+	.eyebrow-row {
+		padding-bottom: 6px;
+		font-size: 8px;
+	}
+
+	.edition {
+		display: none;
+	}
+
+	.hero-grid {
+		gap: 44px;
+		padding: 34px 0 52px;
+	}
+
+	h1 {
+		margin-bottom: 26px;
+		font-size: clamp(56px, 19vw, 90px);
+		line-height: 0.82;
+	}
+
+	h1 em,
+	.hero-deck {
+		padding-left: 0;
+		margin-left: 0;
+	}
+
+	.hero-deck {
+		font-size: 16px;
+	}
+
+	.hero-note {
+		width: calc(100% - 10px);
+		padding: 22px;
+		box-shadow: 7px 8px 0 var(--ink);
+	}
+
+	.hero-note p:not(.note-kicker) {
+		font-size: 22px;
+	}
+
+	.scoreboard-section {
+		margin-top: 80px;
+		padding: 76px 0 84px;
+	}
+
+	.section-heading {
+		margin-bottom: 42px;
+	}
+
+	.section-heading h2,
+	.method h2 {
+		font-size: 43px;
+	}
+
+	.benchmark-tabs {
+		gap: 4px;
+	}
+
+	.benchmark-tab {
+		display: block;
+		padding: 0 5px 15px;
+	}
+
+	.benchmark-tab span {
+		font-size: 12px;
+	}
+
+	.benchmark-tab small {
+		display: none;
+	}
+
+	.chart-meta {
+		align-items: start;
+		padding-bottom: 24px;
+	}
+
+	.chart-meta strong {
+		display: block;
+		max-width: 210px;
+		font-size: 22px;
+		line-height: 1.05;
+	}
+
+	.chart-meta p {
+		max-width: 110px;
+		font-size: 7px;
+	}
+
+	.scale {
+		padding-left: 102px;
+	}
+
+	.rank-row {
+		grid-template-columns: 20px 73px minmax(0, 1fr) 49px;
+		min-height: 56px;
+	}
+
+	.rank-name {
+		font-size: 10px;
+	}
+
+	.rank-score {
+		font-size: 10px;
+	}
+
+	.spotlight {
+		min-height: 410px;
+	}
+
+	.field-notes,
+	.method {
+		padding: 88px 0;
+	}
+
+	.matrix-section {
+		padding: 82px 0 90px;
+	}
+
+	.notes-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.note-card-featured {
+		grid-column: span 1;
+	}
+
+	.note-card {
+		min-height: 390px;
+	}
+
+	.footer {
+		min-height: 100px;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	html {
+		scroll-behavior: auto;
+	}
+
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+	}
+}

--- a/prototypes/ai-model-frontier/styles.css
+++ b/prototypes/ai-model-frontier/styles.css
@@ -705,6 +705,257 @@ h1 em {
 	text-transform: uppercase;
 }
 
+.decision-desk {
+	padding: 126px 0 118px;
+}
+
+.effort-board {
+	display: grid;
+	grid-template-columns: minmax(360px, 0.82fr) minmax(0, 1.18fr);
+	border: 1px solid var(--line-strong);
+}
+
+.effort-advisor {
+	display: flex;
+	flex-direction: column;
+	padding: 30px;
+	border-right: 1px solid var(--line-strong);
+	background: var(--acid);
+}
+
+.effort-advisor-topline,
+.effort-evidence-head,
+.effort-ladder-head,
+.effort-ladder-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 18px;
+}
+
+.effort-advisor-topline > span,
+.effort-evidence-head span,
+.effort-answer-label,
+.economy-note,
+.effort-source-note,
+.effort-stat-grid span,
+.effort-stat-grid small,
+.effort-ladder-head,
+.effort-ladder-row,
+.effort-control small {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 0.055em;
+	text-transform: uppercase;
+}
+
+.recommendation-chip {
+	padding: 5px 8px;
+	background: var(--ink);
+	color: var(--acid);
+}
+
+.effort-answer {
+	padding: 68px 0 56px;
+}
+
+.effort-answer-label {
+	display: block;
+	margin-bottom: 12px;
+}
+
+.effort-answer strong {
+	display: block;
+	margin-bottom: 20px;
+	font-family: var(--serif);
+	font-size: clamp(58px, 6.2vw, 88px);
+	font-weight: 400;
+	letter-spacing: -0.055em;
+	line-height: 0.86;
+}
+
+.effort-answer p {
+	max-width: 470px;
+	margin: 0;
+	font-size: 13px;
+	line-height: 1.7;
+}
+
+.effort-controls {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	border-top: 1px solid var(--line-strong);
+	border-left: 1px solid var(--line-strong);
+}
+
+.effort-control {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	justify-content: space-between;
+	min-height: 94px;
+	padding: 14px;
+	border: 0;
+	border-right: 1px solid var(--line-strong);
+	border-bottom: 1px solid var(--line-strong);
+	background: transparent;
+	color: var(--ink);
+	cursor: pointer;
+	text-align: left;
+}
+
+.effort-control span {
+	font-size: 11px;
+	font-weight: 700;
+}
+
+.effort-control small {
+	opacity: 0.58;
+}
+
+.effort-control:hover,
+.effort-control.is-active {
+	background: var(--ink);
+	color: var(--white);
+}
+
+.effort-control:focus-visible {
+	position: relative;
+	z-index: 1;
+	outline: 3px solid var(--ink);
+	outline-offset: 3px;
+}
+
+.economy-note {
+	margin: 24px 0 0;
+	line-height: 1.75;
+	text-transform: none;
+}
+
+.effort-evidence {
+	padding: 30px;
+	background: var(--paper-deep);
+}
+
+.effort-evidence-head {
+	align-items: start;
+	padding-bottom: 34px;
+	border-bottom: 1px solid var(--line-strong);
+}
+
+.effort-evidence-head span {
+	display: block;
+	margin-bottom: 8px;
+	color: var(--muted);
+}
+
+.effort-evidence-head h3 {
+	margin: 0;
+	font-family: var(--serif);
+	font-size: 33px;
+	font-weight: 400;
+	letter-spacing: -0.04em;
+	line-height: 1;
+}
+
+.effort-evidence-head .evidence-status {
+	flex: 0 0 auto;
+	margin: 0;
+	padding: 6px 8px;
+	border: 1px solid var(--line-strong);
+	color: var(--ink);
+}
+
+.effort-stat-grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	border-bottom: 1px solid var(--line-strong);
+}
+
+.effort-stat-grid > div {
+	display: flex;
+	flex-direction: column;
+	min-height: 145px;
+	padding: 24px 18px 20px;
+	border-right: 1px solid var(--line);
+}
+
+.effort-stat-grid > div:first-child {
+	padding-left: 0;
+}
+
+.effort-stat-grid > div:last-child {
+	border-right: 0;
+}
+
+.effort-stat-grid span,
+.effort-stat-grid small {
+	color: var(--muted);
+}
+
+.effort-stat-grid strong {
+	margin: auto 0 7px;
+	font-family: var(--mono);
+	font-size: clamp(24px, 2.4vw, 34px);
+	font-weight: 500;
+	letter-spacing: -0.04em;
+}
+
+.effort-ladder {
+	padding-top: 24px;
+}
+
+.effort-ladder-head,
+.effort-ladder-row {
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
+}
+
+.effort-ladder-head {
+	padding: 0 12px 10px;
+	color: var(--muted);
+	font-size: 8px;
+}
+
+.effort-ladder-row {
+	padding: 13px 12px;
+	border-top: 1px solid var(--line);
+}
+
+.effort-ladder-row strong,
+.effort-ladder-row span {
+	font-size: 10px;
+	font-weight: 500;
+}
+
+.effort-ladder-row span {
+	display: flex;
+	justify-content: space-between;
+	gap: 10px;
+}
+
+.effort-ladder-row small {
+	color: var(--muted);
+	font-size: 8px;
+}
+
+.effort-ladder-row.is-selected {
+	background: var(--ink);
+	color: var(--white);
+}
+
+.effort-ladder-row.is-selected small {
+	color: #aab0a9;
+}
+
+.effort-source-note {
+	max-width: 800px;
+	margin: 20px 0 0 auto;
+	color: var(--muted);
+	line-height: 1.75;
+	text-align: right;
+}
+
 .field-notes {
 	padding: 126px 0 118px;
 }
@@ -1090,6 +1341,15 @@ td {
 		min-height: 390px;
 	}
 
+	.effort-board {
+		grid-template-columns: 1fr;
+	}
+
+	.effort-advisor {
+		border-right: 0;
+		border-bottom: 1px solid var(--line-strong);
+	}
+
 	.notes-grid {
 		grid-template-columns: repeat(2, 1fr);
 	}
@@ -1252,9 +1512,68 @@ td {
 		min-height: 410px;
 	}
 
+	.decision-desk,
 	.field-notes,
 	.method {
 		padding: 88px 0;
+	}
+
+	.effort-advisor,
+	.effort-evidence {
+		padding: 22px;
+	}
+
+	.effort-answer {
+		padding: 50px 0 42px;
+	}
+
+	.effort-answer strong {
+		font-size: 56px;
+	}
+
+	.effort-controls {
+		grid-template-columns: 1fr;
+	}
+
+	.effort-control {
+		flex-direction: row;
+		align-items: center;
+		min-height: 60px;
+	}
+
+	.effort-stat-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.effort-stat-grid > div,
+	.effort-stat-grid > div:first-child {
+		min-height: 100px;
+		padding: 18px 0;
+		border-right: 0;
+		border-bottom: 1px solid var(--line);
+	}
+
+	.effort-stat-grid > div:last-child {
+		border-bottom: 0;
+	}
+
+	.effort-ladder-head,
+	.effort-ladder-row {
+		grid-template-columns: 0.8fr 1fr 1fr;
+		gap: 8px;
+	}
+
+	.effort-ladder-row span {
+		display: block;
+	}
+
+	.effort-ladder-row small {
+		display: block;
+		margin-top: 3px;
+	}
+
+	.effort-source-note {
+		text-align: left;
 	}
 
 	.matrix-section {

--- a/prototypes/ai-model-frontier/styles.css
+++ b/prototypes/ai-model-frontier/styles.css
@@ -720,7 +720,8 @@ h1 em {
 	flex-direction: column;
 	padding: 30px;
 	border-right: 1px solid var(--line-strong);
-	background: var(--acid);
+	background: var(--advisor-accent, var(--acid));
+	transition: background-color 220ms ease;
 }
 
 .effort-advisor-topline,
@@ -734,6 +735,7 @@ h1 em {
 }
 
 .effort-advisor-topline > span,
+.effort-model-picker label,
 .effort-evidence-head span,
 .effort-answer-label,
 .economy-note,
@@ -749,14 +751,57 @@ h1 em {
 	text-transform: uppercase;
 }
 
+.effort-advisor-topline {
+	align-items: flex-start;
+}
+
+.effort-model-picker label {
+	display: block;
+	margin-bottom: 8px;
+}
+
+.effort-model-select-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.effort-model-monogram {
+	display: grid;
+	place-items: center;
+	flex: 0 0 auto;
+	width: 34px;
+	height: 34px;
+	border: 1px solid var(--line-strong);
+	border-radius: 50%;
+	font-family: var(--mono);
+	font-size: 9px;
+}
+
+.effort-model-picker select {
+	max-width: 220px;
+	padding: 7px 28px 7px 8px;
+	border: 1px solid var(--line-strong);
+	border-radius: 0;
+	background: transparent;
+	color: var(--ink);
+	font: 600 12px/1.2 var(--sans);
+	cursor: pointer;
+}
+
+.effort-model-picker select:focus-visible {
+	outline: 3px solid var(--ink);
+	outline-offset: 3px;
+}
+
 .recommendation-chip {
 	padding: 5px 8px;
 	background: var(--ink);
-	color: var(--acid);
+	color: var(--advisor-accent, var(--acid));
 }
 
 .effort-answer {
-	padding: 68px 0 56px;
+	padding: 58px 0 52px;
 }
 
 .effort-answer-label {
@@ -1521,6 +1566,24 @@ td {
 	.effort-advisor,
 	.effort-evidence {
 		padding: 22px;
+	}
+
+	.effort-advisor-topline {
+		flex-direction: column;
+	}
+
+	.effort-model-picker,
+	.effort-model-picker select {
+		width: 100%;
+		max-width: none;
+	}
+
+	.effort-model-select-row {
+		width: 100%;
+	}
+
+	.effort-model-select-row select {
+		flex: 1;
 	}
 
 	.effort-answer {


### PR DESCRIPTION
Adds a standalone, responsive Frontier Index page comparing Kimi K3, the full GPT-5.6 family, Claude Opus 5, Claude Fable 5, and Gemini 3.6 Flash across DeepSWE v1.1, FrontierCode 1.1 Main, and CursorBench 3.2. Includes interactive benchmark switching, model spotlights, cost context, evidence notes, responsive layouts, reduced-motion support, and direct links to the official leaderboards.\n\nValidation: node syntax check and html-validate 10.8.0.