### PR TITLE
Remove theory confidence step

### DIFF
--- a/convex/dayEntries.test.ts
+++ b/convex/dayEntries.test.ts
@@ -307,3 +307,21 @@ test("manual entries can be marked completed and uncompleted", async () => {
 	});
 	expect(entries["2026-06-16"]?.[0]?.completed).toBe(false);
 });
+
+test("legacy exam subject metadata remains schema-compatible", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+
+	const entryId = await t.run(async (ctx) =>
+		ctx.db.insert("dayEntries", {
+			ownerTokenIdentifier: user.tokenIdentifier,
+			dayKey: "2026-08-07",
+			title: "Englisch Klassenarbeit",
+			subject: "Englisch",
+			kind: "Leistungskontrolle",
+		}),
+	);
+
+	await expect(
+		t.run(async (ctx) => ctx.db.get("dayEntries", entryId)),
+	).resolves.toMatchObject({ subject: "Englisch" });
+});

--- a/convex/learningSessionContent.test.ts
+++ b/convex/learningSessionContent.test.ts
@@ -283,7 +283,6 @@ test("persists deferred and completed theory validation states", async () => {
 	}
 	await t.mutation(api.learningSessionContent.finishSessionContent, {
 		sessionId,
-		knowledgeValidationConfidence: "somewhatSure",
 	});
 
 	const completed = await t.query(
@@ -292,8 +291,8 @@ test("persists deferred and completed theory validation states", async () => {
 	);
 	expect(completed?.session).toMatchObject({
 		knowledgeValidationStatus: "completed",
-		knowledgeValidationConfidence: "somewhatSure",
 	});
+	expect(completed?.session.knowledgeValidationConfidence).toBeUndefined();
 });
 
 test("continue learning appends a fresh timed block", async () => {

--- a/convex/learningSessionContent.ts
+++ b/convex/learningSessionContent.ts
@@ -1207,7 +1207,6 @@ export const finishSessionContent = mutation({
 		if (
 			session.phase === "theory" &&
 			session.compositionVariant === "split" &&
-			args.knowledgeValidationConfidence &&
 			hasCompletedKnowledgeValidation
 		) {
 			await ctx.db.patch("learningPlanSessions", session._id, {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -289,6 +289,8 @@ export default defineSchema({
 		ownerTokenIdentifier: v.string(),
 		dayKey: v.string(),
 		title: v.string(),
+		// Keep entries written by adaptive exam-planning builds schema-compatible.
+		subject: v.optional(v.string()),
 		time: v.optional(v.string()),
 		kind: v.optional(v.string()),
 		notes: v.optional(v.string()),
@@ -437,6 +439,7 @@ export default defineSchema({
 		ownerTokenIdentifier: v.string(),
 		learningPlanId: v.id("learningPlans"),
 		sessionId: v.optional(v.id("learningPlanSessions")),
+		reservationId: v.optional(v.string()),
 		operation: v.union(
 			v.literal("diagnostic"),
 			v.literal("plan"),
@@ -449,13 +452,53 @@ export default defineSchema({
 		cachedInputTokens: v.number(),
 		outputTokens: v.number(),
 		estimatedCostUsdMicros: v.number(),
+		budgetCostUsdMicros: v.optional(v.number()),
+		accountingKind: v.optional(
+			v.union(v.literal("measured"), v.literal("projected_failure")),
+		),
 		createdAt: v.number(),
 	})
 		.index("by_learningPlanId", ["learningPlanId"])
+		.index("by_ownerTokenIdentifier_and_reservationId", [
+			"ownerTokenIdentifier",
+			"reservationId",
+		])
 		.index("by_ownerTokenIdentifier_and_createdAt", [
 			"ownerTokenIdentifier",
 			"createdAt",
 		]),
+	learningPlanAiBudgetReservations: defineTable({
+		ownerTokenIdentifier: v.string(),
+		learningPlanId: v.id("learningPlans"),
+		sessionId: v.optional(v.id("learningPlanSessions")),
+		reservationId: v.string(),
+		operation: v.union(
+			v.literal("diagnostic"),
+			v.literal("plan"),
+			v.literal("session_theory"),
+			v.literal("session_practice"),
+			v.literal("session_praxis"),
+		),
+		modelId: v.string(),
+		projectedCostUsdMicros: v.number(),
+		status: v.union(
+			v.literal("active"),
+			v.literal("settled"),
+			v.literal("forfeited"),
+		),
+		monthStart: v.number(),
+		createdAt: v.number(),
+		updatedAt: v.number(),
+	})
+		.index("by_ownerTokenIdentifier_and_reservationId", [
+			"ownerTokenIdentifier",
+			"reservationId",
+		])
+		.index("by_ownerTokenIdentifier_and_monthStart", [
+			"ownerTokenIdentifier",
+			"monthStart",
+		])
+		.index("by_learningPlanId_and_createdAt", ["learningPlanId", "createdAt"]),
 	learningPlanSessions: defineTable({
 		ownerTokenIdentifier: v.string(),
 		learningPlanId: v.id("learningPlans"),

--- a/convex/schemaCompatibility.test.ts
+++ b/convex/schemaCompatibility.test.ts
@@ -1,0 +1,71 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+const user = {
+	tokenIdentifier: "test:schema-compatibility",
+};
+
+test("AI budget accounting data from prior deployments remains schema-compatible", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	const examDayEntryId = await t.mutation(api.dayEntries.create, {
+		dayKey: "2026-09-05",
+		title: "Mathe Klausur",
+		kind: "Leistungskontrolle",
+		plannedDateLabel: "5. September 2026",
+		durationMinutes: 90,
+		examTypeLabel: "Klausur",
+	});
+	const learningPlanId = await t.mutation(api.learningPlans.start, {
+		examDayEntryId,
+		subject: "Mathe",
+		examTypeLabel: "Klausur",
+		examDateKey: "2026-09-05",
+		examDateLabel: "5. September 2026",
+		durationMinutes: 90,
+		topicDescription: "Lineare Funktionen",
+	});
+
+	await expect(
+		t.run(async (ctx) => {
+			const usageId = await ctx.db.insert("learningPlanAiUsage", {
+				ownerTokenIdentifier: user.tokenIdentifier,
+				learningPlanId,
+				reservationId: "reservation-1",
+				operation: "session_theory",
+				modelId: "gemini-3-flash-preview",
+				inputTokens: 5_058,
+				cachedInputTokens: 0,
+				outputTokens: 1_057,
+				estimatedCostUsdMicros: 5_700,
+				budgetCostUsdMicros: 5_700,
+				accountingKind: "measured",
+				createdAt: Date.now(),
+			});
+			const reservationDocumentId = await ctx.db.insert(
+				"learningPlanAiBudgetReservations",
+				{
+					ownerTokenIdentifier: user.tokenIdentifier,
+					learningPlanId,
+					reservationId: "reservation-1",
+					operation: "session_theory",
+					modelId: "gemini-3-flash-preview",
+					projectedCostUsdMicros: 5_700,
+					status: "settled",
+					monthStart: Date.UTC(2026, 8, 1),
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+				},
+			);
+			return { usageId, reservationDocumentId };
+		}),
+	).resolves.toMatchObject({
+		usageId: expect.any(String),
+		reservationDocumentId: expect.any(String),
+	});
+});

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -8,6 +8,9 @@
 		"allowJs": true,
 		"strict": true,
 		"moduleResolution": "Bundler",
+		"paths": {
+			"#convex/*": ["./*"]
+		},
 		"jsx": "react-jsx",
 		"skipLibCheck": true,
 		"allowSyntheticDefaultImports": true,

--- a/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
+++ b/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
@@ -414,9 +414,6 @@ function CompletionView({
 	correctCount,
 	attemptCount,
 	isTheoryValidationAvailable,
-	isTheoryValidationComplete,
-	knowledgeValidationConfidence,
-	onKnowledgeValidationConfidenceChange,
 	onContinueLearning,
 	onDeferValidation,
 	onPrimary,
@@ -427,11 +424,6 @@ function CompletionView({
 	correctCount: number;
 	attemptCount: number;
 	isTheoryValidationAvailable: boolean;
-	isTheoryValidationComplete: boolean;
-	knowledgeValidationConfidence: "unsure" | "somewhatSure" | "sure" | null;
-	onKnowledgeValidationConfidenceChange: (
-		value: "unsure" | "somewhatSure" | "sure",
-	) => void;
 	onContinueLearning: () => void;
 	onDeferValidation: () => void;
 	onPrimary: () => void;
@@ -449,85 +441,6 @@ function CompletionView({
 				onAnalysis={onPrimary}
 				isBusy={isBusy}
 			/>
-		);
-	}
-
-	if (isTheoryValidationComplete) {
-		const confidenceOptions = [
-			{ value: "unsure" as const, label: "Noch unsicher" },
-			{ value: "somewhatSure" as const, label: "Teilweise sicher" },
-			{ value: "sure" as const, label: "Sicher" },
-		];
-
-		return (
-			<Animated.View
-				entering={FadeIn.duration(280)}
-				className="flex-1 justify-between py-8"
-			>
-				<View className="flex-1 justify-center gap-7">
-					<View className="items-center gap-3">
-						<View className="h-20 w-20 items-center justify-center rounded-info bg-system-subtle">
-							<Check
-								size={36}
-								color={DAYOVA_DESIGN_SYSTEM.colors.primaryStrong}
-								strokeWidth={2.4}
-							/>
-						</View>
-						<Text
-							accessibilityRole="header"
-							className="text-center font-poppins font-semibold text-heading-2 text-text"
-						>
-							Wissen kurz geprüft
-						</Text>
-						<Text className="max-w-[320px] text-center font-poppins text-body-3 text-secondary-text">
-							Deine Antworten aktualisieren jetzt deinen Wissensstand. Wie
-							sicher fühlst du dich bei diesem Thema?
-						</Text>
-					</View>
-					<View className="gap-3">
-						{confidenceOptions.map((option) => {
-							const selected = knowledgeValidationConfidence === option.value;
-							return (
-								<TouchableOpacity
-									key={option.value}
-									accessibilityRole="radio"
-									accessibilityState={{ selected }}
-									activeOpacity={0.8}
-									className={cn(
-										"min-h-14 justify-center rounded-info border px-5",
-										selected
-											? "border-primary bg-system-subtle"
-											: "border-border bg-card",
-									)}
-									onPress={() =>
-										onKnowledgeValidationConfidenceChange(option.value)
-									}
-								>
-									<Text
-										className={cn(
-											"font-poppins font-semibold text-body-3",
-											selected ? "text-primary-strong" : "text-text",
-										)}
-									>
-										{option.label}
-									</Text>
-								</TouchableOpacity>
-							);
-						})}
-					</View>
-				</View>
-				<Button
-					className="w-full"
-					disabled={isBusy || knowledgeValidationConfidence === null}
-					onPress={onPrimary}
-				>
-					{isBusy ? (
-						<ActivityIndicator color={DAYOVA_DESIGN_SYSTEM.colors.light1} />
-					) : (
-						<Text>Auswertung ansehen</Text>
-					)}
-				</Button>
-			</Animated.View>
 		);
 	}
 
@@ -1049,8 +962,6 @@ export default function LearningSessionContentScreen() {
 	const [completionPhase, setCompletionPhase] = useState<
 		LearningSessionContentSnapshot["session"]["phase"] | null
 	>(null);
-	const [knowledgeValidationConfidence, setKnowledgeValidationConfidence] =
-		useState<"unsure" | "somewhatSure" | "sure" | null>(null);
 	const [repeatingItemId, setRepeatingItemId] = useState<string | null>(null);
 	const [retryStartedAt, setRetryStartedAt] = useState<number | null>(null);
 	const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
@@ -1106,13 +1017,17 @@ export default function LearningSessionContentScreen() {
 		user && isConvexAuthenticated && sessionId ? { sessionId } : "skip",
 	) ?? null) as LearningSessionContentSnapshot | null;
 
-	const sessionItems = content
-		? getLearningSessionItems(
-				content.items,
-				content.session.phase,
-				content.session.compositionVariant,
-			)
-		: [];
+	const sessionItems = useMemo(
+		() =>
+			content
+				? getLearningSessionItems(
+						content.items,
+						content.session.phase,
+						content.session.compositionVariant,
+					)
+				: [],
+		[content],
+	);
 	const theoryItems = sessionItems.filter((item) => item.kind === "learnCard");
 	const validationItems = sessionItems.filter(
 		(item) => item.phase === "practice" && item.kind !== "learnCard",
@@ -1141,8 +1056,10 @@ export default function LearningSessionContentScreen() {
 		);
 		if (firstValidationIndex < 0) return;
 		didResumeDeferredValidationRef.current = true;
-		setCurrentIndex(firstValidationIndex);
-		setCompletionPhase(null);
+		queueMicrotask(() => {
+			setCurrentIndex(firstValidationIndex);
+			setCompletionPhase(null);
+		});
 	}, [content, isTheoryValidationSession, sessionItems]);
 	const persistedAttempt = useMemo(() => {
 		if (!currentItem || !content) return null;
@@ -1395,12 +1312,7 @@ export default function LearningSessionContentScreen() {
 		setIsBusy(true);
 		setErrorMessage(null);
 		try {
-			await finishSessionContent({
-				sessionId,
-				...(isTheoryValidationSession && knowledgeValidationConfidence
-					? { knowledgeValidationConfidence }
-					: {}),
-			});
+			await finishSessionContent({ sessionId });
 			setCompletionPhase(null);
 			setShowAnalysis(true);
 		} catch (error) {
@@ -1675,6 +1587,10 @@ export default function LearningSessionContentScreen() {
 			setCurrentIndex((value) => value + 1);
 			return;
 		}
+		if (isTheoryValidationSession) {
+			await finishAndShowAnalysis();
+			return;
+		}
 		setCompletionPhase(
 			getLearningSessionCompletionPhase(
 				content.session.phase,
@@ -1900,13 +1816,6 @@ export default function LearningSessionContentScreen() {
 						attemptCount={currentRunAttempts.length}
 						isTheoryValidationAvailable={
 							isTheoryValidationSession && completionPhase === "theory"
-						}
-						isTheoryValidationComplete={
-							isTheoryValidationSession && completionPhase === "practice"
-						}
-						knowledgeValidationConfidence={knowledgeValidationConfidence}
-						onKnowledgeValidationConfidenceChange={
-							setKnowledgeValidationConfidence
 						}
 						onContinueLearning={() => void startContinueLearning()}
 						onDeferValidation={() => void deferValidationAndLeave()}


### PR DESCRIPTION
## Summary

- remove the “Wissen kurz geprüft” confidence screen from theory validation
- open the existing analysis directly after the final theory-validation answer
- keep practical-session completion and feedback unchanged
- mark completed theory validation without fabricating a confidence value
- preserve development data written by adaptive-planning and AI-budget branches through additive Convex schema compatibility
- make Convex’s TypeScript config resolve the shared `#convex/*` generated-type imports

## Root cause of the runtime error

The release client called `learningPlans:getSchedulingAvailability`, but the shared development deployment had not received that query. Deployment was blocked by forward-compatible records from other branches and then by Convex’s separate TypeScript config lacking the `#convex/*` path mapping.

## Impact

The scheduling-availability query is deployed and callable again, existing development data remains intact, and Convex development deployment succeeds with typechecking enabled.

## Validation

- `pnpm test` — 88 Vitest files / 529 tests and 28 Jest suites / 79 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc -p convex/tsconfig.json --noEmit`
- `pnpm exec convex dev --once --typecheck enable`
- direct `learningPlans:getSchedulingAvailability` query against the configured development deployment, repeated successfully