### PR TITLE
Make pre-theory questions easier to answer

### DIFF
--- a/convex/learningPlanAi.ts
+++ b/convex/learningPlanAi.ts
@@ -456,7 +456,7 @@ const generatedTheoryItemSchema = z.object({
 	),
 	question: germanTextSchema(
 		12,
-		"One natural German guiding question that the learner can answer directly. Never quote or restate an instruction inside another instruction.",
+		"One short German curiosity question shown before the theory. The learner has not seen the explanation yet and must be able to answer with an intuitive first guess. Ask one thing only. Never demand a definition, complete list, comparison, or step-by-step solution. Avoid specialist wording when everyday language works.",
 	),
 	explanation: germanTextSchema(
 		160,
@@ -2171,7 +2171,7 @@ ${personalLearningTimes}`,
 								abortSignal,
 								providerOptions: vertexProviderOptions,
 								output: Output.object({ schema: blockSchema }),
-								system: `Du bist ein präziser Lerncoach für Schüler der 10. bis 12. Klasse. Erstelle eigenständige Theorie-Lernseiten, die jeweils ungefähr vier Minuten Lernzeit sinnvoll füllen. Jede Seite behandelt genau einen Gedanken: eine kurze direkt beantwortbare Leitfrage, eine verständliche Erklärung in drei bis fünf zusammenhängenden Sätzen, zwei bis vier gehaltvolle Kernpunkte, ein wirklich durchgerechnetes oder konkret angewandtes Beispiel, einen eigenen Merksatz und einen fachspezifischen typischen Fehler. Beispiel, Kernpunkte und Merksatz müssen unterschiedliche Inhalte haben. Verwende keine Meta-Anweisungen, internen Labels wie „Variante 1“ oder in Anführungszeichen verschachtelte Aufgaben. Antworte ausschließlich im vorgegebenen JSON-Schema.${generatedTextRetrySystemInstruction(attempt)}`,
+								system: `Du bist ein präziser Lerncoach für Schüler der 10. bis 12. Klasse. Erstelle eigenständige Theorie-Lernseiten, die jeweils ungefähr vier Minuten Lernzeit sinnvoll füllen. Jede Seite behandelt genau einen Gedanken. Die Leitfrage wird dem Schüler vor der Erklärung als lockerer Kurz-Check gezeigt. Sie muss deshalb mit einer Vermutung oder einem ersten Gedanken beantwortbar sein, darf kein bereits gelerntes Fachwissen voraussetzen und weder eine Definition, vollständige Aufzählung, einen Vergleich noch einen schrittweisen Lösungsweg verlangen. Frage genau eine Sache in kurzer, natürlicher Alltagssprache. Danach folgen eine verständliche Erklärung in drei bis fünf zusammenhängenden Sätzen, zwei bis vier gehaltvolle Kernpunkte, ein wirklich durchgerechnetes oder konkret angewandtes Beispiel, ein eigener Merksatz und ein fachspezifischer typischer Fehler. Beispiel, Kernpunkte und Merksatz müssen unterschiedliche Inhalte haben. Verwende keine Meta-Anweisungen, internen Labels wie „Variante 1“ oder in Anführungszeichen verschachtelte Aufgaben. Antworte ausschließlich im vorgegebenen JSON-Schema.${generatedTextRetrySystemInstruction(attempt)}`,
 								messages: [{ role: "user", content: blockContent }],
 							}),
 						);
@@ -2450,7 +2450,7 @@ ${allPriorPrompts.map((prompt) => `- ${prompt}`).join("\n") || "Keine."}`,
 						output: Output.object({
 							schema: createTheoryTopicsSchema(allQuestions.length),
 						}),
-						system: `Du bist ein präziser Lerncoach. Erstelle eigenständige deutsche Theorie-Lernseiten mit Erklärung, Kernpunkten, einem konkreten Beispiel, Merksatz und typischem Fehler. Halte die vorgegebene Reihenfolge exakt ein und antworte ausschließlich im JSON-Schema.${generatedTextRetrySystemInstruction(attempt)}`,
+						system: `Du bist ein präziser Lerncoach. Erstelle eigenständige deutsche Theorie-Lernseiten mit Erklärung, Kernpunkten, einem konkreten Beispiel, Merksatz und typischem Fehler. Die Leitfrage wird vor der Erklärung gezeigt und muss ohne Vorwissen mit einer Vermutung oder einem ersten Gedanken beantwortbar sein. Sie fragt genau eine Sache in kurzer Alltagssprache und verlangt keine Definition, vollständige Aufzählung, keinen Vergleich und keinen schrittweisen Lösungsweg. Halte die vorgegebene Reihenfolge exakt ein und antworte ausschließlich im JSON-Schema.${generatedTextRetrySystemInstruction(attempt)}`,
 					}),
 				)
 			: await runLlmGeneration((abortSignal) =>

--- a/convex/learningSessionContent.test.ts
+++ b/convex/learningSessionContent.test.ts
@@ -200,6 +200,17 @@ test("theory fallback creates active recall cards instead of generic summaries",
 	for (const item of content?.items ?? []) {
 		expect(item.theoryContent?.example).not.toBe(item.theoryContent?.memoryCue);
 	}
+	const applicationQuestions =
+		content?.items.filter((item) => item.questionAngle === "apply") ?? [];
+	expect(applicationQuestions.length).toBeGreaterThan(0);
+	for (const item of applicationQuestions) {
+		expect(item.prompt).toBe(
+			`Was glaubst du: Worauf kommt es bei ${item.title} besonders an?`,
+		);
+	}
+	expect(content?.items.map((item) => item.prompt).join(" ")).not.toMatch(
+		/Schritt für Schritt|vollständige Aufzählung|wofür wird das Verfahren gebraucht/i,
+	);
 });
 
 test("opening an existing short theory session backfills its pre-check", async () => {
@@ -320,6 +331,61 @@ test("reopening a split theory session upgrades an existing paired task to the g
 		title: theoryItem.title,
 		prompt: theoryItem.theoryContent?.question ?? theoryItem.front,
 	});
+});
+
+test("reopening a theory session replaces demanding fallback questions", async () => {
+	const { t, sessionId } = await createGeneratedPlanWithSession(
+		"theory",
+		"split",
+	);
+	await t.mutation(api.learningSessionContent.ensureSessionContent, {
+		sessionId,
+	});
+	const before = await t.query(api.learningSessionContent.getSessionContent, {
+		sessionId,
+	});
+	const theoryItem = before?.items.find(
+		(item) => item.kind === "learnCard" && item.questionAngle === "apply",
+	);
+	if (!theoryItem?.theoryContent) {
+		throw new Error("Expected an application theory item.");
+	}
+	const theoryContent = theoryItem.theoryContent;
+	const pairedQuestion = before?.items.find(
+		(item) => item.coverageKey === `${theoryItem.coverageKey}:paired-practice`,
+	);
+	if (!pairedQuestion) throw new Error("Expected a paired theory question.");
+	const legacyQuestion = `Wie wendest du ${theoryItem.title} Schritt für Schritt an?`;
+
+	await t.run(async (ctx) => {
+		await ctx.db.patch("learningSessionContentItems", theoryItem.id, {
+			prompt: legacyQuestion,
+			front: legacyQuestion,
+			theoryContent: {
+				...theoryContent,
+				question: legacyQuestion,
+			},
+		});
+		await ctx.db.patch("learningSessionContentItems", pairedQuestion.id, {
+			prompt: legacyQuestion,
+		});
+	});
+
+	await t.mutation(api.learningSessionContent.ensureSessionContent, {
+		sessionId,
+	});
+	const after = await t.query(api.learningSessionContent.getSessionContent, {
+		sessionId,
+	});
+	const expectedQuestion = `Was glaubst du: Worauf kommt es bei ${theoryItem.title} besonders an?`;
+	expect(after?.items.find((item) => item.id === theoryItem.id)).toMatchObject({
+		prompt: expectedQuestion,
+		front: expectedQuestion,
+		theoryContent: { question: expectedQuestion },
+	});
+	expect(
+		after?.items.find((item) => item.id === pairedQuestion.id),
+	).toMatchObject({ prompt: expectedQuestion });
 });
 
 test("persists deferred and completed theory validation states", async () => {

--- a/convex/learningSessionContent.ts
+++ b/convex/learningSessionContent.ts
@@ -305,23 +305,61 @@ const getSessionTopics = (
 	});
 };
 
