### PR TITLE
Speed up sessions and unify the theory flow

### DIFF
--- a/convex/adaptiveLearningPlan.ts
+++ b/convex/adaptiveLearningPlan.ts
@@ -13,6 +13,10 @@ import { normalizeLearningTopics } from "./learningTopicMap";
 import { getScheduleConflictMessage } from "./scheduleConflicts";
 
 const MAX_LEARNING_TIMES = 50;
+const PAIRED_THEORY_QUESTION_SUFFIX = ":paired-practice";
+
+const isPairedTheoryQuestionItem = (item: Doc<"learningSessionContentItems">) =>
+	item.coverageKey?.endsWith(PAIRED_THEORY_QUESTION_SUFFIX) === true;
 
 type RollingPlanCalendar = {
 	clearSession: (
@@ -93,7 +97,14 @@ const loadAdaptiveEvidence = async (
 			seenItemIds.add(attempt.itemId);
 			const item = itemById.get(attempt.itemId);
 			const topicId = item?.topicId ?? session.targetTopicIds?.[0];
-			if (!item || !topicId || item.kind === "learnCard") continue;
+			if (
+				!item ||
+				!topicId ||
+				item.kind === "learnCard" ||
+				isPairedTheoryQuestionItem(item)
+			) {
+				continue;
+			}
 			evidence.push({
 				topicId,
 				dimension: getAdaptiveEvidenceDimension(item),

--- a/convex/learningPlanAi.ts
+++ b/convex/learningPlanAi.ts
@@ -630,6 +630,7 @@ type LearningSessionContentAiContext = {
 	priorCoverageKeys: string[];
 	existingItemCount: number;
 	hasTheoryKnowledgeCheck: boolean;
+	hasCompleteTheoryPracticePairs: boolean;
 	needsLegacyContentReplacement: boolean;
 	accessKey: string;
 };
@@ -2668,7 +2669,8 @@ export const ensureSessionContent = action({
 		) {
 			if (
 				!context.session.completed &&
-				!context.hasTheoryKnowledgeCheck &&
+				(!context.hasTheoryKnowledgeCheck ||
+					!context.hasCompleteTheoryPracticePairs) &&
 				isLearningSessionCompositionEligible({
 					phase: context.session.phase,
 					durationMinutes: context.session.durationMinutes,

--- a/convex/learningSessionContent.test.ts
+++ b/convex/learningSessionContent.test.ts
@@ -237,7 +237,7 @@ test("opening an existing short theory session backfills its pre-check", async (
 	).toContain(before?.items[0]?.front);
 });
 
-test("split fallback stores one practical check before theory", async () => {
+test("split fallback pairs every theory page with a practical page", async () => {
 	const { t, sessionId } = await createGeneratedPlanWithSession(
 		"theory",
 		"split",
@@ -251,29 +251,30 @@ test("split fallback stores one practical check before theory", async () => {
 	});
 
 	expect(content?.session.compositionVariant).toBe("split");
-	expect(content?.items).toHaveLength(9);
-	expect(
-		content?.items.slice(0, 1).every((item) => item.phase === "practice"),
-	).toBe(true);
-	expect(content?.items.slice(1).every((item) => item.phase === "theory")).toBe(
-		true,
-	);
-	expect(
-		content?.items.slice(0, 1).every((item) => item.kind !== "learnCard"),
-	).toBe(true);
-	expect(
-		content?.items.slice(1).every((item) => item.kind === "learnCard"),
-	).toBe(true);
+	const theoryItems =
+		content?.items.filter((item) => item.kind === "learnCard") ?? [];
+	const pairedPracticeItems =
+		content?.items.filter((item) =>
+			item.coverageKey.endsWith(":paired-practice"),
+		) ?? [];
+	expect(theoryItems).toHaveLength(8);
+	expect(pairedPracticeItems).toHaveLength(theoryItems.length);
+	for (const theoryItem of theoryItems) {
+		expect(pairedPracticeItems).toContainEqual(
+			expect.objectContaining({
+				phase: "practice",
+				kind: "written",
+				topicId: theoryItem.topicId,
+				coverageKey: `${theoryItem.coverageKey}:paired-practice`,
+			}),
+		);
+	}
 	expect(
 		content?.items.reduce((total, item) => total + item.estimatedSeconds, 0),
 	).toBe(30 * 60);
-	expect(new Set(content?.items.map((item) => item.coverageKey)).size).toBe(9);
-	expect(content?.items.map((item) => item.learningBlockIndex)).toEqual([
-		0,
-		...Array.from({ length: 3 }, () => 1),
-		...Array.from({ length: 3 }, () => 2),
-		...Array.from({ length: 2 }, () => 3),
-	]);
+	expect(new Set(content?.items.map((item) => item.coverageKey)).size).toBe(
+		content?.items.length,
+	);
 });
 
 test("persists deferred and completed theory validation states", async () => {
@@ -305,7 +306,10 @@ test("persists deferred and completed theory validation states", async () => {
 
 	const validationItems =
 		deferred?.items.filter((item) => item.phase === "practice") ?? [];
-	expect(validationItems).toHaveLength(1);
+	expect(validationItems).toHaveLength(
+		(deferred?.items.filter((item) => item.kind === "learnCard").length ?? 0) +
+			1,
+	);
 	for (const item of validationItems) {
 		await t.mutation(api.learningSessionContent.submitAnswer, {
 			itemId: item.id,
@@ -344,6 +348,7 @@ test("continue learning appends a fresh timed block", async () => {
 	});
 	const existingCoverageKeys =
 		before?.items.map((item) => item.coverageKey) ?? [];
+	const existingItemCount = before?.items.length ?? 0;
 
 	const extension = await t.mutation(
 		api.learningSessionContent.extendSessionContent,
@@ -355,13 +360,13 @@ test("continue learning appends a fresh timed block", async () => {
 	const newItems = after?.items.slice(extension.firstNewItemIndex) ?? [];
 
 	expect(extension).toMatchObject({
-		firstNewItemIndex: 9,
+		firstNewItemIndex: existingItemCount,
 		addedItemCount: 3,
 		durationMinutes: 10,
 	});
-	expect(after?.items.slice(0, 9).map((item) => item.id)).toEqual(
-		before?.items.map((item) => item.id),
-	);
+	expect(
+		after?.items.slice(0, existingItemCount).map((item) => item.id),
+	).toEqual(before?.items.map((item) => item.id));
 	expect(newItems.every((item) => item.learningBlockIndex === 4)).toBe(true);
 	expect(
 		newItems.some((item) => existingCoverageKeys.includes(item.coverageKey)),
@@ -381,7 +386,7 @@ test("continue learning appends a fresh timed block", async () => {
 	);
 
 	expect(secondExtension).toMatchObject({
-		firstNewItemIndex: 12,
+		firstNewItemIndex: existingItemCount + 3,
 		addedItemCount: 3,
 	});
 	expect(duplicatePrompts).toEqual([]);
@@ -450,7 +455,12 @@ test("AI theory content gains a practical segment for split sessions", async () 
 
 	expect(content?.items[0]?.phase).toBe("theory");
 	expect(
-		content?.items.filter((item) => item.phase === "practice"),
+		content?.items.filter((item) =>
+			item.coverageKey.endsWith(":paired-practice"),
+		),
+	).toHaveLength(1);
+	expect(
+		content?.items.filter((item) => item.coverageKey.includes(":validation:")),
 	).toHaveLength(1);
 });
 

--- a/convex/learningSessionContent.test.ts
+++ b/convex/learningSessionContent.test.ts
@@ -237,7 +237,7 @@ test("opening an existing short theory session backfills its pre-check", async (
 	).toContain(before?.items[0]?.front);
 });
 
-test("split fallback pairs every theory page with a practical page", async () => {
+test("split fallback pairs every theory page with a related prediction question", async () => {
 	const { t, sessionId } = await createGeneratedPlanWithSession(
 		"theory",
 		"split",
@@ -260,14 +260,17 @@ test("split fallback pairs every theory page with a practical page", async () =>
 	expect(theoryItems).toHaveLength(8);
 	expect(pairedPracticeItems).toHaveLength(theoryItems.length);
 	for (const theoryItem of theoryItems) {
-		expect(pairedPracticeItems).toContainEqual(
-			expect.objectContaining({
-				phase: "practice",
-				kind: "written",
-				topicId: theoryItem.topicId,
-				coverageKey: `${theoryItem.coverageKey}:paired-practice`,
-			}),
+		const pairedQuestion = pairedPracticeItems.find(
+			(item) =>
+				item.coverageKey === `${theoryItem.coverageKey}:paired-practice`,
 		);
+		expect(pairedQuestion).toMatchObject({
+			phase: "practice",
+			kind: "written",
+			title: theoryItem.title,
+			topicId: theoryItem.topicId,
+			prompt: theoryItem.theoryContent?.question ?? theoryItem.front,
+		});
 	}
 	expect(
 		content?.items.reduce((total, item) => total + item.estimatedSeconds, 0),
@@ -275,6 +278,48 @@ test("split fallback pairs every theory page with a practical page", async () =>
 	expect(new Set(content?.items.map((item) => item.coverageKey)).size).toBe(
 		content?.items.length,
 	);
+});
+
+test("reopening a split theory session upgrades an existing paired task to the guiding question", async () => {
+	const { t, sessionId } = await createGeneratedPlanWithSession(
+		"theory",
+		"split",
+	);
+	await t.mutation(api.learningSessionContent.ensureSessionContent, {
+		sessionId,
+	});
+	const before = await t.query(api.learningSessionContent.getSessionContent, {
+		sessionId,
+	});
+	const theoryItem = before?.items.find((item) => item.kind === "learnCard");
+	const pairedQuestion = before?.items.find((item) =>
+		item.coverageKey.endsWith(":paired-practice"),
+	);
+	if (!theoryItem || !pairedQuestion) {
+		throw new Error("Expected a paired theory question.");
+	}
+
+	await t.run(async (ctx) => {
+		await ctx.db.patch("learningSessionContentItems", pairedQuestion.id, {
+			title: "Kurz-Check",
+			prompt: "Bearbeite eine zusätzliche Transferaufgabe.",
+		});
+	});
+
+	await t.mutation(api.learningSessionContent.ensureSessionContent, {
+		sessionId,
+	});
+	const updated = await t.query(api.learningSessionContent.getSessionContent, {
+		sessionId,
+	});
+	const updatedPair = updated?.items.find(
+		(item) => item.id === pairedQuestion.id,
+	);
+
+	expect(updatedPair).toMatchObject({
+		title: theoryItem.title,
+		prompt: theoryItem.theoryContent?.question ?? theoryItem.front,
+	});
 });
 
 test("persists deferred and completed theory validation states", async () => {
@@ -380,7 +425,10 @@ test("continue learning appends a fresh timed block", async () => {
 		api.learningSessionContent.getSessionContent,
 		{ sessionId },
 	);
-	const allPrompts = twiceExtended?.items.map((item) => item.prompt) ?? [];
+	const allPrompts =
+		twiceExtended?.items
+			.filter((item) => !item.coverageKey.endsWith(":paired-practice"))
+			.map((item) => item.prompt) ?? [];
 	const duplicatePrompts = allPrompts.filter(
 		(prompt, index) => allPrompts.indexOf(prompt) !== index,
 	);

--- a/convex/learningSessionContent.ts
+++ b/convex/learningSessionContent.ts
@@ -39,6 +39,13 @@ type AnswerRating = "notCorrect" | "partiallyCorrect" | "correct";
 
 const PAIRED_THEORY_PRACTICE_SUFFIX = ":paired-practice";
 
+const isPairedTheoryQuestionItem = (item: {
+	kind: string;
+	coverageKey?: string;
+}) =>
+	item.kind !== "learnCard" &&
+	item.coverageKey?.endsWith(PAIRED_THEORY_PRACTICE_SUFFIX) === true;
+
 type GeneratedItem = {
 	phase?: "theory" | "practice" | "rehearsal";
 	kind: SessionContentItemKind;
@@ -510,11 +517,8 @@ const buildPairedPracticeItem = (
 ): GeneratedItem => {
 	const concept =
 		theoryItem.theoryContent?.conceptTitle ?? theoryItem.title ?? session.title;
-	const application =
-		session.tasks.find((task) => task.trim().length > 0) ?? session.goal;
-	const prompt = theoryItem.theoryContent
-		? `Ausgangspunkt: ${theoryItem.theoryContent.question} Übertrage ${concept} auf eine eigene Variante dieses Beispiels: ${compactToLength(theoryItem.theoryContent.example, 180)} Verändere eine Bedingung, löse die Variante und begründe den entscheidenden Schritt.`
-		: `Bearbeite den Kurz-Check zu ${concept}: ${application} Begründe den entscheidenden Schritt mit Blick auf diese Leitfrage: ${theoryItem.front ?? theoryItem.prompt}`;
+	const prompt =
+		theoryItem.theoryContent?.question ?? theoryItem.front ?? theoryItem.prompt;
 	const idealAnswer = theoryItem.theoryContent
 		? `${theoryItem.theoryContent.keyPoints.join(" ")} Beispiel: ${theoryItem.theoryContent.example}`
 		: (theoryItem.back ?? theoryItem.idealAnswer);
@@ -525,11 +529,10 @@ const buildPairedPracticeItem = (
 	return {
 		phase: "practice",
 		kind: "written",
-		title: "Kurz-Check",
+		title: concept,
 		prompt,
-		explanation: theoryItem.theoryContent
-			? `${theoryItem.theoryContent.explanation} Achte besonders auf diesen typischen Fehler: ${theoryItem.theoryContent.commonMistake}`
-			: theoryItem.explanation,
+		explanation:
+			theoryItem.theoryContent?.explanation ?? theoryItem.explanation,
 		idealAnswer,
 		evaluationKeywords: theoryItem.evaluationKeywords,
 		learningBlockIndex: theoryItem.learningBlockIndex,
@@ -538,7 +541,7 @@ const buildPairedPracticeItem = (
 			theoryItem.evidenceDimension ??
 			session.targetEvidenceDimension ??
 			"understanding",
-		questionAngle: "apply",
+		questionAngle: theoryItem.questionAngle ?? "recall",
 		coverageKey: getPairedPracticeCoverageKey(theoryItem),
 		estimatedSeconds: practiceSeconds,
 	};
@@ -680,21 +683,60 @@ const ensurePairedTheoryPracticeItems = async (
 	if (session.phase !== "theory" || session.compositionVariant !== "split") {
 		return existingItems;
 	}
-	const existingPairKeys = new Set(
+	const existingPairByCoverageKey = new Map(
 		existingItems
-			.filter(
-				(item) =>
-					item.kind !== "learnCard" &&
-					item.coverageKey?.endsWith(PAIRED_THEORY_PRACTICE_SUFFIX),
-			)
-			.map((item) => item.coverageKey),
+			.filter(isPairedTheoryQuestionItem)
+			.flatMap((item) =>
+				item.coverageKey ? ([[item.coverageKey, item]] as const) : [],
+			),
 	);
 	const missingPracticeItems: GeneratedItem[] = [];
+	let updatedExistingPair = false;
 	for (const theoryItem of existingItems.filter(
 		(item) => item.kind === "learnCard",
 	)) {
 		const pairedCoverageKey = getPairedPracticeCoverageKey(theoryItem);
-		if (existingPairKeys.has(pairedCoverageKey)) continue;
+		const existingPair = existingPairByCoverageKey.get(pairedCoverageKey);
+		if (existingPair) {
+			const predictionItem = buildPairedPracticeItem(session, {
+				phase: theoryItem.phase,
+				kind: theoryItem.kind,
+				title: theoryItem.title,
+				prompt: theoryItem.prompt,
+				front: theoryItem.front,
+				back: theoryItem.back,
+				explanation: theoryItem.explanation,
+				idealAnswer: theoryItem.idealAnswer,
+				theoryContent: theoryItem.theoryContent,
+				choices: theoryItem.choices,
+				correctChoiceId: theoryItem.correctChoiceId,
+				evaluationKeywords: theoryItem.evaluationKeywords,
+				learningBlockIndex: theoryItem.learningBlockIndex,
+				topicId: theoryItem.topicId,
+				evidenceDimension: theoryItem.evidenceDimension,
+				questionAngle: theoryItem.questionAngle,
+				coverageKey: theoryItem.coverageKey,
+				estimatedSeconds: theoryItem.estimatedSeconds,
+			});
+			if (
+				existingPair.title !== predictionItem.title ||
+				existingPair.prompt !== predictionItem.prompt ||
+				existingPair.explanation !== predictionItem.explanation ||
+				existingPair.idealAnswer !== predictionItem.idealAnswer ||
+				existingPair.questionAngle !== predictionItem.questionAngle
+			) {
+				await ctx.db.patch("learningSessionContentItems", existingPair._id, {
+					title: normalizeText(predictionItem.title),
+					prompt: normalizeText(predictionItem.prompt),
+					explanation: normalizeText(predictionItem.explanation),
+					idealAnswer: normalizeText(predictionItem.idealAnswer),
+					questionAngle: predictionItem.questionAngle,
+					updatedAt: Date.now(),
+				});
+				updatedExistingPair = true;
+			}
+			continue;
+		}
 		const { theorySeconds } = splitTheoryPageSeconds(
 			theoryItem.estimatedSeconds,
 		);
@@ -735,6 +777,7 @@ const ensurePairedTheoryPracticeItems = async (
 		);
 		return await listItems(ctx, session._id);
 	}
+	if (updatedExistingPair) return await listItems(ctx, session._id);
 	return existingItems;
 };
 
@@ -821,21 +864,25 @@ const buildAnalysis = (
 	attempts: Doc<"learningSessionAnswerAttempts">[],
 ) => {
 	const itemById = new Map(items.map((item) => [item._id, item]));
-	const correctCount = attempts.filter(
+	const scoredAttempts = attempts.filter((attempt) => {
+		const item = itemById.get(attempt.itemId);
+		return item ? !isPairedTheoryQuestionItem(item) : false;
+	});
+	const correctCount = scoredAttempts.filter(
 		(attempt) => attempt.rating === "correct",
 	).length;
-	const partialCount = attempts.filter(
+	const partialCount = scoredAttempts.filter(
 		(attempt) => attempt.rating === "partiallyCorrect",
 	).length;
-	const attemptedCount = attempts.length;
+	const attemptedCount = scoredAttempts.length;
 	const hasStrongResult =
 		attemptedCount > 0 && correctCount + partialCount >= attemptedCount;
-	const missedPrompts = attempts
+	const missedPrompts = scoredAttempts
 		.filter((attempt) => attempt.rating !== "correct")
 		.map((attempt) => itemById.get(attempt.itemId)?.prompt)
 		.filter((prompt): prompt is string => Boolean(prompt))
 		.slice(0, 3);
-	const firstCorrectPrompt = attempts
+	const firstCorrectPrompt = scoredAttempts
 		.map((attempt) =>
 			attempt.rating === "correct"
 				? itemById.get(attempt.itemId)?.prompt
@@ -1039,7 +1086,13 @@ export const getSessionGenerationContext = internalQuery({
 				}
 				seenAttemptItemIds.add(attempt.itemId);
 				const item = itemById.get(attempt.itemId);
-				if (!item || item.kind === "learnCard") continue;
+				if (
+					!item ||
+					item.kind === "learnCard" ||
+					isPairedTheoryQuestionItem(item)
+				) {
+					continue;
+				}
 				const selectedChoice = item.choices?.find(
 					(choice) => choice.id === attempt.selectedChoiceId,
 				)?.text;

--- a/convex/learningSessionContent.ts
+++ b/convex/learningSessionContent.ts
@@ -37,6 +37,8 @@ type SessionContentItemKind =
 	| "voice";
 type AnswerRating = "notCorrect" | "partiallyCorrect" | "correct";
 
+const PAIRED_THEORY_PRACTICE_SUFFIX = ":paired-practice";
+
 type GeneratedItem = {
 	phase?: "theory" | "practice" | "rehearsal";
 	kind: SessionContentItemKind;
@@ -484,6 +486,93 @@ const buildTaskItems = (
 	});
 };
 
+const getPairedPracticeCoverageKey = (item: {
+	coverageKey?: string;
+	topicId?: string;
+}) =>
+	`${item.coverageKey ?? item.topicId ?? "theory"}${PAIRED_THEORY_PRACTICE_SUFFIX}`;
+
+const splitTheoryPageSeconds = (estimatedSeconds?: number) => {
+	const totalSeconds = Math.max(60, estimatedSeconds ?? 240);
+	const practiceSeconds = Math.min(
+		90,
+		Math.max(30, Math.round(totalSeconds * 0.35)),
+	);
+	return {
+		theorySeconds: totalSeconds - practiceSeconds,
+		practiceSeconds,
+	};
+};
+
+const buildPairedPracticeItem = (
+	session: Doc<"learningPlanSessions">,
+	theoryItem: GeneratedItem,
+): GeneratedItem => {
+	const concept =
+		theoryItem.theoryContent?.conceptTitle ?? theoryItem.title ?? session.title;
+	const application =
+		session.tasks.find((task) => task.trim().length > 0) ?? session.goal;
+	const prompt = theoryItem.theoryContent
+		? `Ausgangspunkt: ${theoryItem.theoryContent.question} Übertrage ${concept} auf eine eigene Variante dieses Beispiels: ${compactToLength(theoryItem.theoryContent.example, 180)} Verändere eine Bedingung, löse die Variante und begründe den entscheidenden Schritt.`
+		: `Bearbeite den Kurz-Check zu ${concept}: ${application} Begründe den entscheidenden Schritt mit Blick auf diese Leitfrage: ${theoryItem.front ?? theoryItem.prompt}`;
+	const idealAnswer = theoryItem.theoryContent
+		? `${theoryItem.theoryContent.keyPoints.join(" ")} Beispiel: ${theoryItem.theoryContent.example}`
+		: (theoryItem.back ?? theoryItem.idealAnswer);
+	const { practiceSeconds } = splitTheoryPageSeconds(
+		theoryItem.estimatedSeconds,
+	);
+
+	return {
+		phase: "practice",
+		kind: "written",
+		title: "Kurz-Check",
+		prompt,
+		explanation: theoryItem.theoryContent
+			? `${theoryItem.theoryContent.explanation} Achte besonders auf diesen typischen Fehler: ${theoryItem.theoryContent.commonMistake}`
+			: theoryItem.explanation,
+		idealAnswer,
+		evaluationKeywords: theoryItem.evaluationKeywords,
+		learningBlockIndex: theoryItem.learningBlockIndex,
+		topicId: theoryItem.topicId,
+		evidenceDimension:
+			theoryItem.evidenceDimension ??
+			session.targetEvidenceDimension ??
+			"understanding",
+		questionAngle: "apply",
+		coverageKey: getPairedPracticeCoverageKey(theoryItem),
+		estimatedSeconds: practiceSeconds,
+	};
+};
+
+const pairGeneratedTheoryItems = (
+	session: Doc<"learningPlanSessions">,
+	items: GeneratedItem[],
+) => {
+	if (session.phase !== "theory" || session.compositionVariant !== "split") {
+		return items;
+	}
+	const existingPairKeys = new Set(
+		items
+			.filter(
+				(item) =>
+					item.kind !== "learnCard" &&
+					item.coverageKey?.endsWith(PAIRED_THEORY_PRACTICE_SUFFIX),
+			)
+			.map((item) => item.coverageKey),
+	);
+
+	return items.flatMap((item) => {
+		if (item.kind !== "learnCard") return [item];
+		const pairedCoverageKey = getPairedPracticeCoverageKey(item);
+		if (existingPairKeys.has(pairedCoverageKey)) return [item];
+		const { theorySeconds } = splitTheoryPageSeconds(item.estimatedSeconds);
+		return [
+			{ ...item, estimatedSeconds: theorySeconds },
+			buildPairedPracticeItem(session, item),
+		];
+	});
+};
+
 const buildGeneratedItems = (
 	plan: Doc<"learningPlans">,
 	session: Doc<"learningPlanSessions">,
@@ -498,7 +587,7 @@ const buildGeneratedItems = (
 		topics: getSessionTopics(plan, session),
 	});
 
-	return contentPlan.blocks.flatMap((block) => {
+	const items = contentPlan.blocks.flatMap((block) => {
 		const segmentSession: Doc<"learningPlanSessions"> = {
 			...session,
 			phase: block.phase,
@@ -514,6 +603,7 @@ const buildGeneratedItems = (
 			learningBlockIndex: block.index,
 		}));
 	});
+	return pairGeneratedTheoryItems(session, items);
 };
 
 const listItems = async (
@@ -582,6 +672,72 @@ const insertGeneratedItemsForSession = async (
 	}
 };
 
+const ensurePairedTheoryPracticeItems = async (
+	ctx: MutationCtx,
+	session: Doc<"learningPlanSessions">,
+	existingItems: Doc<"learningSessionContentItems">[],
+) => {
+	if (session.phase !== "theory" || session.compositionVariant !== "split") {
+		return existingItems;
+	}
+	const existingPairKeys = new Set(
+		existingItems
+			.filter(
+				(item) =>
+					item.kind !== "learnCard" &&
+					item.coverageKey?.endsWith(PAIRED_THEORY_PRACTICE_SUFFIX),
+			)
+			.map((item) => item.coverageKey),
+	);
+	const missingPracticeItems: GeneratedItem[] = [];
+	for (const theoryItem of existingItems.filter(
+		(item) => item.kind === "learnCard",
+	)) {
+		const pairedCoverageKey = getPairedPracticeCoverageKey(theoryItem);
+		if (existingPairKeys.has(pairedCoverageKey)) continue;
+		const { theorySeconds } = splitTheoryPageSeconds(
+			theoryItem.estimatedSeconds,
+		);
+		await ctx.db.patch("learningSessionContentItems", theoryItem._id, {
+			estimatedSeconds: theorySeconds,
+			updatedAt: Date.now(),
+		});
+		missingPracticeItems.push(
+			buildPairedPracticeItem(session, {
+				phase: theoryItem.phase,
+				kind: theoryItem.kind,
+				title: theoryItem.title,
+				prompt: theoryItem.prompt,
+				front: theoryItem.front,
+				back: theoryItem.back,
+				explanation: theoryItem.explanation,
+				idealAnswer: theoryItem.idealAnswer,
+				theoryContent: theoryItem.theoryContent,
+				choices: theoryItem.choices,
+				correctChoiceId: theoryItem.correctChoiceId,
+				evaluationKeywords: theoryItem.evaluationKeywords,
+				learningBlockIndex: theoryItem.learningBlockIndex,
+				topicId: theoryItem.topicId,
+				evidenceDimension: theoryItem.evidenceDimension,
+				questionAngle: theoryItem.questionAngle,
+				coverageKey: theoryItem.coverageKey,
+				estimatedSeconds: theoryItem.estimatedSeconds,
+			}),
+		);
+	}
+
+	if (missingPracticeItems.length > 0) {
+		await insertGeneratedItemsForSession(
+			ctx,
+			session,
+			missingPracticeItems,
+			existingItems.length,
+		);
+		return await listItems(ctx, session._id);
+	}
+	return existingItems;
+};
+
 const ensureItemsForSession = async (
 	ctx: MutationCtx,
 	session: Doc<"learningPlanSessions">,
@@ -589,7 +745,9 @@ const ensureItemsForSession = async (
 ) => {
 	assertSessionIsCommitted(session);
 	const existingItems = await listItems(ctx, session._id);
-	if (existingItems.length > 0) return existingItems;
+	if (existingItems.length > 0) {
+		return await ensurePairedTheoryPracticeItems(ctx, session, existingItems);
+	}
 	if (session.sessionPurpose === "diagnostic") {
 		throwUserFacingError(
 			"Die Fragen des Wissenschecks fehlen. Erstelle den Lernplan erneut.",
@@ -902,6 +1060,19 @@ export const getSessionGenerationContext = internalQuery({
 			}
 		}
 
+		const theoryItems = existingItems.filter(
+			(item) => item.kind === "learnCard",
+		);
+		const pairedPracticeKeys = new Set(
+			existingItems
+				.filter(
+					(item) =>
+						item.kind !== "learnCard" &&
+						item.coverageKey?.endsWith(PAIRED_THEORY_PRACTICE_SUFFIX),
+				)
+				.map((item) => item.coverageKey),
+		);
+
 		return {
 			plan,
 			session,
@@ -923,6 +1094,11 @@ export const getSessionGenerationContext = internalQuery({
 			priorCoverageKeys,
 			existingItemCount: existingItems.length,
 			hasTheoryKnowledgeCheck: existingItems.some(isTheoryKnowledgeCheckItem),
+			hasCompleteTheoryPracticePairs:
+				theoryItems.length > 0 &&
+				theoryItems.every((item) =>
+					pairedPracticeKeys.has(getPairedPracticeCoverageKey(item)),
+				),
 			needsLegacyContentReplacement:
 				existingItems.some(isLegacyTheoryItem) ||
 				existingItems.some(isLegacyTaskItem),
@@ -1005,6 +1181,12 @@ export const backfillTheoryKnowledgeCheck = internalMutation({
 			);
 		}
 
+		await ensurePairedTheoryPracticeItems(
+			ctx,
+			{ ...session, compositionVariant: "split" },
+			await listItems(ctx, session._id),
+		);
+
 		await ctx.db.patch("learningPlanSessions", session._id, {
 			compositionVariant: "split",
 			knowledgeValidationStatus: session.knowledgeValidationStatus ?? "pending",
@@ -1084,7 +1266,11 @@ export const storeGeneratedSessionContent = internalMutation({
 					]
 				: args.items;
 
-		await insertGeneratedItemsForSession(ctx, session, items);
+		await insertGeneratedItemsForSession(
+			ctx,
+			session,
+			pairGeneratedTheoryItems(session, items),
+		);
 		const storedItems = await listItems(ctx, args.sessionId);
 		return { itemCount: storedItems.length };
 	},
@@ -1225,6 +1411,16 @@ export const ensureSessionContent = mutation({
 			ownerTokenIdentifier,
 		);
 		const items = await ensureItemsForSession(ctx, session, plan);
+		if (session.contentGenerationStatus !== "ready") {
+			const now = Date.now();
+			await ctx.db.patch("learningPlanSessions", session._id, {
+				contentGenerationStatus: "ready",
+				contentGenerationError: undefined,
+				contentGenerationStartedAt: undefined,
+				contentGeneratedAt: now,
+				updatedAt: now,
+			});
+		}
 
 		return { itemCount: items.length };
 	},

--- a/src/app/learning-plans/[planId]/index.tsx
+++ b/src/app/learning-plans/[planId]/index.tsx
@@ -144,20 +144,8 @@ export function SessionPreviewCard({
 		: session.executionStatus === "started"
 			? "Weiterlernen"
 			: "Lernsession starten";
-	const horizonLabel = hasRecordedOutcome
-		? "Bearbeitet"
-		: session.planningStatus === "provisional"
-			? "Danach · Vorschau"
-			: "Als Nächstes";
 	const content = (
 		<View className="gap-2">
-			<View className="flex-row">
-				<View className="rounded-full bg-system-subtle px-3 py-1.5">
-					<Text className="font-poppins font-semibold text-body-5 text-primary">
-						{horizonLabel}
-					</Text>
-				</View>
-			</View>
 			<View className="flex-row items-start justify-between gap-3">
 				<Text
 					className="min-w-0 flex-1 pr-2 font-poppins font-semibold text-body-2 text-text"
@@ -201,15 +189,6 @@ export function SessionPreviewCard({
 			>
 				{description}
 			</Text>
-			{session.selectionReason ? (
-				<Text
-					className="font-poppins font-semibold text-body-5 text-primary"
-					numberOfLines={2}
-				>
-					{formatGermanUiText(session.selectionReason)}
-				</Text>
-			) : null}
-
 			{canOpen ? (
 				<Button
 					accessibilityHint="Öffnet die ausgewählte Lerneinheit."

--- a/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
+++ b/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
@@ -1,4 +1,4 @@
-import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import * as Device from "expo-device";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Speech from "expo-speech";
@@ -50,6 +50,7 @@ import {
 	getLearningSessionItems,
 	getLearningSessionTimerDurationSeconds,
 	getTheoryTopicPosition,
+	isPairedTheoryPracticeItem,
 	isTheoryKnowledgeCheckItem,
 } from "~/features/learning-plans/session-progress";
 import { runTheoryTopicPrimaryAction } from "~/features/learning-plans/theory-topic";
@@ -60,6 +61,7 @@ import type {
 	SessionAnswerRating,
 	SessionContentItem,
 } from "~/features/learning-plans/types";
+import { usePrepareSessionContent } from "~/features/learning-plans/use-prepare-session-content";
 import { getErrorMessage } from "~/features/learning-plans/utils";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 import { logDiagnosticError } from "~/lib/diagnostics";
@@ -969,9 +971,6 @@ export default function LearningSessionContentScreen() {
 	const sessionId = params.sessionId as Id<"learningPlanSessions"> | undefined;
 	const { user } = useAuthSession();
 	const { isAuthenticated: isConvexAuthenticated } = useConvexAuth();
-	const ensureSessionContent = useAction(
-		api.learningPlanAi.ensureSessionContent,
-	);
 	const submitAnswer = useMutation(api.learningSessionContent.submitAnswer);
 	const finishSessionContent = useMutation(
 		api.learningSessionContent.finishSessionContent,
@@ -1010,7 +1009,6 @@ export default function LearningSessionContentScreen() {
 	const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
 	const remainingSecondsRef = useRef<number | null>(null);
 	const [isContinuation, setIsContinuation] = useState(false);
-	const didEnsureRef = useRef(false);
 	const didAutoFinishRef = useRef(false);
 	const didStartTrackingRef = useRef(false);
 	const didRecordOutcomeRef = useRef(false);
@@ -1240,21 +1238,18 @@ export default function LearningSessionContentScreen() {
 		}
 	}, [shouldTrackActiveStudy]);
 
-	useEffect(() => {
-		if (!sessionId || !user || !isConvexAuthenticated || didEnsureRef.current)
-			return;
-
-		didEnsureRef.current = true;
-		void ensureSessionContent({ sessionId }).catch((error: unknown) => {
-			didEnsureRef.current = false;
+	usePrepareSessionContent({
+		enabled: Boolean(user && isConvexAuthenticated),
+		sessionId,
+		onError: (error) => {
 			setErrorMessage(
 				getErrorMessage(
 					error,
 					"Der Lernblock konnte nicht vorbereitet werden.",
 				),
 			);
-		});
-	}, [ensureSessionContent, isConvexAuthenticated, sessionId, user]);
+		},
+	});
 
 	useEffect(() => {
 		if (
@@ -1525,11 +1520,16 @@ export default function LearningSessionContentScreen() {
 			currentIndex: theoryTopicPosition.topicIndex,
 			total: theoryTopicPosition.total,
 			onAdvance: () => {
-				if (theoryTopicPosition.nextSessionIndex === null) return;
+				if (currentIndex >= sessionItems.length - 1) return;
 				setErrorMessage(null);
-				setCurrentIndex(theoryTopicPosition.nextSessionIndex);
+				setCurrentIndex((value) => value + 1);
 			},
 			onComplete: () => {
+				if (currentIndex < sessionItems.length - 1) {
+					setErrorMessage(null);
+					setCurrentIndex((value) => value + 1);
+					return;
+				}
 				setCompletionPhase(
 					getLearningSessionCompletionPhase(
 						content.session.phase,
@@ -1701,7 +1701,7 @@ export default function LearningSessionContentScreen() {
 			: content
 				? isDiagnosticSession
 					? "Wissenscheck"
-					: isTheoryKnowledgeCheck
+					: isTheoryKnowledgeCheck || isPairedTheoryPracticeItem(currentItem)
 						? "Kurz-Check"
 						: phaseTitle(currentItem?.phase ?? content.session.phase)
 				: "Lernblock";

--- a/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
+++ b/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
@@ -49,12 +49,16 @@ import {
 	getLearningSessionCompletionPhase,
 	getLearningSessionItems,
 	getLearningSessionTimerDurationSeconds,
+	getPairedTheoryItem,
 	getTheoryTopicPosition,
-	isPairedTheoryPracticeItem,
+	isPairedTheoryQuestionItem,
 	isTheoryKnowledgeCheckItem,
 } from "~/features/learning-plans/session-progress";
 import { runTheoryTopicPrimaryAction } from "~/features/learning-plans/theory-topic";
-import { TheoryTopicPage } from "~/features/learning-plans/theory-topic-page";
+import {
+	TheoryPredictionPage,
+	TheoryTopicPage,
+} from "~/features/learning-plans/theory-topic-page";
 import type {
 	LearningSessionContentSnapshot,
 	SessionAnswerAttempt,
@@ -1013,7 +1017,7 @@ export default function LearningSessionContentScreen() {
 	const didStartTrackingRef = useRef(false);
 	const didRecordOutcomeRef = useRef(false);
 	const didResumeDeferredValidationRef = useRef(false);
-	const advancedTheoryKnowledgeCheckItemIdRef = useRef<string | null>(null);
+	const advancedPreTheoryQuestionItemIdRef = useRef<string | null>(null);
 	const activeStudySecondsRef = useRef(0);
 	const activeStudyStartedAtRef = useRef<number | null>(null);
 	const isStudyInteractionActiveRef = useRef(false);
@@ -1071,6 +1075,7 @@ export default function LearningSessionContentScreen() {
 		[content],
 	);
 	const currentItem = sessionItems[currentIndex] ?? null;
+	const pairedTheoryItem = getPairedTheoryItem(sessionItems, currentIndex);
 	const theoryTopicPosition = getTheoryTopicPosition(
 		sessionItems,
 		currentIndex,
@@ -1087,15 +1092,21 @@ export default function LearningSessionContentScreen() {
 			compositionVariant: content?.session.compositionVariant,
 		}),
 	);
+	const hasPairedTheoryQuestions = sessionItems.some(
+		isPairedTheoryQuestionItem,
+	);
 	const isTheoryValidationSession =
 		content?.session.phase === "theory" &&
 		content.session.compositionVariant === "split" &&
-		validationItems.length > 0;
+		validationItems.length > 0 &&
+		!hasPairedTheoryQuestions;
 	const isTheoryKnowledgeCheck = isTheoryKnowledgeCheckItem({
 		item: currentItem,
 		phase: content?.session.phase,
 		compositionVariant: content?.session.compositionVariant,
 	});
+	const isPairedTheoryQuestion = isPairedTheoryQuestionItem(currentItem);
+	const isPreTheoryQuestion = isTheoryKnowledgeCheck || isPairedTheoryQuestion;
 
 	useEffect(() => {
 		if (
@@ -1128,7 +1139,7 @@ export default function LearningSessionContentScreen() {
 		return attempt;
 	}, [content, currentItem, repeatingItemId, retryStartedAt]);
 	const visibleAttempt =
-		isPraxisSession || isTheoryKnowledgeCheck
+		isPraxisSession || isPreTheoryQuestion
 			? null
 			: localAttempt && currentItem && localAttempt.itemId === currentItem.id
 				? localAttempt
@@ -1366,19 +1377,19 @@ export default function LearningSessionContentScreen() {
 
 	useEffect(() => {
 		if (
-			!isTheoryKnowledgeCheck ||
+			!isPreTheoryQuestion ||
 			!currentItem ||
 			!persistedAttempt ||
-			advancedTheoryKnowledgeCheckItemIdRef.current === currentItem.id
+			advancedPreTheoryQuestionItemIdRef.current === currentItem.id
 		) {
 			return;
 		}
-		advancedTheoryKnowledgeCheckItemIdRef.current = currentItem.id;
+		advancedPreTheoryQuestionItemIdRef.current = currentItem.id;
 		queueMicrotask(advancePastCurrentItem);
 	}, [
 		advancePastCurrentItem,
 		currentItem,
-		isTheoryKnowledgeCheck,
+		isPreTheoryQuestion,
 		persistedAttempt,
 	]);
 
@@ -1648,7 +1659,7 @@ export default function LearningSessionContentScreen() {
 				answerText: currentItem.kind === "written" ? writtenAnswer : undefined,
 				transcript: currentItem.kind === "voice" ? writtenAnswer : undefined,
 			});
-			if (attempt.rating === "correct") {
+			if (attempt.rating === "correct" && !isPreTheoryQuestion) {
 				void triggerSuccessHaptic({
 					platform: process.env.EXPO_OS,
 				});
@@ -1662,9 +1673,9 @@ export default function LearningSessionContentScreen() {
 				setCompletionPhase("rehearsal");
 				return;
 			}
-			if (isTheoryKnowledgeCheck) {
-				if (advancedTheoryKnowledgeCheckItemIdRef.current !== currentItem.id) {
-					advancedTheoryKnowledgeCheckItemIdRef.current = currentItem.id;
+			if (isPreTheoryQuestion) {
+				if (advancedPreTheoryQuestionItemIdRef.current !== currentItem.id) {
+					advancedPreTheoryQuestionItemIdRef.current = currentItem.id;
 					advancePastCurrentItem();
 				}
 				return;
@@ -1701,7 +1712,7 @@ export default function LearningSessionContentScreen() {
 			: content
 				? isDiagnosticSession
 					? "Wissenscheck"
-					: isTheoryKnowledgeCheck || isPairedTheoryPracticeItem(currentItem)
+					: isPreTheoryQuestion
 						? "Kurz-Check"
 						: phaseTitle(currentItem?.phase ?? content.session.phase)
 				: "Lernblock";
@@ -1718,7 +1729,8 @@ export default function LearningSessionContentScreen() {
 
 	if (
 		content?.session.phase === "theory" &&
-		currentItem?.kind === "learnCard" &&
+		(currentItem?.kind === "learnCard" ||
+			(isPairedTheoryQuestion && pairedTheoryItem)) &&
 		!showAnalysis &&
 		!completionPhase
 	) {
@@ -1760,16 +1772,31 @@ export default function LearningSessionContentScreen() {
 					}}
 				/>
 				<ThemedStatusBar />
-				<TheoryTopicPage
-					key={currentItem.id}
-					item={currentItem}
-					currentIndex={theoryTopicPosition.topicIndex}
-					total={theoryTopicPosition.total}
-					isCompleting={isBusy}
-					onPrevious={showPreviousTheoryTopic}
-					onNext={continueTheory}
-				/>
-				{errorMessage ? (
+				{currentItem.kind === "learnCard" ? (
+					<TheoryTopicPage
+						key={currentItem.id}
+						item={currentItem}
+						currentIndex={theoryTopicPosition.topicIndex}
+						total={theoryTopicPosition.total}
+						isCompleting={isBusy}
+						onPrevious={showPreviousTheoryTopic}
+						onNext={continueTheory}
+					/>
+				) : pairedTheoryItem ? (
+					<TheoryPredictionPage
+						key={currentItem.id}
+						theoryItem={pairedTheoryItem}
+						currentIndex={theoryTopicPosition.topicIndex}
+						total={theoryTopicPosition.total}
+						value={answerText}
+						onChange={setAnswerText}
+						onSubmit={() => void submitCurrentAnswer()}
+						onSubmitUnknown={() => void submitCurrentAnswer(true)}
+						isSubmitting={isBusy}
+						errorMessage={errorMessage}
+					/>
+				) : null}
+				{currentItem.kind === "learnCard" && errorMessage ? (
 					<View className="absolute right-6 bottom-28 left-6 rounded-[24px] bg-wrong-subtle px-4 py-3">
 						<Text
 							selectable

--- a/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
@@ -133,9 +133,28 @@ describe("learning-plan path", () => {
 			name: "Lernsession starten: Lineare Funktionen verstehen",
 		});
 		expect(screen.getByText("Lernsession starten")).toBeOnTheScreen();
+		expect(screen.queryByText("Als Nächstes")).toBeNull();
 
 		fireEvent.press(startButton);
 		expect(onOpen).toHaveBeenCalledTimes(1);
+	});
+
+	test("keeps status and selection reason labels out of the preview card", async () => {
+		const screen = await render(
+			<SessionPreviewCard
+				canOpen
+				session={session("session_done", {
+					completed: true,
+					executionStatus: "completed",
+					selectionReason:
+						"Warum jetzt: „Lineare Funktionen“ ist noch nicht stabil.",
+				})}
+				onOpen={() => undefined}
+			/>,
+		);
+
+		expect(screen.queryByText("Bearbeitet")).toBeNull();
+		expect(screen.queryByText(/Warum jetzt/)).toBeNull();
 	});
 
 	test("explains that a provisional session can still change", async () => {
@@ -147,7 +166,7 @@ describe("learning-plan path", () => {
 			/>,
 		);
 
-		expect(screen.getByText("Danach · Vorschau")).toBeOnTheScreen();
+		expect(screen.queryByText("Danach · Vorschau")).toBeNull();
 		expect(
 			screen.getByText(
 				"Diese Vorschau kann sich nach deinem nächsten Abschluss ändern.",

--- a/src/features/learning-plans/session-progress.test.ts
+++ b/src/features/learning-plans/session-progress.test.ts
@@ -9,7 +9,12 @@ import {
 	isTheoryKnowledgeCheckItem,
 } from "./session-progress";
 
-const learnCard = { id: "theory", kind: "learnCard", phase: "theory" } as const;
+const learnCard = {
+	id: "theory",
+	kind: "learnCard",
+	phase: "theory",
+	coverageKey: "topic:recall:0",
+} as const;
 const practiceTask = {
 	id: "practice",
 	kind: "written",
@@ -57,6 +62,47 @@ describe("learning session progress", () => {
 			previousSessionIndex: 1,
 			nextSessionIndex: null,
 		});
+	});
+
+	it("places each practical page directly after its theory page", () => {
+		const secondLearnCard = {
+			id: "theory-2",
+			kind: "learnCard",
+			phase: "theory",
+			coverageKey: "topic:apply:0",
+		} as const;
+		const firstPractice = {
+			id: "practice-1",
+			kind: "written",
+			phase: "practice",
+			coverageKey: "topic:recall:0:paired-practice",
+		} as const;
+		const secondPractice = {
+			id: "practice-2",
+			kind: "written",
+			phase: "practice",
+			coverageKey: "topic:apply:0:paired-practice",
+		} as const;
+
+		expect(
+			getLearningSessionItems(
+				[
+					learnCard,
+					secondLearnCard,
+					practiceTask,
+					firstPractice,
+					secondPractice,
+				],
+				"theory",
+				"split",
+			),
+		).toEqual([
+			practiceTask,
+			learnCard,
+			firstPractice,
+			secondLearnCard,
+			secondPractice,
+		]);
 	});
 
 	it("keeps optional follow-up practice after the theory cards", () => {

--- a/src/features/learning-plans/session-progress.test.ts
+++ b/src/features/learning-plans/session-progress.test.ts
@@ -4,6 +4,7 @@ import {
 	getLearningSessionCompletionPhase,
 	getLearningSessionItems,
 	getLearningSessionTimerDurationSeconds,
+	getPairedTheoryItem,
 	getTheoryTopicPosition,
 	isQualifiedSessionCompletion,
 	isTheoryKnowledgeCheckItem,
@@ -33,9 +34,7 @@ describe("learning session progress", () => {
 		expect(
 			getLearningSessionItems([learnCard, practiceTask], "theory", "split"),
 		).toEqual([practiceTask, learnCard]);
-		expect(getLearningSessionCompletionPhase("theory", "split")).toBe(
-			"practice",
-		);
+		expect(getLearningSessionCompletionPhase("theory", "split")).toBe("theory");
 	});
 
 	it("maps reordered theory cards to their local topic position", () => {
@@ -64,7 +63,7 @@ describe("learning session progress", () => {
 		});
 	});
 
-	it("places each practical page directly after its theory page", () => {
+	it("places each prediction question directly before its theory page", () => {
 		const secondLearnCard = {
 			id: "theory-2",
 			kind: "learnCard",
@@ -98,11 +97,29 @@ describe("learning session progress", () => {
 			),
 		).toEqual([
 			practiceTask,
-			learnCard,
 			firstPractice,
-			secondLearnCard,
+			learnCard,
 			secondPractice,
+			secondLearnCard,
 		]);
+	});
+
+	it("maps a paired question to the same topic as its theory page", () => {
+		const pairedQuestion = {
+			id: "prediction",
+			kind: "written",
+			phase: "practice",
+			coverageKey: "topic:recall:0:paired-practice",
+		} as const;
+		const items = [practiceTask, pairedQuestion, learnCard];
+
+		expect(getPairedTheoryItem(items, 1)).toBe(learnCard);
+		expect(getTheoryTopicPosition(items, 1)).toEqual({
+			topicIndex: 0,
+			total: 1,
+			previousSessionIndex: null,
+			nextSessionIndex: null,
+		});
 	});
 
 	it("keeps optional follow-up practice after the theory cards", () => {

--- a/src/features/learning-plans/session-progress.ts
+++ b/src/features/learning-plans/session-progress.ts
@@ -1,7 +1,8 @@
 import type { SessionPhase } from "./types";
 
 export const CONTINUE_LEARNING_MINUTES = 10;
-export const PAIRED_THEORY_PRACTICE_SUFFIX = ":paired-practice";
+// Keep the persisted suffix stable for sessions created by earlier app versions.
+export const PAIRED_THEORY_QUESTION_SUFFIX = ":paired-practice";
 
 export function getLearningSessionTimerDurationSeconds({
 	phase,
@@ -44,27 +45,27 @@ export function getLearningSessionItems<
 				item.coverageKey?.includes(":validation:"),
 		);
 		const validationItemSet = new Set(validationItems);
-		const pairedPracticeByTheoryCoverageKey = new Map(
+		const pairedQuestionByTheoryCoverageKey = new Map(
 			items.flatMap((item) => {
 				const coverageKey = item.coverageKey;
-				if (!isPairedTheoryPracticeItem(item) || !coverageKey) return [];
+				if (!isPairedTheoryQuestionItem(item) || !coverageKey) return [];
 				return [
 					[
-						coverageKey.slice(0, -PAIRED_THEORY_PRACTICE_SUFFIX.length),
+						coverageKey.slice(0, -PAIRED_THEORY_QUESTION_SUFFIX.length),
 						item,
 					] as const,
 				];
 			}),
 		);
-		const pairedPracticeItems = new Set(
-			pairedPracticeByTheoryCoverageKey.values(),
+		const pairedQuestionItems = new Set(
+			pairedQuestionByTheoryCoverageKey.values(),
 		);
 		const pairedItems = items.flatMap((item) => {
 			if (item.kind !== "learnCard") return [];
-			const practiceItem = item.coverageKey
-				? pairedPracticeByTheoryCoverageKey.get(item.coverageKey)
+			const questionItem = item.coverageKey
+				? pairedQuestionByTheoryCoverageKey.get(item.coverageKey)
 				: undefined;
-			return practiceItem ? [item, practiceItem] : [item];
+			return questionItem ? [questionItem, item] : [item];
 		});
 
 		return [
@@ -74,7 +75,7 @@ export function getLearningSessionItems<
 				(item) =>
 					!validationItemSet.has(item) &&
 					item.kind !== "learnCard" &&
-					!pairedPracticeItems.has(item),
+					!pairedQuestionItems.has(item),
 			),
 		];
 	}
@@ -82,14 +83,33 @@ export function getLearningSessionItems<
 	return [...items];
 }
 
-export function isPairedTheoryPracticeItem<
+export function isPairedTheoryQuestionItem<
 	Item extends { kind: string; phase?: SessionPhase; coverageKey?: string },
 >(item: Item | null | undefined) {
 	return Boolean(
 		item &&
 			item.kind !== "learnCard" &&
 			item.phase === "practice" &&
-			item.coverageKey?.endsWith(PAIRED_THEORY_PRACTICE_SUFFIX),
+			item.coverageKey?.endsWith(PAIRED_THEORY_QUESTION_SUFFIX),
+	);
+}
+
+export function getPairedTheoryItem<
+	Item extends { kind: string; phase?: SessionPhase; coverageKey?: string },
+>(items: readonly Item[], currentIndex: number): Item | null {
+	const questionItem = items[currentIndex];
+	if (!isPairedTheoryQuestionItem(questionItem) || !questionItem?.coverageKey) {
+		return null;
+	}
+	const theoryCoverageKey = questionItem.coverageKey.slice(
+		0,
+		-PAIRED_THEORY_QUESTION_SUFFIX.length,
+	);
+	return (
+		items.find(
+			(item) =>
+				item.kind === "learnCard" && item.coverageKey === theoryCoverageKey,
+		) ?? null
 	);
 }
 
@@ -114,14 +134,17 @@ export function isTheoryKnowledgeCheckItem<
 	);
 }
 
-export function getTheoryTopicPosition<Item extends { kind: string }>(
-	items: readonly Item[],
-	currentIndex: number,
-) {
+export function getTheoryTopicPosition<
+	Item extends { kind: string; phase?: SessionPhase; coverageKey?: string },
+>(items: readonly Item[], currentIndex: number) {
 	const theoryIndices = items.flatMap((item, index) =>
 		item.kind === "learnCard" ? [index] : [],
 	);
-	const topicIndex = theoryIndices.indexOf(currentIndex);
+	const pairedTheoryItem = getPairedTheoryItem(items, currentIndex);
+	const activeTheoryIndex = pairedTheoryItem
+		? items.indexOf(pairedTheoryItem)
+		: currentIndex;
+	const topicIndex = theoryIndices.indexOf(activeTheoryIndex);
 
 	return {
 		topicIndex,
@@ -137,11 +160,9 @@ export function getTheoryTopicPosition<Item extends { kind: string }>(
 
 export function getLearningSessionCompletionPhase(
 	phase: SessionPhase,
-	compositionVariant: "control" | "split",
+	_compositionVariant: "control" | "split",
 ): SessionPhase {
-	return phase === "theory" && compositionVariant === "split"
-		? "practice"
-		: phase;
+	return phase;
 }
 
 export function isQualifiedSessionCompletion(

--- a/src/features/learning-plans/session-progress.ts
+++ b/src/features/learning-plans/session-progress.ts
@@ -1,6 +1,7 @@
 import type { SessionPhase } from "./types";
 
 export const CONTINUE_LEARNING_MINUTES = 10;
+export const PAIRED_THEORY_PRACTICE_SUFFIX = ":paired-practice";
 
 export function getLearningSessionTimerDurationSeconds({
 	phase,
@@ -43,13 +44,53 @@ export function getLearningSessionItems<
 				item.coverageKey?.includes(":validation:"),
 		);
 		const validationItemSet = new Set(validationItems);
+		const pairedPracticeByTheoryCoverageKey = new Map(
+			items.flatMap((item) => {
+				const coverageKey = item.coverageKey;
+				if (!isPairedTheoryPracticeItem(item) || !coverageKey) return [];
+				return [
+					[
+						coverageKey.slice(0, -PAIRED_THEORY_PRACTICE_SUFFIX.length),
+						item,
+					] as const,
+				];
+			}),
+		);
+		const pairedPracticeItems = new Set(
+			pairedPracticeByTheoryCoverageKey.values(),
+		);
+		const pairedItems = items.flatMap((item) => {
+			if (item.kind !== "learnCard") return [];
+			const practiceItem = item.coverageKey
+				? pairedPracticeByTheoryCoverageKey.get(item.coverageKey)
+				: undefined;
+			return practiceItem ? [item, practiceItem] : [item];
+		});
+
 		return [
 			...validationItems,
-			...items.filter((item) => !validationItemSet.has(item)),
+			...pairedItems,
+			...items.filter(
+				(item) =>
+					!validationItemSet.has(item) &&
+					item.kind !== "learnCard" &&
+					!pairedPracticeItems.has(item),
+			),
 		];
 	}
 
 	return [...items];
+}
+
+export function isPairedTheoryPracticeItem<
+	Item extends { kind: string; phase?: SessionPhase; coverageKey?: string },
+>(item: Item | null | undefined) {
+	return Boolean(
+		item &&
+			item.kind !== "learnCard" &&
+			item.phase === "practice" &&
+			item.coverageKey?.endsWith(PAIRED_THEORY_PRACTICE_SUFFIX),
+	);
 }
 
 export function isTheoryKnowledgeCheckItem<

--- a/src/features/learning-plans/theory-topic-page.tsx
+++ b/src/features/learning-plans/theory-topic-page.tsx
@@ -1,8 +1,10 @@
-import * as Speech from "expo-speech";
 import { useFocusEffect } from "expo-router";
+import * as Speech from "expo-speech";
 import { useCallback, useRef, useState } from "react";
 import {
 	ActivityIndicator,
+	KeyboardAvoidingView,
+	Platform,
 	ScrollView,
 	TouchableOpacity,
 	View,
@@ -13,6 +15,7 @@ import Animated, {
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button } from "~/components/ui/button";
+import { ErrorMessage } from "~/components/ui/error-message";
 import { FlowProgressBar } from "~/components/ui/flow-progress-bar";
 import {
 	BookOpen,
@@ -23,6 +26,7 @@ import {
 	VolumeHigh,
 } from "~/components/ui/icon";
 import { Text } from "~/components/ui/text";
+import { Textarea } from "~/components/ui/textarea";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 import { useDayovaTheme } from "~/lib/theme";
 import {
@@ -30,6 +34,7 @@ import {
 	buildTheorySpeechText,
 	getTheoryTopicNavigation,
 	splitTheorySpeechText,
+	type TheoryTopic,
 } from "./theory-topic";
 import type { SessionContentItem } from "./types";
 
@@ -44,6 +49,94 @@ type TheoryTopicPageProps = {
 	onPrevious: () => void;
 	onNext: () => void;
 };
+
+type TheoryPredictionPageProps = {
+	theoryItem: SessionContentItem;
+	currentIndex: number;
+	total: number;
+	value: string;
+	onChange: (value: string) => void;
+	onSubmit: () => void;
+	onSubmitUnknown: () => void;
+	isSubmitting: boolean;
+	errorMessage: string | null;
+};
+
+function TheoryTopicProgress({
+	currentIndex,
+	total,
+}: {
+	currentIndex: number;
+	total: number;
+}) {
+	const safeTotal = Math.max(total, 1);
+	const safeIndex = Math.min(Math.max(currentIndex, 0), safeTotal - 1);
+
+	return (
+		<View className="border-border border-b bg-background px-6 py-5">
+			<View className="mb-3 flex-row items-center justify-between">
+				<Text
+					selectable
+					className="font-poppins font-semibold text-body-5 text-primary"
+				>
+					THEMA {safeIndex + 1}
+				</Text>
+				<Text
+					selectable
+					className="font-poppins text-body-5 text-secondary-text"
+					// Tabular counter alignment requires React Native's text style API.
+					style={{ fontVariant: ["tabular-nums"] }}
+				>
+					{safeIndex + 1} von {safeTotal}
+				</Text>
+			</View>
+			<FlowProgressBar
+				progress={(safeIndex + 1) / safeTotal}
+				accessibilityRole="progressbar"
+				accessibilityValue={{
+					min: 1,
+					max: safeTotal,
+					now: safeIndex + 1,
+					text: `Thema ${safeIndex + 1} von ${safeTotal}`,
+				}}
+			/>
+		</View>
+	);
+}
+
+function TheoryTopicIntroduction({
+	topic,
+	accessory,
+}: {
+	topic: TheoryTopic;
+	accessory?: React.ReactNode;
+}) {
+	return (
+		<View className="gap-4">
+			<View className="flex-row items-start gap-4">
+				<Text
+					selectable
+					accessibilityRole="header"
+					className="flex-1 font-poppins font-semibold text-heading-2 text-text"
+				>
+					{topic.conceptTitle}
+				</Text>
+				{accessory}
+			</View>
+			<View className="rounded-[24px] bg-system-subtle px-5 py-5">
+				<Text className="font-poppins font-semibold text-body-4 text-primary">
+					Leitfrage
+				</Text>
+				<Text
+					selectable
+					className="mt-2 font-poppins font-semibold text-body-1 text-text"
+				>
+					{topic.question}
+				</Text>
+			</View>
+		</View>
+	);
+}
 
 function TopicSectionTitle({
 	icon,
@@ -64,6 +157,97 @@ function TopicSectionTitle({
 				{children}
 			</Text>
 		</View>
+	);
+}
+
+export function TheoryPredictionPage({
+	theoryItem,
+	currentIndex,
+	total,
+	value,
+	onChange,
+	onSubmit,
+	onSubmitUnknown,
+	isSubmitting,
+	errorMessage,
+}: TheoryPredictionPageProps) {
+	const insets = useSafeAreaInsets();
+	const reduceMotion = useReducedMotion();
+	const topic = adaptTheoryTopic(theoryItem, currentIndex);
+
+	return (
+		<KeyboardAvoidingView
+			className="flex-1 bg-background"
+			behavior={Platform.OS === "ios" ? "padding" : undefined}
+		>
+			<TheoryTopicProgress currentIndex={currentIndex} total={total} />
+			<ScrollView
+				contentInsetAdjustmentBehavior="automatic"
+				automaticallyAdjustKeyboardInsets
+				contentContainerStyle={{
+					paddingHorizontal: 24,
+					paddingTop: 28,
+					paddingBottom: 36,
+				}}
+				keyboardShouldPersistTaps="handled"
+				showsVerticalScrollIndicator={false}
+			>
+				<Animated.View
+					key={`${theoryItem.id}:prediction`}
+					entering={reduceMotion ? undefined : FadeInDown.duration(220)}
+					className="gap-7"
+				>
+					<TheoryTopicIntroduction topic={topic} />
+					<View className="gap-3">
+						<Text className="font-poppins font-semibold text-body-2 text-text">
+							Deine Einschätzung
+						</Text>
+						<Text className="font-poppins text-body-4 text-secondary-text">
+							Ein erster Gedanke reicht. Die Erklärung folgt direkt danach.
+						</Text>
+						<View className="min-h-40 rounded-[32px] bg-card px-5 py-5">
+							<Textarea
+								accessibilityLabel="Deine Einschätzung"
+								className="min-h-32"
+								editable={!isSubmitting}
+								onChangeText={onChange}
+								placeholder="Schreibe deinen ersten Gedanken auf."
+								value={value}
+							/>
+						</View>
+					</View>
+					{errorMessage ? <ErrorMessage>{errorMessage}</ErrorMessage> : null}
+				</Animated.View>
+			</ScrollView>
+
+			<View
+				className="flex-row gap-3 border-border border-t bg-card px-6 pt-4"
+				// Footer padding depends on the device safe area.
+				style={{ paddingBottom: Math.max(insets.bottom, 16) }}
+			>
+				<Button
+					accessibilityHint="Überspringt die eigene Einschätzung und zeigt die Erklärung."
+					className="flex-1 px-4"
+					disabled={isSubmitting}
+					onPress={onSubmitUnknown}
+					variant="neutral"
+				>
+					<Text>Unsicher</Text>
+				</Button>
+				<Button
+					accessibilityHint="Speichert deine Einschätzung und zeigt direkt die Erklärung."
+					className="flex-[1.35] px-4"
+					disabled={isSubmitting || !value.trim()}
+					onPress={onSubmit}
+				>
+					{isSubmitting ? (
+						<ActivityIndicator color={DAYOVA_DESIGN_SYSTEM.colors.light1} />
+					) : (
+						<Text>Erklärung ansehen</Text>
+					)}
+				</Button>
+			</View>
+		</KeyboardAvoidingView>
 	);
 }
 
@@ -154,34 +338,7 @@ export function TheoryTopicPage({
 
 	return (
 		<View className="flex-1 bg-background">
-			<View className="border-border border-b bg-background px-6 py-5">
-				<View className="mb-3 flex-row items-center justify-between">
-					<Text
-						selectable
-						className="font-poppins font-semibold text-body-5 text-primary"
-					>
-						THEMA {currentIndex + 1}
-					</Text>
-					<Text
-						selectable
-						className="font-poppins text-body-5 text-secondary-text"
-						// Tabular counter alignment requires React Native's text style API.
-						style={{ fontVariant: ["tabular-nums"] }}
-					>
-						{currentIndex + 1} von {total}
-					</Text>
-				</View>
-				<FlowProgressBar
-					progress={(currentIndex + 1) / Math.max(total, 1)}
-					accessibilityRole="progressbar"
-					accessibilityValue={{
-						min: 1,
-						max: Math.max(total, 1),
-						now: currentIndex + 1,
-						text: `Thema ${currentIndex + 1} von ${total}`,
-					}}
-				/>
-			</View>
+			<TheoryTopicProgress currentIndex={currentIndex} total={total} />
 
 			<ScrollView
 				contentInsetAdjustmentBehavior="automatic"
@@ -197,15 +354,9 @@ export function TheoryTopicPage({
 					entering={reduceMotion ? undefined : FadeInDown.duration(220)}
 					className="gap-7"
 				>
-					<View className="gap-4">
-						<View className="flex-row items-start gap-4">
-							<Text
-								selectable
-								accessibilityRole="header"
-								className="flex-1 font-poppins font-semibold text-heading-2 text-text"
-							>
-								{topic.conceptTitle}
-							</Text>
+					<TheoryTopicIntroduction
+						topic={topic}
+						accessory={
 							<TouchableOpacity
 								accessibilityLabel={
 									isSpeaking ? "Vorlesen stoppen" : "Thema vorlesen"
@@ -231,28 +382,17 @@ export function TheoryTopicPage({
 									/>
 								)}
 							</TouchableOpacity>
-						</View>
-						<View className="rounded-[24px] bg-system-subtle px-5 py-5">
-							<Text className="font-poppins font-semibold text-body-4 text-primary">
-								Leitfrage
-							</Text>
-							<Text
-								selectable
-								className="mt-2 font-poppins font-semibold text-body-1 text-text"
-							>
-								{topic.question}
-							</Text>
-						</View>
-						{speechError ? (
-							<Text
-								selectable
-								accessibilityLiveRegion="polite"
-								className="font-poppins text-body-4 text-wrong"
-							>
-								{speechError}
-							</Text>
-						) : null}
-					</View>
+						}
+					/>
+					{speechError ? (
+						<Text
+							selectable
+							accessibilityLiveRegion="polite"
+							className="font-poppins text-body-4 text-wrong"
+						>
+							{speechError}
+						</Text>
+					) : null}
 
 					<View className="gap-4">
 						<TopicSectionTitle

--- a/src/features/learning-plans/theory-topic-page.ui.test.tsx
+++ b/src/features/learning-plans/theory-topic-page.ui.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { fireEvent, render } from "@testing-library/react-native";
+import { TheoryPredictionPage } from "./theory-topic-page";
+import type { SessionContentItem } from "./types";
+
+jest.mock("expo-router", () => ({
+	useFocusEffect: () => undefined,
+}));
+
+jest.mock("expo-speech", () => ({
+	maxSpeechInputLength: 4_000,
+	speak: jest.fn(),
+	stop: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock("react-native-reanimated", () => {
+	const Native =
+		jest.requireActual<typeof import("react-native")>("react-native");
+	return {
+		__esModule: true,
+		default: { View: Native.View },
+		FadeInDown: { duration: () => undefined },
+		LinearTransition: { duration: () => undefined },
+		useReducedMotion: () => true,
+	};
+});
+
+jest.mock("react-native-safe-area-context", () => ({
+	useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+jest.mock("~/lib/theme", () => ({
+	useDayovaTheme: () => ({
+		colors: {
+			light1: "#FFFFFF",
+			primary: "#00BAFF",
+			text: "#1A1A1A",
+		},
+	}),
+}));
+
+const theoryItem = {
+	id: "theory_1",
+	sessionId: "session_1",
+	phase: "theory",
+	kind: "learnCard",
+	title: "Schadensszenarien bewerten",
+	prompt: "Welche Option ermöglicht eine objektive Bewertung?",
+	explanation: "Betrachte mehrere Schadensszenarien systematisch.",
+	idealAnswer: "Alle relevanten Auswirkungen werden berücksichtigt.",
+	theoryContent: {
+		conceptTitle: "Schadensszenarien bewerten",
+		question: "Welche Option ermöglicht eine objektive Bewertung?",
+		explanation: "Betrachte mehrere Schadensszenarien systematisch.",
+		keyPoints: ["Materielle und immaterielle Schäden berücksichtigen."],
+		example: "Bewerte Betriebsunterbrechung und rechtliche Folgen.",
+		memoryCue: "Erst alle Auswirkungen betrachten, dann bewerten.",
+		commonMistake: "Nur den direkten finanziellen Schaden betrachten.",
+	},
+	choices: [],
+	learningBlockIndex: 0,
+	topicId: "topic_1",
+	questionAngle: "recognize",
+	coverageKey: "topic_1:recognize:0",
+	estimatedSeconds: 180,
+	sortOrder: 0,
+} as unknown as SessionContentItem;
+
+describe("theory prediction page", () => {
+	test("presents the question in the same topic hierarchy as its theory", async () => {
+		const onChange = jest.fn();
+		const onSubmit = jest.fn();
+		const onSubmitUnknown = jest.fn();
+		const screen = await render(
+			<TheoryPredictionPage
+				theoryItem={theoryItem}
+				currentIndex={0}
+				total={2}
+				value="Mehrere Auswirkungen vergleichen"
+				onChange={onChange}
+				onSubmit={onSubmit}
+				onSubmitUnknown={onSubmitUnknown}
+				isSubmitting={false}
+				errorMessage={null}
+			/>,
+		);
+
+		expect(screen.getByText("THEMA 1")).toBeOnTheScreen();
+		expect(screen.getByText("1 von 2")).toBeOnTheScreen();
+		expect(screen.getByText("Schadensszenarien bewerten")).toBeOnTheScreen();
+		expect(
+			screen.getByText("Welche Option ermöglicht eine objektive Bewertung?"),
+		).toBeOnTheScreen();
+		expect(screen.queryByText("Kurz-Check")).toBeNull();
+		expect(screen.queryByText("Noch nicht gewusst")).toBeNull();
+
+		await fireEvent.changeText(
+			screen.getByLabelText("Deine Einschätzung"),
+			"Mehrere Auswirkungen vergleichen",
+		);
+		expect(onChange).toHaveBeenCalledWith("Mehrere Auswirkungen vergleichen");
+
+		await fireEvent.press(screen.getByText("Unsicher"));
+		expect(onSubmitUnknown).toHaveBeenCalledTimes(1);
+		await fireEvent.press(screen.getByText("Erklärung ansehen"));
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/features/learning-plans/use-prepare-session-content.ts
+++ b/src/features/learning-plans/use-prepare-session-content.ts
@@ -1,0 +1,46 @@
+import { useMutation } from "convex/react";
+import { useEffect, useEffectEvent, useRef } from "react";
+import { api } from "#convex/_generated/api";
+import type { Id } from "#convex/_generated/dataModel";
+
+export function usePrepareSessionContent({
+	enabled,
+	sessionId,
+	onError,
+}: {
+	enabled: boolean;
+	sessionId: Id<"learningPlanSessions"> | undefined;
+	onError: (error: unknown) => void;
+}) {
+	const ensureSessionContent = useMutation(
+		api.learningSessionContent.ensureSessionContent,
+	);
+	const preparingSessionIdRef = useRef<Id<"learningPlanSessions"> | null>(null);
+	const preparedSessionIdRef = useRef<Id<"learningPlanSessions"> | null>(null);
+	const reportError = useEffectEvent(onError);
+
+	useEffect(() => {
+		if (
+			!enabled ||
+			!sessionId ||
+			preparingSessionIdRef.current === sessionId ||
+			preparedSessionIdRef.current === sessionId
+		) {
+			return;
+		}
+
+		preparingSessionIdRef.current = sessionId;
+		void ensureSessionContent({ sessionId })
+			.then(() => {
+				preparedSessionIdRef.current = sessionId;
+			})
+			.catch((error: unknown) => {
+				reportError(error);
+			})
+			.finally(() => {
+				if (preparingSessionIdRef.current === sessionId) {
+					preparingSessionIdRef.current = null;
+				}
+			});
+	}, [enabled, ensureSessionContent, sessionId]);
+}

--- a/src/features/learning-plans/use-prepare-session-content.ui.test.tsx
+++ b/src/features/learning-plans/use-prepare-session-content.ui.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { render, waitFor } from "@testing-library/react-native";
+import { View } from "react-native";
+import type { Id } from "#convex/_generated/dataModel";
+import { usePrepareSessionContent } from "./use-prepare-session-content";
+
+const mockEnsureSessionContent =
+	jest.fn<
+		(args: {
+			sessionId: Id<"learningPlanSessions">;
+		}) => Promise<{ itemCount: number }>
+	>();
+const mockUseMutation = jest.fn(
+	(_reference: unknown) => mockEnsureSessionContent,
+);
+
+jest.mock("convex/react", () => ({
+	useMutation: (reference: unknown) => mockUseMutation(reference),
+}));
+
+jest.mock("#convex/_generated/api", () => ({
+	api: {
+		learningSessionContent: {
+			ensureSessionContent: "fastEnsureSessionContent",
+		},
+	},
+}));
+
+function PreparationProbe({
+	enabled,
+	onError,
+}: {
+	enabled: boolean;
+	onError: (error: unknown) => void;
+}) {
+	usePrepareSessionContent({
+		enabled,
+		sessionId: "session_1" as Id<"learningPlanSessions">,
+		onError,
+	});
+	return <View />;
+}
+
+describe("session content preparation", () => {
+	test("uses the immediate Convex mutation once when the session opens", async () => {
+		mockEnsureSessionContent.mockResolvedValue({ itemCount: 4 });
+		const onError = jest.fn();
+
+		const screen = await render(<PreparationProbe enabled onError={onError} />);
+
+		await waitFor(() => {
+			expect(mockUseMutation).toHaveBeenCalledWith("fastEnsureSessionContent");
+			expect(mockEnsureSessionContent).toHaveBeenCalledWith({
+				sessionId: "session_1",
+			});
+		});
+		expect(mockEnsureSessionContent).toHaveBeenCalledTimes(1);
+		expect(onError).not.toHaveBeenCalled();
+
+		await screen.rerender(<PreparationProbe enabled onError={onError} />);
+		expect(mockEnsureSessionContent).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## What changed

- remove the AI action from the session-opening critical path and use the immediate deterministic Convex mutation
- keep AI generation prefetched from the learning-plan screen, with deterministic content as the fast fallback
- pair every theory topic with a short prediction question shown immediately before its explanation
- keep the topic number, concept title, guiding question, progress, and footer structure consistent between question and theory
- bypass right/wrong feedback and success haptics for pre-theory questions, and exclude those predictions from mastery evidence and session analysis
- complete split theory sessions as theory rather than routing learners into an exercise evaluation
- upgrade existing paired tasks to the new guiding-question format when a session is reopened
- remove the session-preview horizon labels and the displayed “Warum jetzt” rationale

## Why

Session opening previously waited for a full AI generation round trip. The paired practice flow also treated a learner's first attempt like a graded answer after teaching, which interrupted the theory rhythm and made question and explanation feel unrelated.

The revised flow captures a low-pressure first thought, then resolves the exact same guiding question in the theory view. It preserves the useful prediction signal without presenting missing prior knowledge as failure.

## Impact

Sessions render as soon as the deterministic Convex preparation returns. In split theory sessions, learners now move through:

`prediction question → matching theory → next topic`

The question and explanation share one topic hierarchy, no right/wrong result screen appears, and the final state remains “Theorie abgeschlossen.”

## Validation

- `pnpm test` — 92 Vitest files / 571 tests, 33 Jest suites / 97 tests, plus infrastructure tests
- `pnpm check`
- `pnpm format:check`
- `git diff --check`
- Convex dev deployment accepted the functions
- verified question → theory → next topic → theory completion, keyboard layout, and accessibility labels in the iOS 26.5 simulator