### PR TITLE
Implement practice-first learning flow

### DIFF
--- a/convex/adaptiveLearningPlan.ts
+++ b/convex/adaptiveLearningPlan.ts
@@ -539,7 +539,7 @@ export const advanceRollingLearningPlan = async (
 					createdAt: Date.now() + 1,
 				},
 			],
-			history,
+			history: projectedHistory,
 		}) ??
 		selectAdaptiveMaintenanceTarget({
 			topics,

--- a/convex/adaptiveLearningPlanPolicy.test.ts
+++ b/convex/adaptiveLearningPlanPolicy.test.ts
@@ -68,6 +68,27 @@ describe("adaptive learning plan policy", () => {
 		});
 	});
 
+	test("moves from one theory exposure to guided practice for the same topic", () => {
+		expect(
+			selectNextAdaptiveLearningTarget({
+				topics,
+				initialReadiness: [],
+				evidence: [],
+				history: [
+					{
+						topicId: "steigung",
+						dimension: "understanding",
+						targetedAt: 1,
+					},
+				],
+			}),
+		).toMatchObject({
+			topicId: "steigung",
+			dimension: "problemSolving",
+			phase: "practice",
+		});
+	});
+
 	test("uses independent work after repeated problem-solving success", () => {
 		const attempts = [
 			evidence({

--- a/convex/adaptiveLearningPlanPolicy.ts
+++ b/convex/adaptiveLearningPlanPolicy.ts
@@ -123,9 +123,9 @@ const reasonForTarget = (
 		return `Kontrollcheck: Neue Evidenz zu „${topicTitle}“ widerspricht früheren sicheren Lösungen.`;
 	}
 	if (status === "unknown") {
-		return `Warum jetzt: Für „${topicTitle}“ fehlt noch Evidenz im ${dimensionLabel[dimension]}.`;
+		return `Für „${topicTitle}“ fehlt noch Evidenz im ${dimensionLabel[dimension]}.`;
 	}
-	return `Warum jetzt: „${topicTitle}“ ist im ${dimensionLabel[dimension]} noch nicht stabil.`;
+	return `„${topicTitle}“ ist im ${dimensionLabel[dimension]} noch nicht stabil.`;
 };
 
 export const selectNextAdaptiveLearningTarget = (args: {
@@ -149,6 +149,13 @@ export const selectNextAdaptiveLearningTarget = (args: {
 			Math.max(latestTargetedAtByKey.get(key) ?? 0, entry.targetedAt),
 		);
 	}
+	const latestHistoryEntry = (args.history ?? []).reduce<
+		AdaptiveTargetHistory | undefined
+	>(
+		(latest, entry) =>
+			!latest || entry.targetedAt > latest.targetedAt ? entry : latest,
+		undefined,
+	);
 	const excludedTargetKeys = new Set(args.excludeTargetKeys ?? []);
 	const candidates = args.topics.flatMap((topic) => {
 		const requiredDimensions = topic.requiredEvidenceDimensions?.length
@@ -162,12 +169,20 @@ export const selectNextAdaptiveLearningTarget = (args: {
 		return requiredDimensions.flatMap((dimension) => {
 			const key = `${topic.id}:${dimension}`;
 			if (excludedTargetKeys.has(key)) return [];
+			const lastTargetedAt = latestTargetedAtByKey.get(key) ?? 0;
 			const dimensionStatus = deriveDimensionStatus({
 				dimension,
 				initialStatus: readinessByTopicId.get(topic.id) ?? "unknown",
 				evidence: topicEvidence,
 			});
 			if (dimensionStatus.status === "secure") return [];
+			if (
+				dimension === "understanding" &&
+				lastTargetedAt > 0 &&
+				!dimensionStatus.needsControlCheck
+			) {
+				return [];
+			}
 			const status: "unknown" | "developing" = dimensionStatus.status;
 
 			return [
@@ -176,7 +191,11 @@ export const selectNextAdaptiveLearningTarget = (args: {
 					dimension,
 					...dimensionStatus,
 					status,
-					lastTargetedAt: latestTargetedAtByKey.get(key) ?? 0,
+					lastTargetedAt,
+					isImmediateGuidedFollowUp:
+						latestHistoryEntry?.dimension === "understanding" &&
+						latestHistoryEntry.topicId === topic.id &&
+						dimension === "problemSolving",
 				},
 			];
 		});
@@ -185,6 +204,8 @@ export const selectNextAdaptiveLearningTarget = (args: {
 	candidates.sort(
 		(left, right) =>
 			Number(right.needsControlCheck) - Number(left.needsControlCheck) ||
+			Number(right.isImmediateGuidedFollowUp) -
+				Number(left.isImmediateGuidedFollowUp) ||
 			priorityRank[left.topic.priority] - priorityRank[right.topic.priority] ||
 			dimensionRank[left.dimension] - dimensionRank[right.dimension] ||
 			left.lastTargetedAt - right.lastTargetedAt ||
@@ -261,7 +282,7 @@ export const selectAdaptiveMaintenanceTarget = (args: {
 		phase: phaseForDimension[selected.dimension],
 		status: "developing",
 		needsControlCheck: false,
-		reason: `Warum jetzt: „${selected.topic.title}“ wird bis zur Prüfung mit einer kurzen Wiederholung sicher gehalten.`,
+		reason: `„${selected.topic.title}“ wird bis zur Prüfung mit einer kurzen Wiederholung sicher gehalten.`,
 	};
 };
 

--- a/convex/learningContentPlan.test.ts
+++ b/convex/learningContentPlan.test.ts
@@ -42,8 +42,8 @@ describe("learning content plan", () => {
 				questionCount: block.questions.length,
 			})),
 		).toEqual([
-			{ phase: "theory", durationMinutes: 10, questionCount: 3 },
-			{ phase: "theory", durationMinutes: 10, questionCount: 3 },
+			{ phase: "theory", durationMinutes: 10, questionCount: 4 },
+			{ phase: "theory", durationMinutes: 10, questionCount: 4 },
 			{ phase: "practice", durationMinutes: 10, questionCount: 2 },
 		]);
 
@@ -61,6 +61,44 @@ describe("learning content plan", () => {
 			block.questions.map((question) => question.coverageKey),
 		);
 		expect(new Set(coverageKeys).size).toBe(coverageKeys.length);
+	});
+
+	test("plans four short theory pages for a ten-minute session", () => {
+		const plan = createLearningContentPlan({
+			segments: [{ phase: "theory", durationMinutes: 10 }],
+			topics,
+		});
+
+		expect(plan.blocks).toHaveLength(1);
+		expect(plan.blocks[0]?.questions).toHaveLength(4);
+		expect(
+			plan.blocks[0]?.questions.reduce(
+				(total, question) => total + question.estimatedSeconds,
+				0,
+			),
+		).toBe(10 * 60);
+	});
+
+	test("plans three to four tasks for guided practice sessions", () => {
+		for (const [durationMinutes, expectedCount] of [
+			[15, 3],
+			[20, 4],
+		] as const) {
+			const plan = createLearningContentPlan({
+				segments: [{ phase: "practice", durationMinutes }],
+				topics,
+				maxBlockMinutes: 20,
+			});
+
+			expect(plan.blocks).toHaveLength(1);
+			expect(plan.blocks[0]?.questions).toHaveLength(expectedCount);
+			expect(
+				plan.blocks[0]?.questions.reduce(
+					(total, question) => total + question.estimatedSeconds,
+					0,
+				),
+			).toBe(durationMinutes * 60);
+		}
 	});
 
 	test("continues with uncovered questions instead of repeating a block", () => {

--- a/convex/learningContentPlan.ts
+++ b/convex/learningContentPlan.ts
@@ -70,7 +70,7 @@ const taskKinds: LearningQuestionKind[] = [
 ];
 
 const estimatedSecondsForKind: Record<LearningQuestionKind, number> = {
-	learnCard: 240,
+	learnCard: 150,
 	multipleChoice: 240,
 	written: 360,
 	voice: 300,
@@ -162,6 +162,13 @@ const createQuestions = ({
 	}
 
 	while (plannedSeconds < targetSeconds) {
+		const remainingSeconds = targetSeconds - plannedSeconds;
+		if (phase !== "theory" && questions.length > 0 && remainingSeconds < 120) {
+			const lastQuestion = questions.at(-1);
+			if (lastQuestion) lastQuestion.estimatedSeconds += remainingSeconds;
+			plannedSeconds = targetSeconds;
+			break;
+		}
 		const globalIndex = questionIndex;
 		questionIndex += 1;
 		const topic = topics[globalIndex % topics.length];

--- a/convex/learningPlanAi.ts
+++ b/convex/learningPlanAi.ts
@@ -459,8 +459,8 @@ const generatedTheoryItemSchema = z.object({
 		"One short German curiosity question shown before the theory. The learner has not seen the explanation yet and must be able to answer with an intuitive first guess. Ask one thing only. Never demand a definition, complete list, comparison, or step-by-step solution. Avoid specialist wording when everyday language works.",
 	),
 	explanation: germanTextSchema(
-		160,
-		"Clear German teaching explanation in three to five connected sentences. Explain why the rule works, not only what the result is.",
+		110,
+		"Concise German teaching explanation in two to three connected sentences. Explain why the rule works, not only what the result is.",
 	),
 	keyPoints: boundedArray(
 		germanTextSchema(
@@ -468,7 +468,7 @@ const generatedTheoryItemSchema = z.object({
 			"One specific German key point that adds information and is not merely a keyword or a copy of another section.",
 		),
 		2,
-		4,
+		3,
 	),
 	example: germanTextSchema(
 		80,
@@ -1397,46 +1397,51 @@ const buildAdaptivePhaseSequence = (
 	const hasTheoryNeed =
 		preparation.topicReadiness.unknown > 0 ||
 		preparation.topicReadiness.developing > 0;
-	const theoryFragmentTarget = hasTheoryNeed
-		? Math.min(
-				8,
-				Math.max(
-					preparation.topicReadiness.unknown > 0 ? 3 : 1,
-					Math.round(
-						preparation.topicReadiness.unknown +
-							preparation.topicReadiness.developing * 0.5,
-					),
-				),
-			)
-		: 0;
-	const theoryFragmentsPerSlot = Math.max(
-		1,
-		Math.ceil(preparation.maxSessionMinutes / 10),
-	);
-	const theorySlotCount = Math.min(
-		Math.max(0, sessionCount - praxisSessionCount - 1),
-		Math.ceil(theoryFragmentTarget / theoryFragmentsPerSlot),
-	);
 	const rehearsalIndexes = new Set<number>();
 	for (let index = 0; index < praxisSessionCount; index += 1) {
 		const position =
 			praxisSessionCount === 1
 				? praxisEligibleIndexes.length - 1
 				: Math.round(
-						(index * (praxisEligibleIndexes.length - 1)) /
-							(praxisSessionCount - 1),
+						((index + 1) * (praxisEligibleIndexes.length - 1)) /
+							praxisSessionCount,
 					);
 		const sessionIndex = praxisEligibleIndexes[position];
 		if (sessionIndex !== undefined) rehearsalIndexes.add(sessionIndex);
 	}
-	let theorySlotsRemaining = theorySlotCount;
+	const learningIndexes = Array.from(
+		{ length: sessionCount },
+		(_, index) => index,
+	).filter((index) => !rehearsalIndexes.has(index));
+	const topicTheoryNeed =
+		preparation.topicReadiness.unknown +
+		Math.ceil(preparation.topicReadiness.developing / 2);
+	const theorySlotCount = hasTheoryNeed
+		? Math.min(
+				Math.max(0, learningIndexes.length - 1),
+				Math.max(1, Math.round(sessionCount * 0.22)),
+				topicTheoryNeed,
+			)
+		: 0;
+	const theoryIndexes = new Set<number>();
+	let lastTheoryIndex = -2;
+	for (let index = 0; index < theorySlotCount; index += 1) {
+		const preferredPosition = Math.floor(
+			(index * learningIndexes.length) / Math.max(theorySlotCount, 1),
+		);
+		const preferredIndex = learningIndexes[preferredPosition];
+		const selectedIndex = learningIndexes.find(
+			(candidate) =>
+				candidate >= (preferredIndex ?? 0) && candidate > lastTheoryIndex + 1,
+		);
+		if (selectedIndex === undefined) break;
+		theoryIndexes.add(selectedIndex);
+		lastTheoryIndex = selectedIndex;
+	}
 
 	return Array.from({ length: sessionCount }, (_, index) => {
 		if (rehearsalIndexes.has(index)) return "rehearsal";
-		if (theorySlotsRemaining > 0) {
-			theorySlotsRemaining -= 1;
-			return "theory";
-		}
+		if (theoryIndexes.has(index)) return "theory";
 		return "practice";
 	});
 };
@@ -1572,12 +1577,10 @@ const normalizeSessions = (
 			...fallbackContentByPhase.rehearsal,
 		},
 	};
-	const phaseBalancedSessions = adaptivePreparation
-		? scheduledSessions
-		: rebalanceLearningPhases({
-				sessions: scheduledSessions,
-				phaseFallbacks,
-			});
+	const phaseBalancedSessions = rebalanceLearningPhases({
+		sessions: scheduledSessions,
+		phaseFallbacks,
+	});
 	const normalizedSessions = splitLargeTheorySessions({
 		sessions: phaseBalancedSessions,
 		topics,
@@ -1794,17 +1797,10 @@ const formatPlanSequence = (
 	sessions.length === 0
 		? "Keine weiteren Sessions gespeichert."
 		: sessions
-				.map((session) => {
-					const confidence =
-						session.knowledgeValidationConfidence === "unsure"
-							? " · Selbsteinschätzung: unsicher"
-							: session.knowledgeValidationConfidence === "somewhatSure"
-								? " · Selbsteinschätzung: teilweise sicher"
-								: session.knowledgeValidationConfidence === "sure"
-									? " · Selbsteinschätzung: sicher"
-									: "";
-					return `${session.sortOrder + 1}. ${session.title} (${session.phase}): ${session.goal}${confidence}`;
-				})
+				.map(
+					(session) =>
+						`${session.sortOrder + 1}. ${session.title} (${session.phase}): ${session.goal}`,
+				)
 				.join("\n");
 
 const formatPriorTheoryCards = (
@@ -2171,7 +2167,7 @@ ${personalLearningTimes}`,
 								abortSignal,
 								providerOptions: vertexProviderOptions,
 								output: Output.object({ schema: blockSchema }),
-								system: `Du bist ein präziser Lerncoach für Schüler der 10. bis 12. Klasse. Erstelle eigenständige Theorie-Lernseiten, die jeweils ungefähr vier Minuten Lernzeit sinnvoll füllen. Jede Seite behandelt genau einen Gedanken. Die Leitfrage wird dem Schüler vor der Erklärung als lockerer Kurz-Check gezeigt. Sie muss deshalb mit einer Vermutung oder einem ersten Gedanken beantwortbar sein, darf kein bereits gelerntes Fachwissen voraussetzen und weder eine Definition, vollständige Aufzählung, einen Vergleich noch einen schrittweisen Lösungsweg verlangen. Frage genau eine Sache in kurzer, natürlicher Alltagssprache. Danach folgen eine verständliche Erklärung in drei bis fünf zusammenhängenden Sätzen, zwei bis vier gehaltvolle Kernpunkte, ein wirklich durchgerechnetes oder konkret angewandtes Beispiel, ein eigener Merksatz und ein fachspezifischer typischer Fehler. Beispiel, Kernpunkte und Merksatz müssen unterschiedliche Inhalte haben. Verwende keine Meta-Anweisungen, internen Labels wie „Variante 1“ oder in Anführungszeichen verschachtelte Aufgaben. Antworte ausschließlich im vorgegebenen JSON-Schema.${generatedTextRetrySystemInstruction(attempt)}`,
+								system: `Du bist ein präziser Lerncoach für Schüler der 10. bis 12. Klasse. Erstelle kompakte Theorie-Lernseiten, die jeweils ungefähr zwei Minuten Lernzeit sinnvoll füllen. Jede Seite behandelt genau einen Gedanken. Nur die Leitfrage der ersten Seite wird dem Schüler vor allen Erklärungen als lockerer Einstieg gezeigt; alle Seiten brauchen die Leitfrage weiterhin für die einheitliche Seitenstruktur. Sie muss mit einer Vermutung oder einem ersten Gedanken beantwortbar sein, darf kein bereits gelerntes Fachwissen voraussetzen und weder eine Definition, vollständige Aufzählung, einen Vergleich noch einen schrittweisen Lösungsweg verlangen. Frage genau eine Sache in kurzer, natürlicher Alltagssprache. Danach folgen eine verständliche Erklärung in zwei bis drei zusammenhängenden Sätzen, zwei bis drei gehaltvolle Kernpunkte, ein knappes durchgerechnetes oder konkret angewandtes Beispiel, ein eigener Merksatz und ein fachspezifischer typischer Fehler. Beispiel, Kernpunkte und Merksatz müssen unterschiedliche Inhalte haben. Verwende keine Meta-Anweisungen, internen Labels wie „Variante 1“ oder in Anführungszeichen verschachtelte Aufgaben. Antworte ausschließlich im vorgegebenen JSON-Schema.${generatedTextRetrySystemInstruction(attempt)}`,
 								messages: [{ role: "user", content: blockContent }],
 							}),
 						);
@@ -2450,7 +2446,7 @@ ${allPriorPrompts.map((prompt) => `- ${prompt}`).join("\n") || "Keine."}`,
 						output: Output.object({
 							schema: createTheoryTopicsSchema(allQuestions.length),
 						}),
-						system: `Du bist ein präziser Lerncoach. Erstelle eigenständige deutsche Theorie-Lernseiten mit Erklärung, Kernpunkten, einem konkreten Beispiel, Merksatz und typischem Fehler. Die Leitfrage wird vor der Erklärung gezeigt und muss ohne Vorwissen mit einer Vermutung oder einem ersten Gedanken beantwortbar sein. Sie fragt genau eine Sache in kurzer Alltagssprache und verlangt keine Definition, vollständige Aufzählung, keinen Vergleich und keinen schrittweisen Lösungsweg. Halte die vorgegebene Reihenfolge exakt ein und antworte ausschließlich im JSON-Schema.${generatedTextRetrySystemInstruction(attempt)}`,
+						system: `Du bist ein präziser Lerncoach. Erstelle kompakte deutsche Theorie-Lernseiten für ungefähr zwei Minuten Lernzeit mit einer Erklärung in zwei bis drei Sätzen, zwei bis drei Kernpunkten, einem konkreten Beispiel, Merksatz und typischem Fehler. Nur die Leitfrage der ersten Seite wird vor allen Erklärungen gezeigt; alle Seiten brauchen sie für die einheitliche Seitenstruktur. Sie muss ohne Vorwissen mit einer Vermutung oder einem ersten Gedanken beantwortbar sein, fragt genau eine Sache in kurzer Alltagssprache und verlangt keine Definition, vollständige Aufzählung, keinen Vergleich und keinen schrittweisen Lösungsweg. Halte die vorgegebene Reihenfolge exakt ein und antworte ausschließlich im JSON-Schema.${generatedTextRetrySystemInstruction(attempt)}`,
 					}),
 				)
 			: await runLlmGeneration((abortSignal) =>

--- a/convex/learningPlanAiScheduling.test.ts
+++ b/convex/learningPlanAiScheduling.test.ts
@@ -4,6 +4,48 @@ import { MISSING_LEARNING_TIMES_HINT } from "./learningPlanPlanningHints";
 
 const germanText = (text: string) => text;
 
+const expectPracticeFirstMix = (
+	sessions: Array<{
+		phase: "theory" | "practice" | "rehearsal";
+		durationMinutes: number;
+	}>,
+	totalMinutes: number,
+) => {
+	const minutesFor = (phase: "theory" | "practice" | "rehearsal") =>
+		sessions
+			.filter((session) => session.phase === phase)
+			.reduce((total, session) => total + session.durationMinutes, 0);
+	const theoryShare = minutesFor("theory") / totalMinutes;
+	const practiceShare = minutesFor("practice") / totalMinutes;
+	const rehearsalShare = minutesFor("rehearsal") / totalMinutes;
+
+	expect(theoryShare).toBeGreaterThanOrEqual(0.17);
+	expect(theoryShare).toBeLessThanOrEqual(0.29);
+	expect(practiceShare).toBeGreaterThanOrEqual(0.45);
+	expect(practiceShare).toBeLessThanOrEqual(0.64);
+	expect(rehearsalShare).toBeGreaterThanOrEqual(0.18);
+	expect(rehearsalShare).toBeLessThanOrEqual(0.27);
+	expect(
+		sessions.every(
+			(session, index) =>
+				session.phase !== "theory" || sessions[index - 1]?.phase !== "theory",
+		),
+	).toBe(true);
+	expect(
+		sessions
+			.filter((session) => session.phase === "theory")
+			.every((session) => session.durationMinutes <= 10),
+	).toBe(true);
+	expect(
+		sessions
+			.filter((session) => session.phase === "practice")
+			.every((session) => session.durationMinutes <= 20),
+	).toBe(true);
+	expect(
+		Math.min(...sessions.map((session) => session.durationMinutes)),
+	).toBeGreaterThanOrEqual(5);
+};
+
 describe("learning plan AI scheduling", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
@@ -54,12 +96,7 @@ describe("learning plan AI scheduling", () => {
 		expect(
 			Math.max(...result.sessions.map((session) => session.durationMinutes)),
 		).toBeLessThanOrEqual(20);
-		expect(
-			result.sessions.filter((session) => session.phase === "theory").length,
-		).toBeGreaterThanOrEqual(6);
-		expect(
-			result.sessions.filter((session) => session.phase === "rehearsal"),
-		).toHaveLength(2);
+		expectPracticeFirstMix(result.sessions, 240);
 		expect(
 			result.sessions.reduce(
 				(total, session) => total + session.durationMinutes,
@@ -96,12 +133,8 @@ describe("learning plan AI scheduling", () => {
 		);
 
 		expect(result.sessions.length).toBeGreaterThan(3);
-		expect(
-			result.sessions.some((session) => session.startTime === "17:20"),
-		).toBe(true);
-		expect(
-			result.sessions.some((session) => session.startTime === "17:40"),
-		).toBe(true);
+		expect(result.sessions.length).toBeGreaterThanOrEqual(3);
+		expectPracticeFirstMix(result.sessions, 60);
 		expect(
 			result.sessions.reduce(
 				(total, session) => total + session.durationMinutes,
@@ -230,11 +263,12 @@ describe("learning plan AI scheduling", () => {
 
 		expect(withLearningTimes.sessions.map((session) => session.phase)).toEqual([
 			"theory",
-			"theory",
-			"theory",
 			"practice",
 			"rehearsal",
 		]);
+		expect(
+			withLearningTimes.sessions.map((session) => session.durationMinutes),
+		).toEqual([10, 15, 5]);
 		expect(
 			withLearningTimes.sessions.reduce(
 				(total, session) => total + session.durationMinutes,
@@ -244,7 +278,7 @@ describe("learning plan AI scheduling", () => {
 		expect(withLearningTimes.sessions[0]).toMatchObject({
 			dateKey: "2026-06-04T00:00:00.000Z",
 			startTime: "17:00",
-			durationMinutes: 7,
+			durationMinutes: 10,
 		});
 		expect(withLearningTimes.planningHint).toBe("30/60 Min. geplant.");
 	});
@@ -298,48 +332,32 @@ describe("learning plan AI scheduling", () => {
 			],
 		);
 
-		expect(result.sessions).toHaveLength(5);
+		expect(result.sessions).toHaveLength(3);
 		expect(
 			result.sessions.map((session) => ({
 				phase: session.phase,
 				startTime: session.startTime,
 				durationMinutes: session.durationMinutes,
-				title: session.title,
 			})),
 		).toEqual([
 			{
 				phase: "theory",
 				startTime: "16:00",
-				durationMinutes: 7,
-				title: "CIDR und Masken",
-			},
-			{
-				phase: "theory",
-				startTime: "16:07",
-				durationMinutes: 7,
-				title: "Host-Bereiche",
-			},
-			{
-				phase: "theory",
-				startTime: "16:14",
-				durationMinutes: 6,
-				title: "Broadcast-Adressen",
+				durationMinutes: 10,
 			},
 			{
 				phase: "practice",
-				startTime: "16:20",
-				durationMinutes: 5,
-				title: "Übungsblock",
+				startTime: "16:10",
+				durationMinutes: 15,
 			},
 			{
 				phase: "rehearsal",
 				startTime: "16:25",
 				durationMinutes: 5,
-				title: "Praxis",
 			},
 		]);
 		expect(new Set(result.sessions.map((session) => session.goal)).size).toBe(
-			5,
+			3,
 		);
 		expect(result.planningHint).toBeUndefined();
 	});
@@ -384,14 +402,7 @@ describe("learning plan AI scheduling", () => {
 		);
 
 		expect(result.sessions.map((session) => session.durationMinutes)).toEqual([
-			10, 10, 10, 10, 10,
-		]);
-		expect(result.sessions.map((session) => session.startTime)).toEqual([
-			"16:00",
-			"16:10",
-			"16:20",
-			"16:00",
-			"16:10",
+			10, 20, 10, 10,
 		]);
 		expect(result.planningHint).toBeUndefined();
 	});
@@ -437,7 +448,7 @@ describe("learning plan AI scheduling", () => {
 		);
 
 		expect(result.sessions.map((session) => session.durationMinutes)).toEqual([
-			10, 10, 10, 10, 10,
+			10, 20, 10, 10,
 		]);
 		expect(result.planningHint).toBeUndefined();
 	});
@@ -467,16 +478,7 @@ describe("learning plan AI scheduling", () => {
 			60,
 		);
 
-		expect(result.sessions.map((session) => session.phase)).toEqual([
-			"theory",
-			"theory",
-			"theory",
-			"practice",
-			"rehearsal",
-		]);
-		expect(result.sessions.map((session) => session.durationMinutes)).toEqual([
-			10, 10, 10, 20, 10,
-		]);
+		expectPracticeFirstMix(result.sessions, 60);
 		expect(new Set(result.sessions.map((session) => session.goal)).size).toBe(
 			5,
 		);
@@ -508,16 +510,21 @@ describe("learning plan AI scheduling", () => {
 			30,
 		);
 
-		expect(result.sessions.map((session) => session.phase)).toEqual([
-			"theory",
-			"theory",
-			"theory",
-			"practice",
-			"rehearsal",
-		]);
-		expect(result.sessions.map((session) => session.durationMinutes)).toEqual([
-			7, 7, 6, 5, 5,
-		]);
+		expect(
+			result.sessions.reduce(
+				(total, session) => total + session.durationMinutes,
+				0,
+			),
+		).toBe(30);
+		expect(result.sessions[0]?.phase).toBe("theory");
+		expect(result.sessions.at(-1)?.phase).toBe("rehearsal");
+		expect(
+			result.sessions.every(
+				(session, index) =>
+					session.phase !== "theory" ||
+					result.sessions[index - 1]?.phase !== "theory",
+			),
+		).toBe(true);
 		expect(result.planningHint).toBeUndefined();
 	});
 
@@ -583,20 +590,10 @@ describe("learning plan AI scheduling", () => {
 		);
 
 		expect(result.sessions).toHaveLength(5);
-		expect(result.sessions).toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					dateKey: "2026-06-02T00:00:00.000Z",
-					startTime: "16:00",
-					durationMinutes: 10,
-				}),
-				expect.objectContaining({
-					dateKey: "2026-06-04T00:00:00.000Z",
-					startTime: "10:00",
-					durationMinutes: 20,
-				}),
-			]),
-		);
+		expect(
+			result.sessions.every((session) => !session.dateKey.includes("06-03")),
+		).toBe(true);
+		expectPracticeFirstMix(result.sessions, 60);
 		expect(result.planningHint).toBe(
 			"Belegte Zeiten ausgelassen. 60/270 Min. geplant.",
 		);
@@ -630,23 +627,7 @@ describe("learning plan AI scheduling", () => {
 			60,
 		);
 
-		expect(result.sessions.map((session) => session.phase)).toEqual([
-			"theory",
-			"theory",
-			"theory",
-			"practice",
-			"rehearsal",
-		]);
-		expect(result.sessions.map((session) => session.durationMinutes)).toEqual([
-			10, 10, 10, 20, 10,
-		]);
-		expect(result.sessions.map((session) => session.startTime)).toEqual([
-			"17:20",
-			"17:10",
-			"17:20",
-			"17:00",
-			"17:20",
-		]);
+		expectPracticeFirstMix(result.sessions, 60);
 		expect(result.planningHint).toBe("Belegte Zeiten ausgelassen.");
 	});
 
@@ -673,10 +654,10 @@ describe("learning plan AI scheduling", () => {
 			[],
 		);
 
-		expect(result.sessions).toHaveLength(5);
+		expect(result.sessions).toHaveLength(3);
 		expect(result.sessions[0]).toMatchObject({
 			startTime: "16:00",
-			durationMinutes: 7,
+			durationMinutes: 10,
 		});
 		expect(result.planningHint).toBe("30/180 Min. geplant.");
 	});
@@ -784,15 +765,7 @@ describe("learning plan AI scheduling", () => {
 			[],
 		);
 
-		expect(result.sessions.map((session) => session.phase)).toEqual([
-			"theory",
-			"theory",
-			"theory",
-			"practice",
-			"practice",
-			"practice",
-			"rehearsal",
-		]);
+		expectPracticeFirstMix(result.sessions, 120);
 		expect(result.planningHint).toBe("120/240 Min. geplant.");
 	});
 
@@ -824,17 +797,13 @@ describe("learning plan AI scheduling", () => {
 			[],
 		);
 
-		expect(result.sessions.map((session) => session.phase)).toEqual([
-			"theory",
-			"theory",
-			"theory",
-			"practice",
-			"practice",
-			"practice",
-			"rehearsal",
-		]);
-		expect(result.sessions[3]?.title).toBe("Übungsblock");
-		expect(result.sessions[6]?.title).toBe("Praxis");
+		expectPracticeFirstMix(result.sessions, 120);
+		expect(
+			result.sessions.some((session) => session.title === "Übungsblock"),
+		).toBe(true);
+		expect(result.sessions.some((session) => session.title === "Praxis")).toBe(
+			true,
+		);
 		expect(result.planningHint).toBeUndefined();
 	});
 
@@ -867,11 +836,11 @@ describe("learning plan AI scheduling", () => {
 			[],
 		);
 
-		expect(result.sessions).toHaveLength(5);
+		expect(result.sessions).toHaveLength(3);
 		expect(result.sessions[0]).toMatchObject({
 			dateKey: "2026-06-05T00:00:00.000Z",
 			startTime: "09:00",
-			durationMinutes: 7,
+			durationMinutes: 10,
 		});
 	});
 

--- a/convex/learningPlans.test.ts
+++ b/convex/learningPlans.test.ts
@@ -501,7 +501,7 @@ test("keeps one committed and one provisional session in the rolling window", as
 	});
 	expect(initial?.sessions[1]).toMatchObject({
 		planningStatus: "provisional",
-		targetEvidenceDimension: "understanding",
+		targetEvidenceDimension: "problemSolving",
 	});
 	expect(initial?.sessions[1]?.contentGenerationStatus).toBeUndefined();
 	const provisionalSessionId = initial?.sessions[1]?.id;
@@ -546,7 +546,7 @@ test("keeps one committed and one provisional session in the rolling window", as
 	expect(
 		openSessions?.find((session) => session.planningStatus === "committed"),
 	).toMatchObject({
-		targetEvidenceDimension: "understanding",
+		targetEvidenceDimension: "problemSolving",
 		contentGenerationStatus: "queued",
 	});
 	const storedOpenSessions = await t.run(async (ctx) =>

--- a/convex/learningPlans.ts
+++ b/convex/learningPlans.ts
@@ -31,7 +31,7 @@ import {
 	getDefaultPreparationDepth,
 	type PreparationDepth,
 } from "./learningPreparationPolicy";
-import { getLearningSessionComposition } from "./learningSessionComposition";
+import { isLearningSessionCompositionEligible } from "./learningSessionComposition";
 import { deleteSessionLearningDataForSession } from "./learningSessionContent";
 import { alignSessionDurationReferences } from "./learningSessionDurationText";
 import {
@@ -1945,13 +1945,12 @@ export const replaceGeneratedSessions = internalMutation({
 				tasks: session.tasks.map((task) => normalizeGeneratedGermanText(task)),
 				expectedOutcome: normalizeGeneratedGermanText(session.expectedOutcome),
 				compositionVariant:
-					getLearningSessionComposition({
+					session.phase === "theory" &&
+					(args.sessionCompositionVariant ?? "split") === "split" &&
+					isLearningSessionCompositionEligible({
 						phase: session.phase,
 						durationMinutes: session.durationMinutes,
-						variant:
-							args.sessionCompositionVariant ??
-							(session.phase === "theory" ? "split" : "control"),
-					}).length > 1
+					})
 						? ("split" as const)
 						: ("control" as const),
 			}),
@@ -2001,6 +2000,13 @@ export const replaceGeneratedSessions = internalMutation({
 								rating: "correct",
 								sessionId: "projected-first-session",
 								createdAt: Date.now(),
+							},
+						],
+						history: [
+							{
+								topicId: firstTarget.topicId,
+								dimension: firstTarget.dimension,
+								targetedAt: Date.now(),
 							},
 						],
 					})

--- a/convex/learningSessionComposition.test.ts
+++ b/convex/learningSessionComposition.test.ts
@@ -15,17 +15,14 @@ describe("learning session composition", () => {
 		).toEqual([{ phase: "theory", durationMinutes: 30 }]);
 	});
 
-	test("starts a theory session with a three-minute knowledge check", () => {
+	test("keeps the full theory slot for the opener and theory pages", () => {
 		expect(
 			getLearningSessionComposition({
 				phase: "theory",
 				durationMinutes: 20,
 				variant: "split",
 			}),
-		).toEqual([
-			{ phase: "practice", durationMinutes: 3 },
-			{ phase: "theory", durationMinutes: 17 },
-		]);
+		).toEqual([{ phase: "theory", durationMinutes: 20 }]);
 	});
 
 	test("does not alter short theory slots or non-theory phases", () => {

--- a/convex/learningSessionComposition.ts
+++ b/convex/learningSessionComposition.ts
@@ -6,7 +6,6 @@ export type LearningSessionSegment = {
 	durationMinutes: number;
 };
 
-export const THEORY_VALIDATION_MINUTES = 3;
 export const MINIMUM_THEORY_SESSION_MINUTES = 6;
 
 export const isLearningSessionCompositionEligible = ({
@@ -26,18 +25,6 @@ export const getLearningSessionComposition = ({
 	durationMinutes: number;
 	variant: LearningSessionCompositionVariant;
 }): LearningSessionSegment[] => {
-	if (
-		variant === "split" &&
-		isLearningSessionCompositionEligible({ phase, durationMinutes })
-	) {
-		return [
-			{ phase: "practice", durationMinutes: THEORY_VALIDATION_MINUTES },
-			{
-				phase: "theory",
-				durationMinutes: durationMinutes - THEORY_VALIDATION_MINUTES,
-			},
-		];
-	}
-
+	void variant;
 	return [{ phase, durationMinutes }];
 };

--- a/convex/learningSessionContent.test.ts
+++ b/convex/learningSessionContent.test.ts
@@ -167,7 +167,7 @@ test("theory fallback creates active recall cards instead of generic summaries",
 		sessionId,
 	});
 
-	expect(content?.items).toHaveLength(9);
+	expect(content?.items).toHaveLength(12);
 	expect(content?.items.every((item) => item.kind === "learnCard")).toBe(true);
 	expect(content?.items[0]).toMatchObject({
 		front: expect.stringContaining("?"),
@@ -240,7 +240,8 @@ test("opening an existing short theory session backfills its pre-check", async (
 	expect(
 		after?.items.filter(
 			(item) =>
-				item.phase === "practice" && item.coverageKey.includes(":validation:"),
+				item.phase === "practice" &&
+				item.coverageKey.endsWith(":paired-practice"),
 		),
 	).toHaveLength(1);
 	expect(
@@ -248,7 +249,7 @@ test("opening an existing short theory session backfills its pre-check", async (
 	).toContain(before?.items[0]?.front);
 });
 
-test("split fallback pairs every theory page with a related prediction question", async () => {
+test("split fallback adds one opening question for the first theory page", async () => {
 	const { t, sessionId } = await createGeneratedPlanWithSession(
 		"theory",
 		"split",
@@ -268,21 +269,17 @@ test("split fallback pairs every theory page with a related prediction question"
 		content?.items.filter((item) =>
 			item.coverageKey.endsWith(":paired-practice"),
 		) ?? [];
-	expect(theoryItems).toHaveLength(8);
-	expect(pairedPracticeItems).toHaveLength(theoryItems.length);
-	for (const theoryItem of theoryItems) {
-		const pairedQuestion = pairedPracticeItems.find(
-			(item) =>
-				item.coverageKey === `${theoryItem.coverageKey}:paired-practice`,
-		);
-		expect(pairedQuestion).toMatchObject({
-			phase: "practice",
-			kind: "written",
-			title: theoryItem.title,
-			topicId: theoryItem.topicId,
-			prompt: theoryItem.theoryContent?.question ?? theoryItem.front,
-		});
-	}
+	expect(theoryItems).toHaveLength(12);
+	expect(pairedPracticeItems).toHaveLength(1);
+	const firstTheoryItem = theoryItems[0];
+	expect(pairedPracticeItems[0]).toMatchObject({
+		phase: "practice",
+		kind: "written",
+		title: firstTheoryItem?.title,
+		topicId: firstTheoryItem?.topicId,
+		prompt: firstTheoryItem?.theoryContent?.question ?? firstTheoryItem?.front,
+		coverageKey: `${firstTheoryItem?.coverageKey}:paired-practice`,
+	});
 	expect(
 		content?.items.reduce((total, item) => total + item.estimatedSeconds, 0),
 	).toBe(30 * 60);
@@ -344,9 +341,7 @@ test("reopening a theory session replaces demanding fallback questions", async (
 	const before = await t.query(api.learningSessionContent.getSessionContent, {
 		sessionId,
 	});
-	const theoryItem = before?.items.find(
-		(item) => item.kind === "learnCard" && item.questionAngle === "apply",
-	);
+	const theoryItem = before?.items.find((item) => item.kind === "learnCard");
 	if (!theoryItem?.theoryContent) {
 		throw new Error("Expected an application theory item.");
 	}
@@ -355,7 +350,7 @@ test("reopening a theory session replaces demanding fallback questions", async (
 		(item) => item.coverageKey === `${theoryItem.coverageKey}:paired-practice`,
 	);
 	if (!pairedQuestion) throw new Error("Expected a paired theory question.");
-	const legacyQuestion = `Wie wendest du ${theoryItem.title} Schritt für Schritt an?`;
+	const legacyQuestion = `Was bedeutet ${theoryItem.title}, und wofür wird das Verfahren gebraucht?`;
 
 	await t.run(async (ctx) => {
 		await ctx.db.patch("learningSessionContentItems", theoryItem.id, {
@@ -377,7 +372,7 @@ test("reopening a theory session replaces demanding fallback questions", async (
 	const after = await t.query(api.learningSessionContent.getSessionContent, {
 		sessionId,
 	});
-	const expectedQuestion = `Was glaubst du: Worauf kommt es bei ${theoryItem.title} besonders an?`;
+	const expectedQuestion = `Was fällt dir zu ${theoryItem.title} spontan ein?`;
 	expect(after?.items.find((item) => item.id === theoryItem.id)).toMatchObject({
 		prompt: expectedQuestion,
 		front: expectedQuestion,
@@ -417,10 +412,7 @@ test("persists deferred and completed theory validation states", async () => {
 
 	const validationItems =
 		deferred?.items.filter((item) => item.phase === "practice") ?? [];
-	expect(validationItems).toHaveLength(
-		(deferred?.items.filter((item) => item.kind === "learnCard").length ?? 0) +
-			1,
-	);
+	expect(validationItems).toHaveLength(1);
 	for (const item of validationItems) {
 		await t.mutation(api.learningSessionContent.submitAnswer, {
 			itemId: item.id,
@@ -472,13 +464,13 @@ test("continue learning appends a fresh timed block", async () => {
 
 	expect(extension).toMatchObject({
 		firstNewItemIndex: existingItemCount,
-		addedItemCount: 3,
+		addedItemCount: 2,
 		durationMinutes: 10,
 	});
 	expect(
 		after?.items.slice(0, existingItemCount).map((item) => item.id),
 	).toEqual(before?.items.map((item) => item.id));
-	expect(newItems.every((item) => item.learningBlockIndex === 4)).toBe(true);
+	expect(newItems.every((item) => item.learningBlockIndex === 3)).toBe(true);
 	expect(
 		newItems.some((item) => existingCoverageKeys.includes(item.coverageKey)),
 	).toBe(false);
@@ -500,8 +492,8 @@ test("continue learning appends a fresh timed block", async () => {
 	);
 
 	expect(secondExtension).toMatchObject({
-		firstNewItemIndex: existingItemCount + 3,
-		addedItemCount: 3,
+		firstNewItemIndex: existingItemCount + 2,
+		addedItemCount: 2,
 	});
 	expect(duplicatePrompts).toEqual([]);
 });
@@ -540,7 +532,7 @@ test("existing theory cards remain readable without structured topic content", a
 	expect(content?.items[0]?.theoryContent).toBeUndefined();
 });
 
-test("AI theory content gains a practical segment for split sessions", async () => {
+test("AI theory content gains one opening question for split sessions", async () => {
 	const { t, sessionId } = await createGeneratedPlanWithSession(
 		"theory",
 		"split",
@@ -575,7 +567,7 @@ test("AI theory content gains a practical segment for split sessions", async () 
 	).toHaveLength(1);
 	expect(
 		content?.items.filter((item) => item.coverageKey.includes(":validation:")),
-	).toHaveLength(1);
+	).toHaveLength(0);
 });
 
 test("practice fallback creates concrete guided practice tasks", async () => {
@@ -589,7 +581,7 @@ test("practice fallback creates concrete guided practice tasks", async () => {
 	});
 	const prompts = content?.items.map((item) => item.prompt).join(" ") ?? "";
 
-	expect(content?.items).toHaveLength(8);
+	expect(content?.items).toHaveLength(6);
 	expect(content?.items.slice(0, 6).map((item) => item.kind)).toEqual([
 		"multipleChoice",
 		"written",
@@ -715,7 +707,7 @@ test("praxis fallback creates generalprobe tasks without generic strategy prompt
 	const prompts = content?.items.map((item) => item.prompt).join(" ") ?? "";
 
 	expect(content?.praxisDurationSeconds).toBe(30 * 60);
-	expect(content?.items).toHaveLength(8);
+	expect(content?.items).toHaveLength(6);
 	expect(prompts).toContain("Generalprobe");
 	expect(prompts).not.toContain("Welche Strategie passt");
 });

--- a/convex/learningSessionContent.ts
+++ b/convex/learningSessionContent.ts
@@ -592,6 +592,10 @@ const pairGeneratedTheoryItems = (
 	if (session.phase !== "theory" || session.compositionVariant !== "split") {
 		return items;
 	}
+	const firstTheoryItem = items.find((item) => item.kind === "learnCard");
+	if (!firstTheoryItem) return items;
+	const openingQuestionCoverageKey =
+		getPairedPracticeCoverageKey(firstTheoryItem);
 	const existingPairKeys = new Set(
 		items
 			.filter(
@@ -603,9 +607,8 @@ const pairGeneratedTheoryItems = (
 	);
 
 	return items.flatMap((item) => {
-		if (item.kind !== "learnCard") return [item];
-		const pairedCoverageKey = getPairedPracticeCoverageKey(item);
-		if (existingPairKeys.has(pairedCoverageKey)) return [item];
+		if (item !== firstTheoryItem) return [item];
+		if (existingPairKeys.has(openingQuestionCoverageKey)) return [item];
 		const { theorySeconds } = splitTheoryPageSeconds(item.estimatedSeconds);
 		return [
 			{ ...item, estimatedSeconds: theorySeconds },
@@ -730,9 +733,8 @@ const ensurePairedTheoryPracticeItems = async (
 	);
 	const missingPracticeItems: GeneratedItem[] = [];
 	let updatedExistingPair = false;
-	for (const theoryItem of existingItems.filter(
-		(item) => item.kind === "learnCard",
-	)) {
+	const theoryItem = existingItems.find((item) => item.kind === "learnCard");
+	if (theoryItem) {
 		const pairedCoverageKey = getPairedPracticeCoverageKey(theoryItem);
 		const existingPair = existingPairByCoverageKey.get(pairedCoverageKey);
 		if (existingPair) {
@@ -773,37 +775,37 @@ const ensurePairedTheoryPracticeItems = async (
 				});
 				updatedExistingPair = true;
 			}
-			continue;
+		} else {
+			const { theorySeconds } = splitTheoryPageSeconds(
+				theoryItem.estimatedSeconds,
+			);
+			await ctx.db.patch("learningSessionContentItems", theoryItem._id, {
+				estimatedSeconds: theorySeconds,
+				updatedAt: Date.now(),
+			});
+			missingPracticeItems.push(
+				buildPairedPracticeItem(session, {
+					phase: theoryItem.phase,
+					kind: theoryItem.kind,
+					title: theoryItem.title,
+					prompt: theoryItem.prompt,
+					front: theoryItem.front,
+					back: theoryItem.back,
+					explanation: theoryItem.explanation,
+					idealAnswer: theoryItem.idealAnswer,
+					theoryContent: theoryItem.theoryContent,
+					choices: theoryItem.choices,
+					correctChoiceId: theoryItem.correctChoiceId,
+					evaluationKeywords: theoryItem.evaluationKeywords,
+					learningBlockIndex: theoryItem.learningBlockIndex,
+					topicId: theoryItem.topicId,
+					evidenceDimension: theoryItem.evidenceDimension,
+					questionAngle: theoryItem.questionAngle,
+					coverageKey: theoryItem.coverageKey,
+					estimatedSeconds: theoryItem.estimatedSeconds,
+				}),
+			);
 		}
-		const { theorySeconds } = splitTheoryPageSeconds(
-			theoryItem.estimatedSeconds,
-		);
-		await ctx.db.patch("learningSessionContentItems", theoryItem._id, {
-			estimatedSeconds: theorySeconds,
-			updatedAt: Date.now(),
-		});
-		missingPracticeItems.push(
-			buildPairedPracticeItem(session, {
-				phase: theoryItem.phase,
-				kind: theoryItem.kind,
-				title: theoryItem.title,
-				prompt: theoryItem.prompt,
-				front: theoryItem.front,
-				back: theoryItem.back,
-				explanation: theoryItem.explanation,
-				idealAnswer: theoryItem.idealAnswer,
-				theoryContent: theoryItem.theoryContent,
-				choices: theoryItem.choices,
-				correctChoiceId: theoryItem.correctChoiceId,
-				evaluationKeywords: theoryItem.evaluationKeywords,
-				learningBlockIndex: theoryItem.learningBlockIndex,
-				topicId: theoryItem.topicId,
-				evidenceDimension: theoryItem.evidenceDimension,
-				questionAngle: theoryItem.questionAngle,
-				coverageKey: theoryItem.coverageKey,
-				estimatedSeconds: theoryItem.estimatedSeconds,
-			}),
-		);
 	}
 
 	if (missingPracticeItems.length > 0) {
@@ -1043,9 +1045,7 @@ const isLegacyTaskItem = (item: Doc<"learningSessionContentItems">) =>
 		item.explanation.includes("Prüfungsnah ist die Antwort"));
 
 const isTheoryKnowledgeCheckItem = (item: Doc<"learningSessionContentItems">) =>
-	item.phase === "practice" &&
-	item.kind !== "learnCard" &&
-	item.coverageKey?.includes(":validation:") === true;
+	isPairedTheoryQuestionItem(item);
 
 export const deleteSessionLearningDataForSession = async (
 	ctx: MutationCtx,
@@ -1205,7 +1205,7 @@ export const getSessionGenerationContext = internalQuery({
 			}
 		}
 
-		const theoryItems = existingItems.filter(
+		const firstTheoryItem = existingItems.find(
 			(item) => item.kind === "learnCard",
 		);
 		const pairedPracticeKeys = new Set(
@@ -1240,10 +1240,8 @@ export const getSessionGenerationContext = internalQuery({
 			existingItemCount: existingItems.length,
 			hasTheoryKnowledgeCheck: existingItems.some(isTheoryKnowledgeCheckItem),
 			hasCompleteTheoryPracticePairs:
-				theoryItems.length > 0 &&
-				theoryItems.every((item) =>
-					pairedPracticeKeys.has(getPairedPracticeCoverageKey(item)),
-				),
+				firstTheoryItem !== undefined &&
+				pairedPracticeKeys.has(getPairedPracticeCoverageKey(firstTheoryItem)),
 			needsLegacyContentReplacement:
 				existingItems.some(isLegacyTheoryItem) ||
 				existingItems.some(isLegacyTaskItem),
@@ -1262,11 +1260,6 @@ export const backfillTheoryKnowledgeCheck = internalMutation({
 			ownerTokenIdentifier,
 		);
 		assertSessionIsCommitted(session);
-		const plan = await getOwnedPlan(
-			ctx,
-			session.learningPlanId,
-			ownerTokenIdentifier,
-		);
 		const existingItems = await listItems(ctx, session._id);
 
 		if (session.completed) {
@@ -1280,50 +1273,6 @@ export const backfillTheoryKnowledgeCheck = internalMutation({
 			})
 		) {
 			return { itemCount: existingItems.length };
-		}
-
-		if (!existingItems.some(isTheoryKnowledgeCheckItem)) {
-			const firstTheoryItem = existingItems.find(
-				(item) => item.kind === "learnCard",
-			);
-			const checkItems: GeneratedItem[] = firstTheoryItem
-				? [
-						{
-							phase: "practice",
-							kind: "written",
-							title: "Vorwissenscheck",
-							prompt: `${firstTheoryItem.front ?? firstTheoryItem.prompt} Begründe deinen ersten Gedanken an einem konkreten Beispiel.`,
-							explanation: firstTheoryItem.explanation,
-							idealAnswer: firstTheoryItem.back ?? firstTheoryItem.idealAnswer,
-							evaluationKeywords: firstTheoryItem.evaluationKeywords,
-							learningBlockIndex: 0,
-							topicId: firstTheoryItem.topicId,
-							evidenceDimension: "understanding",
-							questionAngle: "apply",
-							coverageKey: `${firstTheoryItem.coverageKey ?? firstTheoryItem.topicId ?? "theory"}:validation:prior-knowledge`,
-							estimatedSeconds: 180,
-						},
-					]
-				: createLearningContentPlan({
-						segments: [{ phase: "practice", durationMinutes: 3 }],
-						topics: getSessionTopics(plan, session),
-					}).blocks.flatMap((block) =>
-						buildTaskItems(
-							plan,
-							{ ...session, phase: "practice", durationMinutes: 3 },
-							block.questions,
-						).map((item) => ({
-							...item,
-							phase: "practice" as const,
-							learningBlockIndex: 0,
-						})),
-					);
-			await insertGeneratedItemsForSession(
-				ctx,
-				session,
-				checkItems,
-				existingItems.length,
-			);
 		}
 
 		await ensurePairedTheoryPracticeItems(

--- a/convex/learningSessionSegmentation.test.ts
+++ b/convex/learningSessionSegmentation.test.ts
@@ -46,7 +46,7 @@ const session = ({
 	expectedOutcome: phaseFallbacks[phase].expectedOutcome,
 });
 
-test("turns two fragmented theory allocations into three short sessions", () => {
+test("keeps existing short theory allocations as separate sessions", () => {
 	const sessions = splitLargeTheorySessions({
 		sessions: [
 			session({ phase: "theory", startTime: "17:00", durationMinutes: 10 }),
@@ -63,10 +63,10 @@ test("turns two fragmented theory allocations into three short sessions", () => 
 		sessions
 			.filter((entry) => entry.phase === "theory")
 			.map((entry) => entry.durationMinutes),
-	).toEqual([5, 5, 10]);
+	).toEqual([10, 10]);
 });
 
-test("caps highly fragmented availability at five theory sessions", () => {
+test("rebalances a theory-heavy plan into an interleaved practice-first mix", () => {
 	const balanced = rebalanceLearningPhases({
 		sessions: [
 			...Array.from({ length: 6 }, (_, index) =>
@@ -88,8 +88,35 @@ test("caps highly fragmented availability at five theory sessions", () => {
 		maxTitleChars: 28,
 	});
 
-	expect(sessions.filter((entry) => entry.phase === "theory")).toHaveLength(5);
+	const minutesFor = (phase: "theory" | "practice" | "rehearsal") =>
+		sessions
+			.filter((entry) => entry.phase === phase)
+			.reduce((total, entry) => total + entry.durationMinutes, 0);
+	expect(minutesFor("theory")).toBe(15);
+	expect(minutesFor("practice")).toBe(30);
+	expect(minutesFor("rehearsal")).toBe(15);
+	expect(
+		sessions.every(
+			(entry, index) =>
+				entry.phase !== "theory" || sessions[index - 1]?.phase !== "theory",
+		),
+	).toBe(true);
 	expect(
 		sessions.reduce((total, entry) => total + entry.durationMinutes, 0),
 	).toBe(60);
+});
+
+test("preserves the available minutes when a short phase tail meets a short window tail", () => {
+	const sessions = [
+		session({ phase: "theory", startTime: "17:00", durationMinutes: 7 }),
+		session({ phase: "theory", startTime: "17:07", durationMinutes: 6 }),
+		session({ phase: "practice", startTime: "17:13", durationMinutes: 12 }),
+	];
+
+	const balanced = rebalanceLearningPhases({ sessions, phaseFallbacks });
+
+	expect(
+		balanced.reduce((total, entry) => total + entry.durationMinutes, 0),
+	).toBe(25);
+	expect(balanced.every((entry) => entry.durationMinutes >= 5)).toBe(true);
 });

--- a/convex/learningSessionSegmentation.ts
+++ b/convex/learningSessionSegmentation.ts
@@ -24,10 +24,12 @@ type PhaseMetadata = Pick<
 	"title" | "goal" | "tasks" | "expectedOutcome"
 >;
 
-const MIN_THEORY_SESSION_MINUTES = 5;
+const MIN_PHASE_SESSION_MINUTES = 5;
 const MAX_THEORY_SESSION_MINUTES = 10;
-const MIN_THEORY_SESSION_COUNT = 3;
-const MAX_THEORY_SESSION_COUNT = 5;
+const MAX_PRACTICE_SESSION_MINUTES = 20;
+const MAX_REHEARSAL_SESSION_MINUTES = 20;
+const TARGET_THEORY_SHARE = 0.22;
+const TARGET_REHEARSAL_SHARE = 0.22;
 
 const theorySessionStages = [
 	{ title: "Grundlagen", verb: "Erarbeite" },
@@ -46,62 +48,18 @@ const splitDurationEvenly = (durationMinutes: number, sessionCount: number) => {
 	);
 };
 
-const getTheoryDurationsBySession = ({
-	sessions,
-	maxSessions,
-}: {
-	sessions: SchedulableLearningSession<LearningSessionPhase>[];
-	maxSessions: number;
-}) => {
-	const theorySources = sessions
-		.map((session, index) => ({ session, index }))
-		.filter(({ session }) => session.phase === "theory");
-	const availableTheorySessionCount = Math.max(
-		0,
-		maxSessions - (sessions.length - theorySources.length),
-	);
-	const requiredCountForMaximumDuration = theorySources.reduce(
-		(total, { session }) =>
-			total + Math.ceil(session.durationMinutes / MAX_THEORY_SESSION_MINUTES),
-		0,
-	);
-	const targetCount = Math.min(
-		MAX_THEORY_SESSION_COUNT,
-		availableTheorySessionCount,
-		Math.max(
-			MIN_THEORY_SESSION_COUNT,
-			theorySources.length,
-			requiredCountForMaximumDuration,
-		),
-	);
-	const fragmentCounts = theorySources.map(({ session }) =>
-		Math.max(
-			1,
-			Math.ceil(session.durationMinutes / MAX_THEORY_SESSION_MINUTES),
-		),
-	);
-	let fragmentCount = fragmentCounts.reduce((total, count) => total + count, 0);
-	while (fragmentCount < targetCount) {
-		const sourceIndex = theorySources.findIndex(
-			({ session }, index) =>
-				(fragmentCounts[index] ?? 1) <
-				Math.floor(session.durationMinutes / MIN_THEORY_SESSION_MINUTES),
-		);
-		if (sourceIndex < 0) break;
-		fragmentCounts[sourceIndex] = (fragmentCounts[sourceIndex] ?? 1) + 1;
-		fragmentCount += 1;
-	}
-
-	return new Map(
-		theorySources.map(({ session, index }, sourceIndex) => [
-			index,
-			splitDurationEvenly(
-				session.durationMinutes,
-				fragmentCounts[sourceIndex] ?? 1,
-			),
-		]),
-	);
+const splitPhaseDuration = (durationMinutes: number, maxMinutes: number) => {
+	if (durationMinutes <= 0) return [];
+	const chunkCount = Math.ceil(durationMinutes / maxMinutes);
+	return splitDurationEvenly(durationMinutes, chunkCount);
 };
+
+const roundToFiveMinutes = (durationMinutes: number) =>
+	Math.max(
+		MIN_PHASE_SESSION_MINUTES,
+		Math.round(durationMinutes / MIN_PHASE_SESSION_MINUTES) *
+			MIN_PHASE_SESSION_MINUTES,
+	);
 
 export const rebalanceLearningPhases = ({
 	sessions,
@@ -115,31 +73,110 @@ export const rebalanceLearningPhases = ({
 		0,
 	);
 	if (totalMinutes < 25) return sessions;
-
-	const theoryMinutes = Math.min(30, totalMinutes - 10);
-	const remainingMinutes = totalMinutes - theoryMinutes;
-	const rehearsalMinutes = remainingMinutes >= 20 ? 10 : 5;
+	const theoryMinutes = Math.max(
+		MAX_THEORY_SESSION_MINUTES,
+		roundToFiveMinutes(totalMinutes * TARGET_THEORY_SHARE),
+	);
+	const rehearsalMinutes = roundToFiveMinutes(
+		totalMinutes * TARGET_REHEARSAL_SHARE,
+	);
 	const phaseMinutes: Record<LearningSessionPhase, number> = {
 		theory: theoryMinutes,
-		practice: remainingMinutes - rehearsalMinutes,
+		practice: totalMinutes - theoryMinutes - rehearsalMinutes,
 		rehearsal: rehearsalMinutes,
 	};
+	const theoryChunks = splitPhaseDuration(
+		phaseMinutes.theory,
+		MAX_THEORY_SESSION_MINUTES,
+	);
+	const practiceChunks = splitPhaseDuration(
+		phaseMinutes.practice,
+		MAX_PRACTICE_SESSION_MINUTES,
+	);
+	const rehearsalChunks = splitPhaseDuration(
+		phaseMinutes.rehearsal,
+		MAX_REHEARSAL_SESSION_MINUTES,
+	);
+	const desiredChunks: Array<{
+		phase: LearningSessionPhase;
+		durationMinutes: number;
+	}> = [];
+	while (theoryChunks.length > 0 || practiceChunks.length > 0) {
+		const theoryDuration = theoryChunks.shift();
+		if (theoryDuration !== undefined) {
+			desiredChunks.push({ phase: "theory", durationMinutes: theoryDuration });
+		}
+		const practiceDuration = practiceChunks.shift();
+		if (practiceDuration !== undefined) {
+			desiredChunks.push({
+				phase: "practice",
+				durationMinutes: practiceDuration,
+			});
+		}
+	}
+	desiredChunks.push(
+		...rehearsalChunks.map((durationMinutes) => ({
+			phase: "rehearsal" as const,
+			durationMinutes,
+		})),
+	);
+	const borrowFromFollowingChunks = (afterIndex: number, minutes: number) => {
+		let remaining = minutes;
+		for (
+			let index = afterIndex + 1;
+			index < desiredChunks.length && remaining > 0;
+			index += 1
+		) {
+			const chunk = desiredChunks[index];
+			if (!chunk) continue;
+			const borrowed = Math.min(chunk.durationMinutes, remaining);
+			chunk.durationMinutes -= borrowed;
+			remaining -= borrowed;
+		}
+		return minutes - remaining;
+	};
+
 	const result: SchedulableLearningSession<LearningSessionPhase>[] = [];
-	const phases: LearningSessionPhase[] = ["theory", "practice", "rehearsal"];
-	let phaseIndex = 0;
+	let chunkIndex = 0;
+	let remainingChunkMinutes = desiredChunks[0]?.durationMinutes ?? 0;
+	const maximumDurationByPhase: Record<LearningSessionPhase, number> = {
+		theory: MAX_THEORY_SESSION_MINUTES,
+		practice: MAX_PRACTICE_SESSION_MINUTES,
+		rehearsal: MAX_REHEARSAL_SESSION_MINUTES,
+	};
 
 	for (const session of sessions) {
 		let unallocatedMinutes = session.durationMinutes;
 		let startMinutes = parseLearningTimeToMinutes(session.startTime) ?? 0;
-		while (unallocatedMinutes > 0 && phaseIndex < phases.length) {
-			const phase = phases[phaseIndex];
-			if (!phase) break;
-			if (phaseMinutes[phase] <= 0) {
-				phaseIndex += 1;
+		while (unallocatedMinutes > 0 && chunkIndex < desiredChunks.length) {
+			if (remainingChunkMinutes <= 0) {
+				chunkIndex += 1;
+				remainingChunkMinutes = desiredChunks[chunkIndex]?.durationMinutes ?? 0;
 				continue;
 			}
-
-			const durationMinutes = Math.min(unallocatedMinutes, phaseMinutes[phase]);
+			const chunk = desiredChunks[chunkIndex];
+			if (!chunk) break;
+			const phase = chunk.phase;
+			let durationMinutes = Math.min(unallocatedMinutes, remainingChunkMinutes);
+			const completesChunk = durationMinutes === remainingChunkMinutes;
+			const trailingMinutes = unallocatedMinutes - durationMinutes;
+			if (
+				completesChunk &&
+				durationMinutes < MIN_PHASE_SESSION_MINUTES &&
+				unallocatedMinutes >= MIN_PHASE_SESSION_MINUTES
+			) {
+				const needed = MIN_PHASE_SESSION_MINUTES - durationMinutes;
+				const borrowed = borrowFromFollowingChunks(chunkIndex, needed);
+				durationMinutes += borrowed;
+			} else if (
+				completesChunk &&
+				trailingMinutes > 0 &&
+				trailingMinutes < MIN_PHASE_SESSION_MINUTES &&
+				durationMinutes + trailingMinutes <= maximumDurationByPhase[chunk.phase]
+			) {
+				const borrowed = borrowFromFollowingChunks(chunkIndex, trailingMinutes);
+				durationMinutes += borrowed;
+			}
 			const metadata =
 				session.phase === phase ? session : phaseFallbacks[phase];
 			result.push({
@@ -149,24 +186,200 @@ export const rebalanceLearningPhases = ({
 				startTime: formatLearningTimeFromMinutes(startMinutes),
 				durationMinutes,
 			});
-			phaseMinutes[phase] -= durationMinutes;
 			unallocatedMinutes -= durationMinutes;
+			remainingChunkMinutes = Math.max(
+				0,
+				remainingChunkMinutes - durationMinutes,
+			);
 			startMinutes += durationMinutes;
+			if (remainingChunkMinutes === 0) {
+				chunkIndex += 1;
+				remainingChunkMinutes = desiredChunks[chunkIndex]?.durationMinutes ?? 0;
+			}
 		}
 	}
-
-	let retainedTheorySessionCount = 0;
-	return result.map((session) => {
-		if (session.phase !== "theory") return session;
-		retainedTheorySessionCount += 1;
-		if (retainedTheorySessionCount <= MAX_THEORY_SESSION_COUNT) return session;
-
-		return {
-			...session,
-			...phaseFallbacks.practice,
-			phase: "practice" as const,
-		};
+	const mergedSessions = result.reduce<
+		SchedulableLearningSession<LearningSessionPhase>[]
+	>((merged, session) => {
+		const previous = merged.at(-1);
+		const previousStart = previous
+			? parseLearningTimeToMinutes(previous.startTime)
+			: null;
+		const sessionStart = parseLearningTimeToMinutes(session.startTime);
+		if (
+			previous &&
+			previous.phase === session.phase &&
+			previous.dateKey === session.dateKey &&
+			previousStart !== null &&
+			sessionStart !== null &&
+			previousStart + previous.durationMinutes === sessionStart &&
+			previous.durationMinutes + session.durationMinutes <=
+				maximumDurationByPhase[session.phase]
+		) {
+			previous.durationMinutes += session.durationMinutes;
+			return merged;
+		}
+		merged.push(session);
+		return merged;
+	}, []);
+	const minimumSizedSessions: SchedulableLearningSession<LearningSessionPhase>[] =
+		[];
+	const mergeCandidates = mergedSessions.map((session) => ({ ...session }));
+	for (const [index, candidate] of mergeCandidates.entries()) {
+		let session = candidate;
+		if (session.durationMinutes >= MIN_PHASE_SESSION_MINUTES) {
+			minimumSizedSessions.push(session);
+			continue;
+		}
+		if (session.phase === "theory") {
+			session = {
+				...session,
+				...phaseFallbacks.practice,
+				phase: "practice",
+			};
+			mergeCandidates[index] = session;
+		}
+		const next = mergeCandidates[index + 1];
+		const sessionStart = parseLearningTimeToMinutes(session.startTime);
+		const nextStart = next ? parseLearningTimeToMinutes(next.startTime) : null;
+		if (
+			next &&
+			next.phase === session.phase &&
+			next.dateKey === session.dateKey &&
+			sessionStart !== null &&
+			nextStart === sessionStart + session.durationMinutes
+		) {
+			const [firstDuration, secondDuration] = splitDurationEvenly(
+				session.durationMinutes + next.durationMinutes,
+				2,
+			);
+			if (
+				firstDuration !== undefined &&
+				secondDuration !== undefined &&
+				firstDuration >= MIN_PHASE_SESSION_MINUTES &&
+				secondDuration >= MIN_PHASE_SESSION_MINUTES &&
+				firstDuration <= maximumDurationByPhase[session.phase] &&
+				secondDuration <= maximumDurationByPhase[next.phase]
+			) {
+				session.durationMinutes = firstDuration;
+				next.startTime = formatLearningTimeFromMinutes(
+					sessionStart + firstDuration,
+				);
+				next.durationMinutes = secondDuration;
+				minimumSizedSessions.push(session);
+				continue;
+			}
+		}
+		const previous = minimumSizedSessions.at(-1);
+		const previousStart = previous
+			? parseLearningTimeToMinutes(previous.startTime)
+			: null;
+		if (
+			previous &&
+			previous.phase === session.phase &&
+			previous.dateKey === session.dateKey &&
+			previousStart !== null &&
+			sessionStart !== null &&
+			previousStart + previous.durationMinutes === sessionStart
+		) {
+			const [firstDuration, secondDuration] = splitDurationEvenly(
+				previous.durationMinutes + session.durationMinutes,
+				2,
+			);
+			if (
+				firstDuration !== undefined &&
+				secondDuration !== undefined &&
+				firstDuration >= MIN_PHASE_SESSION_MINUTES &&
+				secondDuration >= MIN_PHASE_SESSION_MINUTES &&
+				firstDuration <= maximumDurationByPhase[previous.phase] &&
+				secondDuration <= maximumDurationByPhase[session.phase]
+			) {
+				previous.durationMinutes = firstDuration;
+				session.startTime = formatLearningTimeFromMinutes(
+					previousStart + firstDuration,
+				);
+				session.durationMinutes = secondDuration;
+				minimumSizedSessions.push(session);
+				continue;
+			}
+		}
+		if (
+			previous &&
+			previous.dateKey === session.dateKey &&
+			previousStart !== null &&
+			sessionStart !== null &&
+			previousStart + previous.durationMinutes === sessionStart &&
+			previous.durationMinutes + session.durationMinutes <=
+				maximumDurationByPhase[previous.phase]
+		) {
+			previous.durationMinutes += session.durationMinutes;
+			continue;
+		}
+		if (
+			next &&
+			next.dateKey === session.dateKey &&
+			sessionStart !== null &&
+			nextStart === sessionStart + session.durationMinutes &&
+			next.durationMinutes + session.durationMinutes <=
+				maximumDurationByPhase[next.phase]
+		) {
+			next.startTime = session.startTime;
+			next.durationMinutes += session.durationMinutes;
+			continue;
+		}
+		minimumSizedSessions.push(session);
+	}
+	let previousPhase: LearningSessionPhase | null = null;
+	let displacedTheoryMinutes = 0;
+	const withoutConsecutiveTheory = minimumSizedSessions.map((session) => {
+		if (session.phase === "theory" && previousPhase === "theory") {
+			displacedTheoryMinutes += session.durationMinutes;
+			previousPhase = "practice";
+			return {
+				...session,
+				...phaseFallbacks.practice,
+				phase: "practice" as const,
+			};
+		}
+		previousPhase = session.phase;
+		return session;
 	});
+	const restoredSessions: SchedulableLearningSession<LearningSessionPhase>[] =
+		[];
+	for (const [index, session] of withoutConsecutiveTheory.entries()) {
+		const previous = restoredSessions.at(-1);
+		const next = withoutConsecutiveTheory[index + 1];
+		const availableTheoryMinutes = Math.min(
+			MAX_THEORY_SESSION_MINUTES,
+			displacedTheoryMinutes,
+			session.durationMinutes - MIN_PHASE_SESSION_MINUTES,
+		);
+		if (
+			session.phase === "practice" &&
+			availableTheoryMinutes >= MIN_PHASE_SESSION_MINUTES &&
+			previous?.phase !== "theory" &&
+			next?.phase !== "theory"
+		) {
+			restoredSessions.push({
+				...session,
+				...phaseFallbacks.theory,
+				phase: "theory",
+				durationMinutes: availableTheoryMinutes,
+			});
+			restoredSessions.push({
+				...session,
+				startTime: formatLearningTimeFromMinutes(
+					(parseLearningTimeToMinutes(session.startTime) ?? 0) +
+						availableTheoryMinutes,
+				),
+				durationMinutes: session.durationMinutes - availableTheoryMinutes,
+			});
+			displacedTheoryMinutes -= availableTheoryMinutes;
+			continue;
+		}
+		restoredSessions.push(session);
+	}
+	return restoredSessions;
 };
 
 export const splitLargeTheorySessions = ({
@@ -180,65 +393,35 @@ export const splitLargeTheorySessions = ({
 	maxSessions: number;
 	maxTitleChars: number;
 }) => {
-	const result: SchedulableLearningSession<LearningSessionPhase>[] = [];
+	void maxSessions;
+	const theorySessionCount = sessions.filter(
+		(session) => session.phase === "theory",
+	).length;
 	let theoryTopicIndex = 0;
-	const theoryDurationsBySession = getTheoryDurationsBySession({
-		sessions,
-		maxSessions,
-	});
-	const totalTheoryFragmentCount = Array.from(
-		theoryDurationsBySession.values(),
-	).reduce((total, durations) => total + durations.length, 0);
 	const distinctTopicTitleCount = new Set(
 		topics.map((topic) => topic.title.trim().toLocaleLowerCase("de")),
 	).size;
-	const customizeTheoryMetadata = totalTheoryFragmentCount > 1;
-
-	for (const [sessionIndex, session] of sessions.entries()) {
-		const durations = theoryDurationsBySession.get(sessionIndex) ?? [
-			session.durationMinutes,
-		];
-		let startMinutes = parseLearningTimeToMinutes(session.startTime) ?? 0;
-
-		for (const [fragmentIndex, durationMinutes] of durations.entries()) {
-			if (
-				session.phase !== "theory" ||
-				(durations.length === 1 && !customizeTheoryMetadata)
-			) {
-				result.push(session);
-				if (session.phase === "theory") theoryTopicIndex += 1;
-				break;
-			}
-
-			const topic = topics[theoryTopicIndex % Math.max(topics.length, 1)];
-			const stage =
-				theorySessionStages[theoryTopicIndex % theorySessionStages.length] ??
-				theorySessionStages[0];
-			const repeatsTopic = distinctTopicTitleCount < totalTheoryFragmentCount;
-			const topicTitle = topic?.title || session.title;
-			const topicGoal = topic?.learningGoal || session.goal;
-			const title = repeatsTopic ? `${stage.title}: ${topicTitle}` : topicTitle;
-			const goal = `${stage.verb} ${topicTitle}: ${topicGoal.replace(/[.!?]+$/, "")}.`;
-			const sourceTask =
-				session.tasks[fragmentIndex % Math.max(session.tasks.length, 1)];
-
-			result.push({
-				...session,
-				title:
-					compactLearningSessionTitle(title, maxTitleChars) || session.title,
-				startTime: formatLearningTimeFromMinutes(startMinutes),
-				durationMinutes,
-				goal,
-				tasks: [
-					`${stage.verb} das Lernziel zu ${topicTitle}.`,
-					...(sourceTask ? [sourceTask] : []),
-				],
-				expectedOutcome: `Du hast ${topicTitle} im Schritt „${stage.title}“ abgeschlossen.`,
-			});
-			startMinutes += durationMinutes;
-			theoryTopicIndex += 1;
-		}
-	}
-
-	return result;
+	return sessions.map((session) => {
+		if (session.phase !== "theory" || theorySessionCount === 1) return session;
+		const topic = topics[theoryTopicIndex % Math.max(topics.length, 1)];
+		const stage =
+			theorySessionStages[theoryTopicIndex % theorySessionStages.length] ??
+			theorySessionStages[0];
+		const repeatsTopic = distinctTopicTitleCount < theorySessionCount;
+		const topicTitle = topic?.title || session.title;
+		const topicGoal = topic?.learningGoal || session.goal;
+		const title = repeatsTopic ? `${stage.title}: ${topicTitle}` : topicTitle;
+		const sourceTask = session.tasks[0];
+		theoryTopicIndex += 1;
+		return {
+			...session,
+			title: compactLearningSessionTitle(title, maxTitleChars) || session.title,
+			goal: `${stage.verb} ${topicTitle}: ${topicGoal.replace(/[.!?]+$/, "")}.`,
+			tasks: [
+				`${stage.verb} das Lernziel zu ${topicTitle}.`,
+				...(sourceTask ? [sourceTask] : []),
+			],
+			expectedOutcome: `Du hast ${topicTitle} im Schritt „${stage.title}“ abgeschlossen.`,
+		};
+	});
 };

--- a/src/features/learning-plans/session-progress.test.ts
+++ b/src/features/learning-plans/session-progress.test.ts
@@ -62,7 +62,7 @@ describe("learning session progress", () => {
 		});
 	});
 
-	it("places each prediction question directly before its theory page", () => {
+	it("shows one opening question before all theory pages", () => {
 		const secondLearnCard = {
 			id: "theory-2",
 			kind: "learnCard",
@@ -94,7 +94,7 @@ describe("learning session progress", () => {
 				"theory",
 				"split",
 			),
-		).toEqual([firstPractice, learnCard, secondPractice, secondLearnCard]);
+		).toEqual([firstPractice, learnCard, secondLearnCard]);
 	});
 
 	it("maps a paired question to the same topic as its theory page", () => {

--- a/src/features/learning-plans/session-progress.ts
+++ b/src/features/learning-plans/session-progress.ts
@@ -38,25 +38,19 @@ export function getLearningSessionItems<
 		return items.filter((item) => item.kind === "learnCard");
 	}
 	if (phase === "theory") {
-		const pairedQuestionByTheoryCoverageKey = new Map(
-			items.flatMap((item) => {
-				const coverageKey = item.coverageKey;
-				if (!isPairedTheoryQuestionItem(item) || !coverageKey) return [];
-				return [
-					[
-						coverageKey.slice(0, -PAIRED_THEORY_QUESTION_SUFFIX.length),
-						item,
-					] as const,
-				];
-			}),
-		);
-		return items.flatMap((item) => {
-			if (item.kind !== "learnCard") return [];
-			const questionItem = item.coverageKey
-				? pairedQuestionByTheoryCoverageKey.get(item.coverageKey)
-				: undefined;
-			return questionItem ? [questionItem, item] : [item];
-		});
+		const theoryItems = items.filter((item) => item.kind === "learnCard");
+		const firstTheoryItem = theoryItems[0];
+		const pairedCoverageKey = firstTheoryItem?.coverageKey
+			? `${firstTheoryItem.coverageKey}${PAIRED_THEORY_QUESTION_SUFFIX}`
+			: null;
+		const openingQuestion = pairedCoverageKey
+			? items.find(
+					(item) =>
+						isPairedTheoryQuestionItem(item) &&
+						item.coverageKey === pairedCoverageKey,
+				)
+			: undefined;
+		return openingQuestion ? [openingQuestion, ...theoryItems] : theoryItems;
 	}
 
 	return [...items];


### PR DESCRIPTION
Implements one optional theory opener followed by four short theory pages, practice-first adaptive progression, interleaved theory/practice/rehearsal scheduling, and confidence-independent mastery. Preserves legacy learning data while hiding obsolete extra theory checks. Validation: pnpm test; pnpm check; pnpm format:check; git diff --check; pnpm exec convex dev --once; iOS simulator opener-to-theory flow.