-const theoryQuestionFor = (blueprint: LearningQuestionBlueprint) => {
-	const topic = blueprint.topic.title;
-	switch (blueprint.angle) {
+const approachableTheoryQuestionFor = (angle: string, topic: string) => {
+	switch (angle) {
 		case "recall":
-			return `Was bedeutet ${topic}, und wofür wird das Verfahren gebraucht?`;
+			return `Was fällt dir zu ${topic} spontan ein?`;
 		case "recognize":
-			return `Woran erkennst du eine Aufgabe zu ${topic}?`;
+			return `In welcher Situation könnte das Thema ${topic} wichtig werden?`;
 		case "apply":
-			return `Wie wendest du ${topic} Schritt für Schritt an?`;
+			return `Was glaubst du: Worauf kommt es bei ${topic} besonders an?`;
 		case "findError":
-			return `Welcher Fehler passiert häufig bei ${topic}, und wie vermeidest du ihn?`;
+			return `Was könnte bei ${topic} leicht schiefgehen?`;
 		case "compare":
-			return `Worin unterscheiden sich zwei Lösungswege bei ${topic}?`;
+			return `Was macht für dich bei ${topic} einen guten Lösungsweg aus?`;
 		case "examTransfer":
-			return `Wie gehst du in einer Prüfungsaufgabe zu ${topic} vor?`;
+			return `Was wäre bei einer Prüfungsaufgabe zu ${topic} dein erster Gedanke?`;
+		default:
+			return null;
 	}
 };
+
+const obsoleteTheoryQuestionsFor = (angle: string, topic: string) => {
+	switch (angle) {
+		case "recall":
+			return [
+				`Was bedeutet ${topic}, und wofür wird das Verfahren gebraucht?`,
+				`Was verbindest du bisher mit ${topic}?`,
+			];
+		case "recognize":
+			return [
+				`Woran erkennst du eine Aufgabe zu ${topic}?`,
+				`Wann könnte ${topic} wichtig werden?`,
+			];
+		case "apply":
+			return [
+				`Wie wendest du ${topic} Schritt für Schritt an?`,
+				`Was würdest du bei ${topic} zuerst beachten?`,
+			];
+		case "findError":
+			return [
+				`Welcher Fehler passiert häufig bei ${topic}, und wie vermeidest du ihn?`,
+			];
+		case "compare":
+			return [
+				`Worin unterscheiden sich zwei Lösungswege bei ${topic}?`,
+				`Woran würdest du bei ${topic} einen guten Lösungsweg erkennen?`,
+			];
+		case "examTransfer":
+			return [`Wie gehst du in einer Prüfungsaufgabe zu ${topic} vor?`];
+		default:
+			return [];
+	}
+};
+
+const theoryQuestionFor = (blueprint: LearningQuestionBlueprint) =>
+	approachableTheoryQuestionFor(blueprint.angle, blueprint.topic.title) ??
+	`Was fällt dir zu ${blueprint.topic.title} als Erstes ein?`;
 
 const buildTheoryItems = (
 	plan: Doc<"learningPlans">,
@@ -781,6 +819,55 @@ const ensurePairedTheoryPracticeItems = async (
 	return existingItems;
 };
 
+const ensureApproachableTheoryQuestions = async (
+	ctx: MutationCtx,
+	session: Doc<"learningPlanSessions">,
+	existingItems: Doc<"learningSessionContentItems">[],
+) => {
+	if (session.phase !== "theory") return existingItems;
+
+	let updated = false;
+	for (const item of existingItems) {
+		if (item.kind !== "learnCard" || !item.questionAngle) continue;
+		const concept = item.theoryContent?.conceptTitle ?? item.title;
+		const obsoleteQuestions = obsoleteTheoryQuestionsFor(
+			item.questionAngle,
+			concept,
+		);
+		const approachableQuestion = approachableTheoryQuestionFor(
+			item.questionAngle,
+			concept,
+		);
+		if (obsoleteQuestions.length === 0 || !approachableQuestion) continue;
+		const containsLegacyQuestion = [
+			item.prompt,
+			item.front,
+			item.theoryContent?.question,
+		].some(
+			(value) =>
+				value !== undefined && obsoleteQuestions.includes(value.trim()),
+		);
+		if (!containsLegacyQuestion) continue;
+
+		await ctx.db.patch("learningSessionContentItems", item._id, {
+			prompt: approachableQuestion,
+			front: approachableQuestion,
+			...(item.theoryContent
+				? {
+						theoryContent: {
+							...item.theoryContent,
+							question: approachableQuestion,
+						},
+					}
+				: {}),
+			updatedAt: Date.now(),
+		});
+		updated = true;
+	}
+
+	return updated ? await listItems(ctx, session._id) : existingItems;
+};
+
 const ensureItemsForSession = async (
 	ctx: MutationCtx,
 	session: Doc<"learningPlanSessions">,
@@ -789,7 +876,12 @@ const ensureItemsForSession = async (
 	assertSessionIsCommitted(session);
 	const existingItems = await listItems(ctx, session._id);
 	if (existingItems.length > 0) {
-		return await ensurePairedTheoryPracticeItems(ctx, session, existingItems);
+		const upgradedItems = await ensureApproachableTheoryQuestions(
+			ctx,
+			session,
+			existingItems,
+		);
+		return await ensurePairedTheoryPracticeItems(ctx, session, upgradedItems);
 	}
 	if (session.sessionPurpose === "diagnostic") {
 		throwUserFacingError(


### PR DESCRIPTION
## Summary

- replace demanding fallback Leitfragen such as “Wie wendest du … Schritt für Schritt an?” with low-pressure opinion and first-thought prompts
- require future AI-generated theory questions to be answerable without seeing the theory first
- prohibit definitions, complete lists, comparisons, and step-by-step solutions in pre-theory questions
- upgrade already-created theory sessions in place while preserving their answer attempts
- keep the Kurz-Check prompt and following theory Leitfrage exactly synchronized

Example:

> Was glaubst du: Worauf kommt es bei IT-Sicherheit und Schadensszenarien besonders an?

## Validation

- `pnpm test` — 92 Vitest files / 571 tests plus UI and infrastructure suites
- `pnpm check`
- `pnpm format:check`
- `pnpm exec convex dev --once`
- `git diff --check`
- verified on iOS 26.5 simulator using the existing affected session:
  - legacy question upgraded on reopen
  - question is shown in the Kurz-Check UI
  - `Noch nicht` opens theory directly
  - the following Leitfrage matches exactly