### PR TITLE
Add haptics for correct answers

### DIFF
--- a/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
+++ b/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
@@ -62,6 +62,7 @@ import { getErrorMessage } from "~/features/learning-plans/utils";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 import { logDiagnosticError } from "~/lib/diagnostics";
 import { dismissToOrReplace, useBackIntent } from "~/lib/navigation";
+import { triggerSuccessHaptic } from "~/lib/safe-haptics";
 import { useDayovaTheme } from "~/lib/theme";
 import { useValidationAnalytics } from "~/lib/use-validation-analytics";
 import { cn } from "~/lib/utils";
@@ -1643,6 +1644,11 @@ export default function LearningSessionContentScreen() {
 				answerText: currentItem.kind === "written" ? writtenAnswer : undefined,
 				transcript: currentItem.kind === "voice" ? writtenAnswer : undefined,
 			});
+			if (attempt.rating === "correct") {
+				void triggerSuccessHaptic({
+					platform: process.env.EXPO_OS,
+				});
+			}
 			if (content?.session.phase === "rehearsal") {
 				resetItemState();
 				if (currentIndex < content.items.length - 1) {

--- a/src/lib/safe-haptics.test.ts
+++ b/src/lib/safe-haptics.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
-import { triggerSelectionHaptic } from "./safe-haptics";
+import * as Haptics from "expo-haptics";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { triggerSelectionHaptic, triggerSuccessHaptic } from "./safe-haptics";
+
+vi.mock("expo-haptics", () => ({
+	NotificationFeedbackType: { Success: "success" },
+	notificationAsync: vi.fn(),
+}));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
 
 describe("triggerSelectionHaptic", () => {
 	it("does not surface a missing native haptics module as an unhandled error", async () => {
@@ -29,5 +39,46 @@ describe("triggerSelectionHaptic", () => {
 		});
 
 		expect(selectionAsync).not.toHaveBeenCalled();
+	});
+});
+
+describe("triggerSuccessHaptic", () => {
+	it("triggers success feedback on iOS", async () => {
+		const notificationAsync = vi.mocked(Haptics.notificationAsync);
+		notificationAsync.mockResolvedValue(undefined);
+
+		await triggerSuccessHaptic({
+			platform: "ios",
+		});
+
+		expect(notificationAsync).toHaveBeenCalledOnce();
+		expect(notificationAsync).toHaveBeenCalledWith(
+			Haptics.NotificationFeedbackType.Success,
+		);
+	});
+
+	it("does not surface native haptics failures", async () => {
+		const notificationAsync = vi.mocked(Haptics.notificationAsync);
+		notificationAsync.mockRejectedValue(
+			new Error("Success haptics are unavailable"),
+		);
+
+		await expect(
+			triggerSuccessHaptic({
+				platform: "ios",
+			}),
+		).resolves.toBeUndefined();
+		expect(notificationAsync).toHaveBeenCalledOnce();
+	});
+
+	it("does not trigger success feedback on other platforms", async () => {
+		const notificationAsync = vi.mocked(Haptics.notificationAsync);
+		notificationAsync.mockResolvedValue(undefined);
+
+		await triggerSuccessHaptic({
+			platform: "android",
+		});
+
+		expect(notificationAsync).not.toHaveBeenCalled();
 	});
 });

--- a/src/lib/safe-haptics.ts
+++ b/src/lib/safe-haptics.ts
@@ -1,16 +1,34 @@
+import * as Haptics from "expo-haptics";
+
 type SelectionHapticOptions = {
 	platform: string | undefined;
 	selectionAsync: () => Promise<void>;
 };
 
+type SuccessHapticOptions = {
+	platform: string | undefined;
+};
+
+const triggerIosHaptic = async (
+	platform: string | undefined,
+	trigger: () => Promise<void>,
+) => {
+	if (platform !== "ios") return;
+	try {
+		await trigger();
+	} catch {
+		// Haptics are an enhancement and must never interrupt app behavior.
+	}
+};
+
 export const triggerSelectionHaptic = async ({
 	platform,
 	selectionAsync,
-}: SelectionHapticOptions) => {
-	if (platform !== "ios") return;
-	try {
-		await selectionAsync();
-	} catch {
-		// Haptics are an enhancement and must never interrupt navigation.
-	}
-};
+}: SelectionHapticOptions) => triggerIosHaptic(platform, selectionAsync);
+
+export const triggerSuccessHaptic = async ({
+	platform,
+}: SuccessHapticOptions) =>
+	triggerIosHaptic(platform, () =>
+		Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success),
+	);


### PR DESCRIPTION
## What changed

- trigger iOS success haptics after Convex grades a learning-session answer as correct
- keep haptic failures isolated from answer submission and navigation
- cover success feedback, unsupported-platform behavior, and native failures with unit tests

## Why

Correct answers should receive immediate tactile confirmation without firing before the authoritative server rating is available.

## Validation

- `pnpm exec vitest run src/lib/safe-haptics.test.ts` (5 tests passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec biome check` on the three changed files
- `git diff --check`

Targeted ESLint also surfaced two existing hook violations at session screen lines 1110 and 1145; those lines are unchanged by this PR.