### PR TITLE
Fix EAS app config module loading

### DIFF
--- a/app.config.cts
+++ b/app.config.cts
@@ -175,4 +175,4 @@ const config: ExpoConfig = {
 	},
 };
 
-export default config;
+module.exports = config;

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -12,7 +12,7 @@
 			"convex/**",
 			"plugins/**",
 			"scripts/**",
-			"app.config.ts",
+			"app.config.cts",
 			"babel.config.js",
 			"biome.jsonc",
 			"components.json",

--- a/docs/contexts/platform/CONTEXT.md
+++ b/docs/contexts/platform/CONTEXT.md
@@ -29,7 +29,7 @@ available while Expo bundles JavaScript:
 - `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY`
 - `EXPO_PUBLIC_CONVEX_URL`
 
-`app.config.ts` fails release config evaluation when either value is missing, so
+`app.config.cts` fails release config evaluation when either value is missing, so
 a broken artifact cannot ship and crash on startup. Set these in EAS/CI for the
 target environment before running production builds or publishing updates.
 
@@ -39,8 +39,16 @@ The mobile app reads these values through `src/lib/runtime-config.ts`, which use
 
 When adding a new required public app env, add it to `publicEnvSchema` in
 `src/lib/runtime-config.ts`. The app runtime fallback, tests, and
-`app.config.ts` release validation all derive their required-key list from that
+`app.config.cts` release validation all derive their required-key list from that
 schema.
+
+Keep the dynamic Expo config at `app.config.cts` and export it through
+`module.exports`. The config loads the shared TypeScript runtime validator with
+`require`, so the explicit CommonJS extension prevents Node and EAS Build from
+classifying the config as ESM and removing `require` from its module scope. A
+future ESM migration must convert the config and its imported TypeScript module
+as one change and keep `tests/app-config-loading.test.ts` green under Node's
+native TypeScript loader.
 
 PostHog validation analytics envs are optional public app envs:
 
@@ -167,7 +175,7 @@ while development builds retain watch mode.
 
 Dayova uses camera/photo upload for learning material and microphone/speech
 recognition for spoken answers. Keep these App Store privacy purpose strings in
-`app.config.ts`. If a local native `ios/Dayova/Info.plist` exists after
+`app.config.cts`. If a local native `ios/Dayova/Info.plist` exists after
 prebuild, keep it in sync too:
 
 - `NSMicrophoneUsageDescription`
@@ -175,7 +183,7 @@ prebuild, keep it in sync too:
 - `NSCameraUsageDescription`
 - `NSPhotoLibraryUsageDescription`
 
-`src/lib/ios-privacy-config.test.ts` always guards `app.config.ts` and also
+`tests/ios-privacy-config.test.ts` always guards `app.config.cts` and also
 checks the generated native plist when it exists. Run it before an iOS release
 build so App Store Connect does not reject the uploaded bundle for missing
 purpose strings.

--- a/modules/dayova-system-appearance/README.md
+++ b/modules/dayova-system-appearance/README.md
@@ -427,7 +427,7 @@ rebuild the app. A Metro reload cannot add native code to an existing binary.
 
 Check, in order:
 
-1. [`app.config.ts`](../../app.config.ts) still sets
+1. [`app.config.cts`](../../app.config.cts) still sets
    `userInterfaceStyle: "automatic"`.
 2. The stored Dayova preference is the expected Light, System, or Dark value.
 3. System mode passes `"unspecified"` to `Appearance.setColorScheme`.

--- a/plugins/withAndroidPackagingOptions.js
+++ b/plugins/withAndroidPackagingOptions.js
@@ -23,7 +23,7 @@ const { withGradleProperties } = require("expo/config-plugins");
 //   .\gradlew.bat ":app:mergeDebugJavaResource" "--rerun-tasks" `
 //     "-Pandroid.packagingOptions.excludes=" "--stacktrace"
 //
-// If that succeeds, remove this plugin from app.config.ts, delete this file, then run
+// If that succeeds, remove this plugin from app.config.cts, delete this file, then run
 // the normal Android debug build to confirm the full app still assembles.
 const DUPLICATE_OSGI_MANIFEST = "META-INF/versions/9/OSGI-INF/MANIFEST.MF";
 

--- a/src/components/ui/android-material-controls.test.ts
+++ b/src/components/ui/android-material-controls.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import type { ExpoConfig } from "expo/config";
 import { describe, expect, test } from "vitest";
 import {
 	fromMaterialDatePickerDate,
@@ -42,19 +43,22 @@ describe("Android Material controls", () => {
 		]).toEqual([2012, 8, 9, 16, 44, 12, 34]);
 	});
 
