### PR TITLE
Fix Convex shared type resolution

### DIFF
--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -8,6 +8,9 @@
 		"allowJs": true,
 		"strict": true,
 		"moduleResolution": "Bundler",
+		"paths": {
+			"#convex/*": ["./*"]
+		},
 		"jsx": "react-jsx",
 		"skipLibCheck": true,
 		"allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Summary
- add the `#convex/*` path mapping to Convex's standalone TypeScript configuration
- allow shared app modules imported by Convex tests to resolve generated Convex types

## Validation
- `pnpm exec tsc -p convex/tsconfig.json --noEmit --pretty false`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run convex/notifications.test.ts src/lib/notification-planner.test.ts --passWithNoTests` (17 tests passed)

No AI-budget code is included.