### PR TITLE
Fix timetable notification ID mismatch

### DIFF
--- a/convex/dayEntries.ts
+++ b/convex/dayEntries.ts
@@ -45,6 +45,7 @@ type OptionalEntryFields = {
 
 type PublicDayEntry = OptionalEntryFields & {
 	id: Id<"dayEntries"> | Id<"learningPlanSessions"> | Id<"timetableLessons">;
+	relatedDayEntryId?: Id<"dayEntries">;
 	source?: "timetable";
 	title: string;
 };
@@ -90,6 +91,7 @@ const optionalEntryFields = (
 
 const publicEntry = (entry: Doc<"dayEntries">): PublicDayEntry => ({
 	id: entry._id,
+	relatedDayEntryId: entry._id,
 	title: entry.title,
 	...optionalEntryFields({
 		...entry,

--- a/convex/notifications.test.ts
+++ b/convex/notifications.test.ts
@@ -2,6 +2,10 @@
 
 import { convexTest } from "convex-test";
 import { expect, test } from "vitest";
+import {
+	buildLocalNotificationPlan,
+	buildLocalNotificationRegistrationInput,
+} from "../src/lib/notification-planner";
 import { api } from "./_generated/api";
 import schema from "./schema";
 
@@ -10,6 +14,47 @@ const modules = import.meta.glob("./**/*.ts");
 const user = {
 	tokenIdentifier: "test:user",
 };
+
+test("local notification registration accepts plans containing timetable lessons", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	const timetableId = await t.mutation(api.timetables.createDraft, {});
+	await t.mutation(api.timetables.saveAndActivate, {
+		timetableId,
+		lessons: [
+			{
+				dayOfWeek: 1,
+				subject: "Mathematik",
+				startTime: "08:00",
+				endTime: "08:45",
+			},
+		],
+	});
+	const entriesByDay = await t.query(api.dayEntries.listByDayKeys, {
+		dayKeys: ["2026-07-27"],
+	});
+	const plan = buildLocalNotificationPlan({
+		now: new Date(2026, 6, 27, 7, 0),
+		preferences: {
+			systemNotificationsEnabled: true,
+			dailyBriefingEnabled: true,
+			dailyBriefingTime: "07:30",
+			beforeExamEnabled: true,
+			beforeLearningTimeEnabled: true,
+			beforeHomeworkWorkEnabled: true,
+			beforeHomeworkDueEnabled: true,
+			reminderOffsetMinutes: 15,
+			forgottenEventEnabled: true,
+		},
+		entriesByDay,
+	});
+
+	await expect(
+		t.mutation(
+			api.notifications.registerLocalNotificationPlan,
+			buildLocalNotificationRegistrationInput(plan),
+		),
+	).resolves.toHaveLength(1);
+});
 
 test("notification preferences default to the MVP reminder settings", async () => {
 	const t = convexTest(schema, modules).withIdentity(user);

--- a/src/components/notification-sync.tsx
+++ b/src/components/notification-sync.tsx
@@ -19,6 +19,7 @@ import {
 } from "~/lib/notification-permissions";
 import {
 	buildLocalNotificationPlan,
+	buildLocalNotificationRegistrationInput,
 	type NotificationPlanningPreferences,
 } from "~/lib/notification-planner";
 import type { DayEntry } from "~/types/dayEntries";
@@ -213,22 +214,9 @@ export function NotificationSync() {
 				preferences,
 				entriesByDay,
 			});
-			const registrations = await registerLocalNotificationPlan({
-				notifications: plan.map((notification) => ({
-					eventKey: notification.key,
-					category: notification.category,
-					type: notification.type,
-					title: notification.title,
-					body: notification.body,
-					...(notification.relatedEntryId
-						? {
-								relatedDayEntryId:
-									notification.relatedEntryId as Id<"dayEntries">,
-							}
-						: {}),
-					scheduledFor: notification.triggerAt.toISOString(),
-				})),
-			});
+			const registrations = await registerLocalNotificationPlan(
+				buildLocalNotificationRegistrationInput(plan),
+			);
 			const registrationBySchedule = new Map(
 				registrations.map((registration) => [
 					`${registration.eventKey}\0${registration.scheduledFor}`,

--- a/src/lib/local-notification-scheduler.test.ts
+++ b/src/lib/local-notification-scheduler.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from "vitest";
+import type { Id } from "#convex/_generated/dataModel";
 import {
 	type RegisteredLocalNotification,
 	syncPlannedLocalNotifications,
@@ -30,7 +31,7 @@ test("syncPlannedLocalNotifications replaces Dayova-owned scheduled notification
 			title: "Hausaufgabe",
 			body: "Deine Mathe Hausaufgabe startet in 15 Minuten.",
 			triggerAt: new Date(2026, 5, 16, 15, 45),
-			relatedEntryId: "entry-1",
+			relatedDayEntryId: "entry-1" as Id<"dayEntries">,
 			registrationId: "registration-1",
 		},
 	];

--- a/src/lib/notification-planner.test.ts
+++ b/src/lib/notification-planner.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "vitest";
+import type { Id } from "#convex/_generated/dataModel";
+import type { DayEntry } from "~/types/dayEntries";
 import {
 	buildLocalNotificationPlan,
 	type NotificationPlanningPreferences,
@@ -23,7 +25,7 @@ test("local notification planner creates briefing, before-event, and forgotten r
 		entriesByDay: {
 			"2026-06-16": [
 				{
-					id: "entry-1",
+					relatedDayEntryId: "entry-1" as Id<"dayEntries">,
 					title: "Mathe Hausaufgabe",
 					time: "16:00",
 					kind: "Hausaufgabe",
@@ -31,7 +33,6 @@ test("local notification planner creates briefing, before-event, and forgotten r
 					completed: false,
 				},
 				{
-					id: "entry-2",
 					title: "Deutsch Hausaufgabe",
 					time: "17:00",
 					kind: "Hausaufgabe",
@@ -62,5 +63,31 @@ test("local notification planner creates briefing, before-event, and forgotten r
 		"Heute steht 1 Eintrag an: Mathe Hausaufgabe um 16:00.",
 		"Deine Mathe Hausaufgabe startet in 15 Minuten.",
 		"Du kannst deine Mathe Hausaufgabe noch als erledigt markieren.",
+	]);
+});
+
+test("timetable lessons appear in the briefing without creating individual reminders", () => {
+	const timetableLesson = {
+		id: "timetable-lesson-1" as Id<"timetableLessons">,
+		source: "timetable",
+		title: "Mathematik",
+		time: "08:00",
+		kind: "Unterricht",
+		durationMinutes: 45,
+	} satisfies DayEntry;
+	const plan = buildLocalNotificationPlan({
+		now: new Date(2026, 6, 27, 7, 0),
+		preferences: defaultPreferences,
+		entriesByDay: {
+			"2026-07-27": [timetableLesson],
+		},
+	});
+
+	expect(plan).toEqual([
+		expect.objectContaining({
+			key: "briefing:2026-07-27:07:30",
+			type: "dailyBriefing",
+			body: "Heute steht 1 Eintrag an: Mathematik um 08:00.",
+		}),
 	]);
 });

--- a/src/lib/notification-planner.ts
+++ b/src/lib/notification-planner.ts
@@ -1,3 +1,4 @@
+import type { Id } from "#convex/_generated/dataModel";
 import { parseDayKey } from "./day-key";
 
 export type NotificationPlanningPreferences = {
@@ -13,7 +14,7 @@ export type NotificationPlanningPreferences = {
 };
 
 export type NotificationPlanningEntry = {
-	id: string;
+	relatedDayEntryId?: Id<"dayEntries">;
 	title?: unknown;
 	time?: string;
 	kind?: string;
@@ -30,7 +31,7 @@ export type PlannedLocalNotification = {
 	title: string;
 	body: string;
 	triggerAt: Date;
-	relatedEntryId?: string;
+	relatedDayEntryId?: Id<"dayEntries">;
 };
 
 const TIME_PATTERN = /^(\d{1,2}):(\d{2})$/;
@@ -150,6 +151,8 @@ export const buildLocalNotificationPlan = ({
 
 		for (const entry of entries) {
 			if (entry.completed === true) continue;
+			const relatedDayEntryId = entry.relatedDayEntryId;
+			if (!relatedDayEntryId) continue;
 			const startMinutes = isExamEntry(entry)
 				? null
 				: parseTimeToMinutes(entry.time);
@@ -163,13 +166,13 @@ export const buildLocalNotificationPlan = ({
 				if (beforeDate && beforeDate.getTime() > now.getTime()) {
 					const eventTitle = getEventTitle(entry);
 					plan.push({
-						key: `before:${entry.id}`,
+						key: `before:${relatedDayEntryId}`,
 						type: "beforeEvent",
 						category: getCategory(entry),
 						title: eventTitle,
 						body: `Deine ${getEntryTitle(entry)} startet in ${preferences.reminderOffsetMinutes} Minuten.`,
 						triggerAt: beforeDate,
-						relatedEntryId: entry.id,
+						relatedDayEntryId,
 					});
 				}
 			}
@@ -186,13 +189,13 @@ export const buildLocalNotificationPlan = ({
 				if (forgottenDate && forgottenDate.getTime() > now.getTime()) {
 					const eventTitle = getEventTitle(entry);
 					plan.push({
-						key: `forgotten:${entry.id}`,
+						key: `forgotten:${relatedDayEntryId}`,
 						type: "forgottenEvent",
 						category: getCategory(entry),
 						title: `${eventTitle} nicht vergessen`,
 						body: `Du kannst deine ${getEntryTitle(entry)} noch als erledigt markieren.`,
 						triggerAt: forgottenDate,
-						relatedEntryId: entry.id,
+						relatedDayEntryId,
 					});
 				}
 			}
@@ -205,3 +208,19 @@ export const buildLocalNotificationPlan = ({
 			left.key.localeCompare(right.key),
 	);
 };
+
+export const buildLocalNotificationRegistrationInput = (
+	plan: PlannedLocalNotification[],
+) => ({
+	notifications: plan.map((notification) => ({
+		eventKey: notification.key,
+		category: notification.category,
+		type: notification.type,
+		title: notification.title,
+		body: notification.body,
+		...(notification.relatedDayEntryId
+			? { relatedDayEntryId: notification.relatedDayEntryId }
+			: {}),
+		scheduledFor: notification.triggerAt.toISOString(),
+	})),
+});

--- a/src/types/dayEntries.ts
+++ b/src/types/dayEntries.ts
@@ -6,6 +6,7 @@ import type {
 
 export type DayEntry = {
 	id: Id<"dayEntries"> | Id<"learningPlanSessions"> | Id<"timetableLessons">;
+	relatedDayEntryId?: Id<"dayEntries">;
 	source?: "timetable";
 	title?: unknown;
 	time?: string;


### PR DESCRIPTION
## What changed

- expose a typed `relatedDayEntryId` only for real `dayEntries`
- keep timetable occurrences in daily briefings while excluding them from individual before/forgotten reminders
- centralize local notification registration payload construction and remove the unsafe ID assertion
- add planner and Convex regression coverage for active timetable lessons

## Root cause

The agenda combines `dayEntries`, learning sessions, and derived timetable occurrences. Notification planning copied the generic entry ID and the client asserted it was always `Id<"dayEntries">`. When the first planned reminder belonged to a timetable lesson, Convex correctly rejected its `Id<"timetableLessons">` at the `relatedDayEntryId` validator.

## User impact

Opening or foregrounding the app with an active timetable no longer produces repeated unhandled `registerLocalNotificationPlan` errors. Timetable lessons remain visible in the daily briefing.

## Validation

- 43 relevant tests passed across day entries, timetables, notifications, agenda classification, planning, and local scheduling
- `pnpm exec tsc --noEmit`
- Biome and ESLint on all seven changed files
- `git diff --check`