-	test("keep native Android fallback colors aligned with the design system", async () => {
+	test("keep native Android fallback colors aligned with the design system", () => {
 		const previousAppVariant = process.env.APP_VARIANT;
 		process.env.APP_VARIANT = "development";
 
-		const appConfig = await import("../../../app.config")
-			.then((module) => module.default)
-			.finally(() => {
-				if (previousAppVariant === undefined) {
-					delete process.env.APP_VARIANT;
-				} else {
-					process.env.APP_VARIANT = previousAppVariant;
-				}
-			});
+		let appConfig: ExpoConfig;
+		try {
+			const appConfigPath = require.resolve("../../../app.config.cts");
+			delete require.cache[appConfigPath];
+			appConfig = require(appConfigPath) as ExpoConfig;
+		} finally {
+			if (previousAppVariant === undefined) {
+				delete process.env.APP_VARIANT;
+			} else {
+				process.env.APP_VARIANT = previousAppVariant;
+			}
+		}
 
 		const pluginNames = (appConfig.plugins ?? []).map((plugin) =>
 			Array.isArray(plugin) ? plugin[0] : plugin,

--- a/src/lib/android-gradle-config.test.ts
+++ b/src/lib/android-gradle-config.test.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
-import { describe, expect, test, vi } from "vitest";
+import type { ExpoConfig } from "expo/config";
+import { describe, expect, test } from "vitest";
 
 const require = createRequire(import.meta.url);
 const { applyAndroidGradleJvmMemory, DAYOVA_GRADLE_JVM_ARGS } =
@@ -50,20 +51,22 @@ describe("Android Gradle build configuration", () => {
 		]);
 	});
 
-	test("registers the memory plugin in the Expo config", async () => {
+	test("registers the memory plugin in the Expo config", () => {
 		const previousAppVariant = process.env.APP_VARIANT;
-		vi.resetModules();
 		process.env.APP_VARIANT = "development";
 
-		const appConfig = await import("../../app.config")
-			.then((module) => module.default)
-			.finally(() => {
-				if (previousAppVariant === undefined) {
-					delete process.env.APP_VARIANT;
-				} else {
-					process.env.APP_VARIANT = previousAppVariant;
-				}
-			});
+		let appConfig: ExpoConfig;
+		try {
+			const appConfigPath = require.resolve("../../app.config.cts");
+			delete require.cache[appConfigPath];
+			appConfig = require(appConfigPath) as ExpoConfig;
+		} finally {
+			if (previousAppVariant === undefined) {
+				delete process.env.APP_VARIANT;
+			} else {
+				process.env.APP_VARIANT = previousAppVariant;
+			}
+		}
 		const pluginNames = (appConfig.plugins ?? []).map((plugin) =>
 			Array.isArray(plugin) ? plugin[0] : plugin,
 		);

--- a/src/lib/theme-css.test.ts
+++ b/src/lib/theme-css.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./theme-variables";
 
 const GLOBAL_CSS_PATH = resolve(process.cwd(), "src/global.css");
-const APP_CONFIG_PATH = resolve(process.cwd(), "app.config.ts");
+const APP_CONFIG_PATH = resolve(process.cwd(), "app.config.cts");
 const THEME_PROVIDER_PATH = resolve(process.cwd(), "src/lib/theme.ts");
 
 describe("theme CSS", () => {

--- a/tests/app-config-loading.test.ts
+++ b/tests/app-config-loading.test.ts
@@ -1,0 +1,38 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const APP_CONFIG_PATH = ["app.config.cts", "app.config.ts"]
+	.map((filename) => resolve(process.cwd(), filename))
+	.find(existsSync);
+
+describe("Expo app config loading", () => {
+	it("loads through Node's native TypeScript loader without mixing module formats", () => {
+		expect(APP_CONFIG_PATH).toBeDefined();
+
+		const result = spawnSync(
+			process.execPath,
+			[
+				"--experimental-strip-types",
+				"--input-type=module",
+				"--eval",
+				`await import(${JSON.stringify(pathToFileURL(APP_CONFIG_PATH ?? "").href)})`,
+			],
+			{
+				cwd: process.cwd(),
+				encoding: "utf8",
+				env: {
+					...process.env,
+					APP_VARIANT: "preview",
+				},
+			},
+		);
+
+		expect(result.stderr).not.toContain(
+			"require is not defined in ES module scope",
+		);
+		expect(result.status, result.stderr).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

- lock the dynamic Expo config to CommonJS with `app.config.cts`
- export through `module.exports` so EAS cannot evaluate `require` in ESM scope
- add a native Node TypeScript-loader regression test and update config references

## Root cause

`app.config.ts` mixed `export default` with `require(...)`. The EAS worker classified the file as ESM, where `require` is unavailable, and failed before native compilation.

## Validation

- `pnpm check`
- full Vitest, Node test, and Jest test suites in an isolated worktree at commit `280cd0d`
- `APP_VARIANT=preview expo config --type public --json`
- focused Expo config tests: 13 passed

## EAS build proof

- [Android preview build `ad98c377`](https://expo.dev/accounts/dayova/projects/dayova/builds/ad98c377-b336-47f3-b643-2f15f032c563) from commit `280cd0d`
- The original module-loading error is fixed remotely: EAS transpiled `app.config.cts` to CommonJS and reached `validatePublicEnvForRelease`; `require is not defined` no longer occurs.
- The build then stopped on a separate configuration blocker: the EAS `preview` environment has no variables, so the required Clerk, Convex, RevenueCat, and legal/support public values are unavailable.

The PR remains draft until the preview environment is populated and a full proof build succeeds.