### PR TITLE
Improve theory content and preloading

### DIFF
--- a/convex/learningContentPlan.test.ts
+++ b/convex/learningContentPlan.test.ts
@@ -71,6 +71,12 @@ describe("learning content plan", () => {
 
 		expect(plan.blocks).toHaveLength(1);
 		expect(plan.blocks[0]?.questions).toHaveLength(4);
+		expect(plan.blocks[0]?.questions.map((question) => question.angle)).toEqual(
+			["recall", "recognize", "apply", "findError"],
+		);
+		expect(
+			new Set(plan.blocks[0]?.questions.map((question) => question.topic.id)),
+		).toEqual(new Set([topics[0]?.id]));
 		expect(
 			plan.blocks[0]?.questions.reduce(
 				(total, question) => total + question.estimatedSeconds,

--- a/convex/learningContentPlan.ts
+++ b/convex/learningContentPlan.ts
@@ -63,6 +63,13 @@ const questionAngles: LearningQuestionAngle[] = [
 	"examTransfer",
 ];
 
+const theoryPageAngles: LearningQuestionAngle[] = [
+	"recall",
+	"recognize",
+	"apply",
+	"findError",
+];
+
 const taskKinds: LearningQuestionKind[] = [
 	"multipleChoice",
 	"written",
@@ -171,16 +178,24 @@ const createQuestions = ({
 		}
 		const globalIndex = questionIndex;
 		questionIndex += 1;
-		const topic = topics[globalIndex % topics.length];
+		const topicIndex =
+			phase === "theory"
+				? Math.floor(globalIndex / theoryPageAngles.length)
+				: globalIndex;
+		const topic = topics[topicIndex % topics.length];
 		if (!topic)
 			throw new Error("A learning content plan needs at least one topic.");
 		const angle =
-			questionAngles[
-				Math.floor(globalIndex / topics.length) % questionAngles.length
-			] ?? "apply";
-		const cycle = Math.floor(
-			globalIndex / Math.max(topics.length * questionAngles.length, 1),
-		);
+			phase === "theory"
+				? (theoryPageAngles[globalIndex % theoryPageAngles.length] ?? "recall")
+				: (questionAngles[
+						Math.floor(globalIndex / topics.length) % questionAngles.length
+					] ?? "apply");
+		const cycleLength =
+			phase === "theory"
+				? topics.length * theoryPageAngles.length
+				: topics.length * questionAngles.length;
+		const cycle = Math.floor(globalIndex / Math.max(cycleLength, 1));
 		const kind = questionKindFor(phase, globalIndex);
 		const estimatedSeconds = Math.min(
 			estimatedSecondsForKind[kind],

--- a/convex/learningPlanAi.ts
+++ b/convex/learningPlanAi.ts
@@ -27,6 +27,7 @@ import {
 import {
 	createLearningContentPlan,
 	type LearningContentBlock,
+	type LearningQuestionAngle,
 	type LearningQuestionBlueprint,
 	type LearningTopic,
 } from "./learningContentPlan";
@@ -457,30 +458,36 @@ const generatedTheoryItemSchema = z.object({
 	question: germanTextSchema(
 		12,
 		"One short German curiosity question shown before the theory. The learner has not seen the explanation yet and must be able to answer with an intuitive first guess. Ask one thing only. Never demand a definition, complete list, comparison, or step-by-step solution. Avoid specialist wording when everyday language works.",
+		140,
 	),
 	explanation: germanTextSchema(
-		110,
-		"Concise German teaching explanation in two to three connected sentences. Explain why the rule works, not only what the result is.",
+		60,
+		"Concise German teaching explanation in one or two connected sentences. Explain why the idea works, not only what the result is.",
+		320,
 	),
 	keyPoints: boundedArray(
 		germanTextSchema(
-			20,
+			12,
 			"One specific German key point that adds information and is not merely a keyword or a copy of another section.",
+			150,
 		),
+		1,
 		2,
-		3,
 	),
 	example: germanTextSchema(
-		80,
+		45,
 		"A concrete worked German example with an input or situation, the decisive step, and the result. Never copy the short answer or memory cue.",
+		300,
 	),
 	memoryCue: germanTextSchema(
-		20,
+		12,
 		"One memorable German rule of thumb that helps recall the concept. It must not duplicate the example or a key point.",
+		120,
 	),
 	commonMistake: germanTextSchema(
-		40,
+		24,
 		"One concept-specific German mistake, including how the learner can notice or prevent it.",
+		180,
 	),
 	keywords: atMostArray(
 		germanTextSchema(
@@ -685,6 +692,15 @@ const generatedTextRetrySystemInstruction = (attempt: number) =>
 	attempt === 0
 		? ""
 		: " Die vorherige Ausgabe war ungültig oder wiederholte bereits vorhandene Fragen. Erzeuge alle Fragen vollständig neu, ohne inhaltliche Duplikate und mit korrekten Unicode-Zeichen wie ä, ö, ü, Ä, Ö, Ü und ß.";
+
+const theoryGenerationSystemInstruction = (attempt: number) =>
+	`Du bist ein präziser Lerncoach für Schüler der 10. bis 12. Klasse in Deutschland. Erstelle eine zusammenhängende Mini-Lektion aus kurzen deutschen Theorie-Seiten. Jede Seite konzentriert sich auf die in der Planung genannte Seitenrolle und baut auf der vorherigen Seite auf. Alle Pflichtfelder des Schemas unterstützen diese Rolle, statt ein zweites Thema einzuführen. Wiederhole keine Erklärung, kein Beispiel und keinen Merksatz auf einer späteren Seite.
+
+Die hochgeladenen Schulunterlagen und die gespeicherte Materialzusammenfassung sind die fachliche Quelle. Übernimm ihre Begriffe und Schwerpunktsetzung. Erfinde keine Gesetze, Grenzwerte, Formeln, Fachbegriffe oder angeblichen Prüfungsanforderungen, die dort nicht belegt sind. Falls für ein Beispiel Details fehlen, verwende ein einfaches, ausdrücklich illustratives Beispiel ohne neue Fachbehauptungen.
+
+Die erste Leitfrage wird vor der Erklärung als lockerer Einstieg gezeigt. Sie muss ohne Vorwissen mit einer Vermutung beantwortbar sein, genau eine Sache fragen und darf keine Definition, vollständige Aufzählung, keinen Vergleich oder fertigen Lösungsweg verlangen. Spätere Leitfragen lenken jeweils auf den nächsten Gedanken der Mini-Lektion.
+
+Schreibe klar und altersgerecht. Halte alle Felder knapp: eine bis zwei Erklärungssätze, ein bis zwei konkrete Kernpunkte, ein kurzes nachvollziehbares Beispiel, einen knappen Merksatz und einen spezifischen Fehlerhinweis. Die Bereiche dürfen sich nicht inhaltlich wiederholen. Verwende keine Meta-Anweisungen oder internen Labels. Halte Reihenfolge und Seitenrollen exakt ein und antworte ausschließlich im vorgegebenen JSON-Schema.${generatedTextRetrySystemInstruction(attempt)}`;
 
 class DuplicateGeneratedPromptError extends Error {}
 
@@ -1742,11 +1758,26 @@ const getLearningContentTopics = (
 	});
 };
 
+const theoryPageRoleForAngle: Record<LearningQuestionAngle, string> = {
+	recall:
+		"Kernidee: Erkläre den zentralen Gedanken in Alltagssprache und warum er wichtig ist.",
+	recognize:
+		"Erkennen: Zeige, woran der Schüler den Gedanken in einer Aufgabe oder Situation erkennt und wovon er ihn abgrenzt.",
+	apply:
+		"Anwendung: Führe ein einziges konkretes Beispiel Schritt für Schritt vom Ausgangspunkt zum Ergebnis.",
+	findError:
+		"Fehlerkontrolle: Zeige einen typischen Denkfehler, wie man ihn bemerkt und wie man ihn korrigiert.",
+	compare:
+		"Einordnung: Stelle genau einen entscheidenden Unterschied oder Zusammenhang heraus.",
+	examTransfer:
+		"Prüfungstransfer: Zeige, wie der Gedanke in einer realistischen Prüfungsaufgabe genutzt wird.",
+};
+
 const formatQuestionBlueprints = (block: LearningContentBlock) =>
 	block.questions
 		.map(
 			(question, index) =>
-				`${index + 1}. Thema: ${question.topic.title}; Lernziel: ${question.topic.learningGoal}; Fragetyp: ${question.angle}; Antwortmodus: ${question.kind}; Zeitbudget: ${question.estimatedSeconds} Sekunden; Coverage-Key: ${question.coverageKey}`,
+				`${index + 1}. Thema: ${question.topic.title}; Lernziel: ${question.topic.learningGoal}; ${block.phase === "theory" ? `Seitenrolle: ${theoryPageRoleForAngle[question.angle]}` : `Fragetyp: ${question.angle}`}; Antwortmodus: ${question.kind}; Zeitbudget: ${question.estimatedSeconds} Sekunden; Coverage-Key: ${question.coverageKey}`,
 		)
 		.join("\n");
 
@@ -2128,7 +2159,7 @@ ${personalLearningTimes}`,
 				...userContent,
 				{
 					type: "text" as const,
-					text: `Dieser Lernblock dauert ${block.durationMinutes} Minuten und enthält genau ${block.questions.length} ${block.phase === "theory" ? "ausführliche Lernseiten" : "neue Fragen"}. Halte dich in Reihenfolge und Themenbezug exakt an diese Planung:\n${blueprintText}`,
+					text: `Dieser Lernblock dauert ${block.durationMinutes} Minuten und enthält genau ${block.questions.length} ${block.phase === "theory" ? "fokussierte Seiten einer zusammenhängenden Mini-Lektion" : "neue Fragen"}. Halte dich in Reihenfolge und Themenbezug exakt an diese Planung:\n${blueprintText}`,
 				},
 				...(previouslyUsedPrompts.length > 0 || generatedItems.length > 0
 					? [
@@ -2167,7 +2198,7 @@ ${personalLearningTimes}`,
 								abortSignal,
 								providerOptions: vertexProviderOptions,
 								output: Output.object({ schema: blockSchema }),
-								system: `Du bist ein präziser Lerncoach für Schüler der 10. bis 12. Klasse. Erstelle kompakte Theorie-Lernseiten, die jeweils ungefähr zwei Minuten Lernzeit sinnvoll füllen. Jede Seite behandelt genau einen Gedanken. Nur die Leitfrage der ersten Seite wird dem Schüler vor allen Erklärungen als lockerer Einstieg gezeigt; alle Seiten brauchen die Leitfrage weiterhin für die einheitliche Seitenstruktur. Sie muss mit einer Vermutung oder einem ersten Gedanken beantwortbar sein, darf kein bereits gelerntes Fachwissen voraussetzen und weder eine Definition, vollständige Aufzählung, einen Vergleich noch einen schrittweisen Lösungsweg verlangen. Frage genau eine Sache in kurzer, natürlicher Alltagssprache. Danach folgen eine verständliche Erklärung in zwei bis drei zusammenhängenden Sätzen, zwei bis drei gehaltvolle Kernpunkte, ein knappes durchgerechnetes oder konkret angewandtes Beispiel, ein eigener Merksatz und ein fachspezifischer typischer Fehler. Beispiel, Kernpunkte und Merksatz müssen unterschiedliche Inhalte haben. Verwende keine Meta-Anweisungen, internen Labels wie „Variante 1“ oder in Anführungszeichen verschachtelte Aufgaben. Antworte ausschließlich im vorgegebenen JSON-Schema.${generatedTextRetrySystemInstruction(attempt)}`,
+								system: theoryGenerationSystemInstruction(attempt),
 								messages: [{ role: "user", content: blockContent }],
 							}),
 						);
@@ -2446,7 +2477,7 @@ ${allPriorPrompts.map((prompt) => `- ${prompt}`).join("\n") || "Keine."}`,
 						output: Output.object({
 							schema: createTheoryTopicsSchema(allQuestions.length),
 						}),
-						system: `Du bist ein präziser Lerncoach. Erstelle kompakte deutsche Theorie-Lernseiten für ungefähr zwei Minuten Lernzeit mit einer Erklärung in zwei bis drei Sätzen, zwei bis drei Kernpunkten, einem konkreten Beispiel, Merksatz und typischem Fehler. Nur die Leitfrage der ersten Seite wird vor allen Erklärungen gezeigt; alle Seiten brauchen sie für die einheitliche Seitenstruktur. Sie muss ohne Vorwissen mit einer Vermutung oder einem ersten Gedanken beantwortbar sein, fragt genau eine Sache in kurzer Alltagssprache und verlangt keine Definition, vollständige Aufzählung, keinen Vergleich und keinen schrittweisen Lösungsweg. Halte die vorgegebene Reihenfolge exakt ein und antworte ausschließlich im JSON-Schema.${generatedTextRetrySystemInstruction(attempt)}`,
+						system: theoryGenerationSystemInstruction(attempt),
 					}),
 				)
 			: await runLlmGeneration((abortSignal) =>

--- a/convex/learningPlanAi.ts
+++ b/convex/learningPlanAi.ts
@@ -396,8 +396,7 @@ const generatedPlanSchema = z
 const generatedTaskChoiceSchema = z.object({
 	text: germanTextSchema(
 		1,
-		"Concise German answer option containing one concept and at most one distinguishing characteristic.",
-		MAX_MULTIPLE_CHOICE_OPTION_CHARS,
+		`Concise German answer option containing one concept and at most one distinguishing characteristic. Keep it within ${MAX_MULTIPLE_CHOICE_OPTION_CHARS} characters.`,
 	),
 	isCorrect: z.boolean(),
 });
@@ -760,6 +759,27 @@ const compactText = (value: string, maxChars: number) => {
 
 	return `${normalized.slice(0, maxChars)}\n\n[Inhalt wurde gekürzt.]`;
 };
+
+const compactInlineText = (value: string, maxChars: number) => {
+	const normalized = value.replace(/\s+/g, " ").trim();
+	if (normalized.length <= maxChars) return normalized;
+
+	const maximumContentLength = Math.max(1, maxChars - 1);
+	const candidate = normalized.slice(0, maximumContentLength).trimEnd();
+	const lastWordBoundary = candidate.lastIndexOf(" ");
+	const minimumUsefulLength = Math.floor(maximumContentLength * 0.6);
+	const content =
+		lastWordBoundary >= minimumUsefulLength
+			? candidate.slice(0, lastWordBoundary)
+			: candidate;
+	return `${content.trimEnd()}…`;
+};
+
+const normalizeTaskChoiceText = (value: GeneratedGermanText) =>
+	compactInlineText(
+		normalizeAiGeneratedGermanText(value),
+		MAX_MULTIPLE_CHOICE_OPTION_CHARS,
+	);
 
 const fallbackTitleByPhase: Record<GeneratedSessionPhase, string> = {
 	theory: "Theorie-Block",
@@ -1636,6 +1656,8 @@ const normalizeSessions = (
 export const __testOnlyLearningPlanAi = {
 	normalizeSessions,
 	getEmptyScheduleErrorMessage,
+	generatedTaskChoiceSchema,
+	normalizeTaskChoiceText,
 };
 
 const buildBaseContext = (
@@ -1919,7 +1941,7 @@ const normalizeGeneratedTaskItems = (
 		if (item.kind === "multipleChoice") {
 			const generatedChoices = item.choices.map((choice, choiceIndex) => ({
 				id: `choice-${choiceIndex + 1}`,
-				text: normalizeAiGeneratedGermanText(choice.text),
+				text: normalizeTaskChoiceText(choice.text),
 				isCorrect: choice.isCorrect,
 			}));
 			const correctGeneratedChoice =

--- a/convex/learningPlanAiContent.test.ts
+++ b/convex/learningPlanAiContent.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { __testOnlyLearningPlanAi } from "./learningPlanAi";
+import { MAX_MULTIPLE_CHOICE_OPTION_CHARS } from "./learningSessionContentConstraints";
+
+describe("learning plan AI practice content", () => {
+	test("accepts a usable model-generated choice that is longer than the UI limit", () => {
+		const result = __testOnlyLearningPlanAi.generatedTaskChoiceSchema.safeParse(
+			{
+				text: "Tower-PCs werden für lokale Rechenleistung an einzelnen Arbeitsplätzen eingesetzt.",
+				isCorrect: false,
+			},
+		);
+
+		expect(result.success).toBe(true);
+	});
+
+	test("compacts long generated choices before storing them for the UI", () => {
+		const choice = __testOnlyLearningPlanAi.normalizeTaskChoiceText(
+			"Tower-PCs werden für lokale Rechenleistung an einzelnen Arbeitsplätzen eingesetzt.",
+		);
+
+		expect(choice.length).toBeLessThanOrEqual(MAX_MULTIPLE_CHOICE_OPTION_CHARS);
+		expect(choice).toMatch(/…$/);
+	});
+});

--- a/convex/learningPlans.ts
+++ b/convex/learningPlans.ts
@@ -311,6 +311,7 @@ type PublicSession = {
 	contentGenerationStatus?: "queued" | "generating" | "ready" | "failed";
 	contentGenerationError?: string;
 	contentGeneratedAt?: number;
+	contentGenerationVersion?: number;
 	completed: boolean;
 	executionStatus:
 		| "notStarted"
@@ -513,6 +514,7 @@ const publicSession = (
 	contentGenerationStatus: session.contentGenerationStatus,
 	contentGenerationError: session.contentGenerationError,
 	contentGeneratedAt: session.contentGeneratedAt,
+	contentGenerationVersion: session.contentGenerationVersion,
 	completed: session.completed ?? false,
 	executionStatus: getSessionExecutionStatus(session),
 	startedAt: session.startedAt,

--- a/convex/learningSessionContent.test.ts
+++ b/convex/learningSessionContent.test.ts
@@ -204,9 +204,8 @@ test("theory fallback creates active recall cards instead of generic summaries",
 		content?.items.filter((item) => item.questionAngle === "apply") ?? [];
 	expect(applicationQuestions.length).toBeGreaterThan(0);
 	for (const item of applicationQuestions) {
-		expect(item.prompt).toBe(
-			`Was glaubst du: Worauf kommt es bei ${item.title} besonders an?`,
-		);
+		expect(item.prompt).toContain(item.title);
+		expect(item.prompt).toMatch(/\?$/);
 	}
 	expect(content?.items.map((item) => item.prompt).join(" ")).not.toMatch(
 		/Schritt für Schritt|vollständige Aufzählung|wofür wird das Verfahren gebraucht/i,
@@ -222,6 +221,11 @@ test("opening an existing short theory session backfills its pre-check", async (
 	await t.mutation(api.learningSessionContent.ensureSessionContent, {
 		sessionId,
 	});
+	await t.run((ctx) =>
+		ctx.db.patch("learningPlanSessions", sessionId, {
+			contentGenerationVersion: 2,
+		}),
+	);
 
 	const before = await t.query(api.learningSessionContent.getSessionContent, {
 		sessionId,
@@ -637,6 +641,42 @@ test("marks shallow generated theory content for regeneration", async () => {
 	);
 
 	expect(generationContext.needsLegacyContentReplacement).toBe(true);
+});
+
+test("upgrades unstarted fallback theory content to the current AI version", async () => {
+	const { t, sessionId } = await createGeneratedPlanWithSession("theory");
+
+	await t.mutation(api.learningSessionContent.ensureSessionContent, {
+		sessionId,
+	});
+
+	const fallbackContent = await t.query(
+		api.learningSessionContent.getSessionContent,
+		{ sessionId },
+	);
+	const generationContext = await t.query(
+		internal.learningSessionContent.getSessionGenerationContext,
+		{ sessionId },
+	);
+
+	expect(fallbackContent?.session.contentGenerationVersion).toBe(1);
+	expect(generationContext.needsLegacyContentReplacement).toBe(true);
+});
+
+test("preserves older theory content after the learner has started", async () => {
+	const { t, sessionId } = await createGeneratedPlanWithSession("theory");
+
+	await t.mutation(api.learningSessionContent.ensureSessionContent, {
+		sessionId,
+	});
+	await t.mutation(api.learningPlans.startSession, { sessionId });
+
+	const generationContext = await t.query(
+		internal.learningSessionContent.getSessionGenerationContext,
+		{ sessionId },
+	);
+
+	expect(generationContext.needsLegacyContentReplacement).toBe(false);
 });
 
 test("marks nested variant exercises for regeneration", async () => {

--- a/convex/learningSessionContent.ts
+++ b/convex/learningSessionContent.ts
@@ -38,6 +38,7 @@ type SessionContentItemKind =
 type AnswerRating = "notCorrect" | "partiallyCorrect" | "correct";
 
 const PAIRED_THEORY_PRACTICE_SUFFIX = ":paired-practice";
+const CURRENT_THEORY_CONTENT_VERSION = 2;
 
 const isPairedTheoryQuestionItem = (item: {
 	kind: string;
@@ -305,7 +306,24 @@ const getSessionTopics = (
 	});
 };
 
-const approachableTheoryQuestionFor = (angle: string, topic: string) => {
+const approachableTheoryQuestionFor = (
+	angle: string,
+	topic: string,
+	coverageCycle = 0,
+) => {
+	if (coverageCycle > 0) {
+		const depthLabel = `Vertiefung ${coverageCycle}`;
+		switch (angle) {
+			case "recall":
+				return `${depthLabel}: Welcher Zusammenhang zu ${topic} ist dir jetzt besonders wichtig?`;
+			case "recognize":
+				return `${depthLabel}: Welches konkrete Signal würde dich an ${topic} denken lassen?`;
+			case "apply":
+				return `${depthLabel}: Wo würdest du ${topic} in einem neuen Beispiel einsetzen?`;
+			case "findError":
+				return `${depthLabel}: Welche Kontrolle schützt dich bei ${topic} vor einem Fehler?`;
+		}
+	}
 	switch (angle) {
 		case "recall":
 			return `Was fällt dir zu ${topic} spontan ein?`;
@@ -357,9 +375,16 @@ const obsoleteTheoryQuestionsFor = (angle: string, topic: string) => {
 	}
 };
 
-const theoryQuestionFor = (blueprint: LearningQuestionBlueprint) =>
-	approachableTheoryQuestionFor(blueprint.angle, blueprint.topic.title) ??
-	`Was fällt dir zu ${blueprint.topic.title} als Erstes ein?`;
+const theoryQuestionFor = (blueprint: LearningQuestionBlueprint) => {
+	const coverageCycle = Number(blueprint.coverageKey.split(":").at(-1) ?? "0");
+	return (
+		approachableTheoryQuestionFor(
+			blueprint.angle,
+			blueprint.topic.title,
+			Number.isFinite(coverageCycle) ? coverageCycle : 0,
+		) ?? `Was fällt dir zu ${blueprint.topic.title} als Erstes ein?`
+	);
+};
 
 const buildTheoryItems = (
 	plan: Doc<"learningPlans">,
@@ -1113,6 +1138,12 @@ export const getSessionGenerationContext = internalQuery({
 			)
 			.take(50);
 		const existingItems = await listItems(ctx, args.sessionId);
+		const currentSessionAttempts = await ctx.db
+			.query("learningSessionAnswerAttempts")
+			.withIndex("by_sessionId_and_createdAt", (q) =>
+				q.eq("sessionId", session._id),
+			)
+			.take(1);
 		const planSessions = await ctx.db
 			.query("learningPlanSessions")
 			.withIndex("by_learningPlanId_and_sortOrder", (q) =>
@@ -1217,6 +1248,14 @@ export const getSessionGenerationContext = internalQuery({
 				)
 				.map((item) => item.coverageKey),
 		);
+		const needsTheoryContentUpgrade =
+			session.phase === "theory" &&
+			existingItems.length > 0 &&
+			session.contentGenerationVersion !== CURRENT_THEORY_CONTENT_VERSION &&
+			(session.executionStatus === undefined ||
+				session.executionStatus === "notStarted") &&
+			!session.completed &&
+			currentSessionAttempts.length === 0;
 
 		return {
 			plan,
@@ -1243,6 +1282,7 @@ export const getSessionGenerationContext = internalQuery({
 				firstTheoryItem !== undefined &&
 				pairedPracticeKeys.has(getPairedPracticeCoverageKey(firstTheoryItem)),
 			needsLegacyContentReplacement:
+				needsTheoryContentUpgrade ||
 				existingItems.some(isLegacyTheoryItem) ||
 				existingItems.some(isLegacyTaskItem),
 			accessKey: `learningPlan:${session.learningPlanId}`,
@@ -1365,6 +1405,13 @@ export const storeGeneratedSessionContent = internalMutation({
 			session,
 			pairGeneratedTheoryItems(session, items),
 		);
+		await ctx.db.patch("learningPlanSessions", session._id, {
+			contentGenerationVersion:
+				session.phase === "theory"
+					? CURRENT_THEORY_CONTENT_VERSION
+					: session.contentGenerationVersion,
+			updatedAt: Date.now(),
+		});
 		const storedItems = await listItems(ctx, args.sessionId);
 		return { itemCount: storedItems.length };
 	},
@@ -1394,6 +1441,15 @@ export const ensureFallbackSessionContent = internalMutation({
 		}
 
 		const items = await ensureItemsForSession(ctx, session, plan);
+		if (
+			session.phase === "theory" &&
+			session.contentGenerationVersion === undefined
+		) {
+			await ctx.db.patch("learningPlanSessions", session._id, {
+				contentGenerationVersion: 1,
+				updatedAt: Date.now(),
+			});
+		}
 		return { itemCount: items.length };
 	},
 });
@@ -1505,13 +1561,21 @@ export const ensureSessionContent = mutation({
 			ownerTokenIdentifier,
 		);
 		const items = await ensureItemsForSession(ctx, session, plan);
-		if (session.contentGenerationStatus !== "ready") {
+		if (
+			session.contentGenerationStatus !== "ready" ||
+			(session.phase === "theory" &&
+				session.contentGenerationVersion === undefined)
+		) {
 			const now = Date.now();
 			await ctx.db.patch("learningPlanSessions", session._id, {
 				contentGenerationStatus: "ready",
 				contentGenerationError: undefined,
 				contentGenerationStartedAt: undefined,
 				contentGeneratedAt: now,
+				contentGenerationVersion:
+					session.phase === "theory"
+						? (session.contentGenerationVersion ?? 1)
+						: session.contentGenerationVersion,
 				updatedAt: now,
 			});
 		}
@@ -1567,6 +1631,8 @@ export const getSessionContent = query({
 				compositionVariant: session.compositionVariant ?? "control",
 				knowledgeValidationStatus: session.knowledgeValidationStatus,
 				knowledgeValidationConfidence: session.knowledgeValidationConfidence,
+				contentGenerationStatus: session.contentGenerationStatus,
+				contentGenerationVersion: session.contentGenerationVersion,
 			},
 			praxisDurationSeconds:
 				session.phase === "rehearsal"

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -533,6 +533,7 @@ export default defineSchema({
 		contentGenerationError: v.optional(v.string()),
 		contentGenerationStartedAt: v.optional(v.number()),
 		contentGeneratedAt: v.optional(v.number()),
+		contentGenerationVersion: v.optional(v.number()),
 		completed: v.optional(v.boolean()),
 		executionStatus: v.optional(sessionExecutionStatusValidator),
 		startedAt: v.optional(v.number()),

--- a/src/app/learning-plans/[planId]/index.tsx
+++ b/src/app/learning-plans/[planId]/index.tsx
@@ -1,6 +1,12 @@
 import { useAction, useConvexAuth, useQuery } from "convex/react";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import {
 	ActivityIndicator,
 	Pressable,
@@ -29,6 +35,7 @@ import { Button } from "~/components/ui/button";
 import {
 	ArrowRight,
 	Check,
+	CircleAlert,
 	Dumbbell,
 	GraduationCap,
 	Note,
@@ -99,6 +106,7 @@ const LEARNING_PATH_ICON_COMPONENT = {
 
 const screenContentStyle = { rowGap: 28 } satisfies ViewStyle;
 const SESSION_PREVIEW_TRANSITION_DURATION_MS = 160;
+const CURRENT_THEORY_CONTENT_VERSION = 2;
 
 export const getExamCountdownLabel = (examDateKey: string, today: Date) => {
 	const examDate = parseDayKey(examDateKey);
@@ -121,10 +129,14 @@ const getSessionRoute = (
 
 export function SessionPreviewCard({
 	canOpen,
+	onRetryPreparation,
+	preparationState,
 	session,
 	onOpen,
 }: {
 	canOpen: boolean;
+	onRetryPreparation?: () => void;
+	preparationState?: "preparing" | "failed";
 	session: PlanSession;
 	onOpen: () => void;
 }) {
@@ -189,7 +201,48 @@ export function SessionPreviewCard({
 			>
 				{description}
 			</Text>
-			{canOpen ? (
+			{preparationState === "preparing" ? (
+				<View
+					accessible
+					accessibilityLiveRegion="polite"
+					className="mt-1 flex-row items-center gap-3 rounded-[20px] bg-system-subtle px-3 py-3"
+				>
+					<ActivityIndicator
+						color={DAYOVA_DESIGN_SYSTEM.colors.primary}
+						size="small"
+					/>
+					<View className="min-w-0 flex-1">
+						<Text className="font-poppins font-semibold text-body-5 text-text">
+							Lerninhalte werden vorbereitet
+						</Text>
+						<Text className="mt-0.5 font-poppins text-body-5 text-secondary-text">
+							Du kannst den Plan verlassen. Dayova arbeitet im Hintergrund
+							weiter.
+						</Text>
+					</View>
+				</View>
+			) : preparationState === "failed" ? (
+				<View className="mt-1 gap-3 rounded-[20px] bg-wrong-subtle px-3 py-3">
+					<View className="flex-row items-start gap-2">
+						<CircleAlert
+							size={17}
+							color={DAYOVA_DESIGN_SYSTEM.colors.wrong}
+							strokeWidth={2.1}
+						/>
+						<Text className="min-w-0 flex-1 font-poppins text-body-5 text-secondary-text">
+							Die Lerninhalte konnten noch nicht vorbereitet werden.
+						</Text>
+					</View>
+					<Button
+						accessibilityLabel={`Vorbereitung erneut versuchen: ${title}`}
+						onPress={onRetryPreparation}
+						size="sm"
+						variant="neutral"
+					>
+						<Text>Erneut versuchen</Text>
+					</Button>
+				</View>
+			) : canOpen ? (
 				<Button
 					accessibilityHint="Öffnet die ausgewählte Lerneinheit."
 					accessibilityLabel={`${actionLabel}: ${title}`}
@@ -851,32 +904,64 @@ export default function LearningPlanSessionsScreen() {
 					getCommittedSessionIndex(snapshot.sessions),
 				)
 			: null;
+	const selectedSessionNeedsTheoryUpgrade = Boolean(
+		selectedSession &&
+			selectedSession.phase === "theory" &&
+			selectedSession.executionStatus === "notStarted" &&
+			(selectedSession.contentGenerationVersion ?? 0) <
+				CURRENT_THEORY_CONTENT_VERSION,
+	);
 	const canOpenSelectedSession =
 		selectedSessionState !== null &&
 		selectedSessionState !== "locked" &&
-		selectedSession?.planningStatus !== "provisional";
+		selectedSession?.planningStatus !== "provisional" &&
+		!selectedSessionNeedsTheoryUpgrade &&
+		(selectedSession?.contentGenerationStatus === undefined ||
+			selectedSession.contentGenerationStatus === "ready");
+	const preparationState =
+		selectedSession?.contentGenerationStatus === "failed"
+			? ("failed" as const)
+			: selectedSessionNeedsTheoryUpgrade ||
+					selectedSession?.contentGenerationStatus === "queued" ||
+					selectedSession?.contentGenerationStatus === "generating"
+				? ("preparing" as const)
+				: undefined;
+
+	const prepareSession = useCallback(
+		(sessionId: Id<"learningPlanSessions">) => {
+			if (preparingSessionIdRef.current === sessionId) return;
+			preparingSessionIdRef.current = sessionId;
+			void ensureSessionContent({ sessionId })
+				.catch(() => {
+					// The reactive session status drives the retry presentation.
+				})
+				.finally(() => {
+					if (preparingSessionIdRef.current === sessionId) {
+						preparingSessionIdRef.current = null;
+					}
+				});
+		},
+		[ensureSessionContent],
+	);
 
 	useEffect(() => {
+		const needsTheoryUpgrade = Boolean(
+			defaultSession &&
+				defaultSession.phase === "theory" &&
+				defaultSession.executionStatus === "notStarted" &&
+				(defaultSession.contentGenerationVersion ?? 0) <
+					CURRENT_THEORY_CONTENT_VERSION,
+		);
 		if (
 			!defaultSession ||
-			defaultSession.contentGenerationStatus === "ready" ||
-			preparingSessionIdRef.current === defaultSession.id
+			(defaultSession.contentGenerationStatus === "ready" &&
+				!needsTheoryUpgrade) ||
+			defaultSession.contentGenerationStatus === "failed"
 		) {
 			return;
 		}
-
-		preparingSessionIdRef.current = defaultSession.id;
-		void ensureSessionContent({ sessionId: defaultSession.id })
-			.catch(() => {
-				// The session route owns the user-facing retry state. This is only
-				// an eager preparation attempt when a session becomes current.
-			})
-			.finally(() => {
-				if (preparingSessionIdRef.current === defaultSession.id) {
-					preparingSessionIdRef.current = null;
-				}
-			});
-	}, [defaultSession, ensureSessionContent]);
+		prepareSession(defaultSession.id);
+	}, [defaultSession, prepareSession]);
 
 	const goBack = () => {
 		dismissToOrReplace(router, "/learning-plans");
@@ -914,7 +999,9 @@ export default function LearningPlanSessionsScreen() {
 					<SessionPreviewCard
 						key={selectedSession.id}
 						canOpen={canOpenSelectedSession}
+						preparationState={preparationState}
 						session={selectedSession}
+						onRetryPreparation={() => prepareSession(selectedSession.id)}
 						onOpen={() => {
 							if (!canOpenSelectedSession) return;
 							router.push(

--- a/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
+++ b/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
@@ -1,4 +1,4 @@
-import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
 import * as Device from "expo-device";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Speech from "expo-speech";
@@ -137,6 +137,7 @@ const iosSimulatorSpeechMessage =
 	"Spracherkennung ist im iOS Simulator nicht zuverlässig verfügbar. Auf einem iPhone kannst du deine Antwort einsprechen. Hier kannst du sie stattdessen eintippen.";
 const nativeSpeechUnavailableMessage =
 	"Spracherkennung ist in dieser App-Version nicht verfügbar. Du kannst deine Antwort stattdessen eintippen.";
+const CURRENT_THEORY_CONTENT_VERSION = 2;
 
 const getSpeechRecognitionErrorMessage = (error: SpeechRecognitionError) => {
 	if (error === SpeechRecognitionError.LocaleNotSupported) {
@@ -964,6 +965,9 @@ export default function LearningSessionContentScreen() {
 	const recordSessionOutcome = useMutation(
 		api.learningPlans.recordSessionOutcome,
 	);
+	const prepareSessionContent = useAction(
+		api.learningPlanAi.ensureSessionContent,
+	);
 	const { capture } = useValidationAnalytics();
 	const { colors } = useDayovaTheme();
 
@@ -1036,17 +1040,24 @@ export default function LearningSessionContentScreen() {
 		api.learningSessionContent.getSessionContent,
 		user && isConvexAuthenticated && sessionId ? { sessionId } : "skip",
 	) ?? null) as LearningSessionContentSnapshot | null;
+	const needsTheoryContentUpgrade = Boolean(
+		content &&
+			content.session.phase === "theory" &&
+			content.session.executionStatus === "notStarted" &&
+			(content.session.contentGenerationVersion ?? 0) <
+				CURRENT_THEORY_CONTENT_VERSION,
+	);
 
 	const sessionItems = useMemo(
 		() =>
-			content
+			content && !needsTheoryContentUpgrade
 				? getLearningSessionItems(
 						content.items,
 						content.session.phase,
 						content.session.compositionVariant,
 					)
 				: [],
-		[content],
+		[content, needsTheoryContentUpgrade],
 	);
 	const currentItem = sessionItems[currentIndex] ?? null;
 	const theoryTopicPosition = getTheoryTopicPosition(
@@ -1195,10 +1206,30 @@ export default function LearningSessionContentScreen() {
 		},
 	});
 
+	const retrySessionPreparation = async () => {
+		if (!sessionId || isBusy) return;
+		setIsBusy(true);
+		setErrorMessage(null);
+		try {
+			await prepareSessionContent({ sessionId });
+		} catch (error) {
+			setErrorMessage(
+				getErrorMessage(
+					error,
+					"Der Lernblock konnte nicht vorbereitet werden.",
+				),
+			);
+		} finally {
+			setIsBusy(false);
+		}
+	};
+
 	useEffect(() => {
 		if (
 			!sessionId ||
 			!content ||
+			content.items.length === 0 ||
+			needsTheoryContentUpgrade ||
 			content.session.executionStatus !== "notStarted" ||
 			didStartTrackingRef.current
 		)
@@ -1210,7 +1241,7 @@ export default function LearningSessionContentScreen() {
 				level: "warn",
 			});
 		});
-	}, [content, ensureSessionStarted, sessionId]);
+	}, [content, ensureSessionStarted, needsTheoryContentUpgrade, sessionId]);
 
 	const timerDurationSeconds = getLearningSessionTimerDurationSeconds({
 		phase: content?.session.phase,
@@ -1382,7 +1413,22 @@ export default function LearningSessionContentScreen() {
 		setIsBusy(true);
 		setErrorMessage(null);
 		try {
-			await recordCompletedOutcome();
+			const completed = await recordCompletedOutcome();
+			const nextSessionId = completed?.rollingUpdate?.committedSessionId;
+			if (nextSessionId) {
+				void prepareSessionContent({ sessionId: nextSessionId }).catch(
+					(error: unknown) => {
+						logDiagnosticError(
+							"Failed to prewarm the next learning session.",
+							error,
+							{
+								source: "learningSession.prewarmNextSession",
+								level: "warn",
+							},
+						);
+					},
+				);
+			}
 			goBack();
 		} catch (error) {
 			setErrorMessage(
@@ -1803,9 +1849,43 @@ export default function LearningSessionContentScreen() {
 				keyboardShouldPersistTaps="handled"
 				showsVerticalScrollIndicator={false}
 			>
-				{!content || content.items.length === 0 ? (
-					<View className="flex-1 items-center justify-center py-24">
-						<ActivityIndicator color={DAYOVA_DESIGN_SYSTEM.colors.primary} />
+				{!content || content.items.length === 0 || needsTheoryContentUpgrade ? (
+					<View className="flex-1 items-center justify-center px-4 py-24">
+						<View className="h-14 w-14 items-center justify-center rounded-full bg-system-subtle">
+							<ActivityIndicator
+								accessibilityLabel="Lerninhalte werden vorbereitet"
+								color={DAYOVA_DESIGN_SYSTEM.colors.primary}
+							/>
+						</View>
+						<Text className="mt-6 text-center font-poppins font-semibold text-body-1 text-text">
+							Dein Lernblock wird vorbereitet
+						</Text>
+						<Text className="mt-2 text-center font-poppins text-body-3 text-secondary-text">
+							Dayova erstellt gerade passende Inhalte aus deinen Unterlagen. Du
+							kannst zum Lernplan zurückgehen – die Vorbereitung läuft weiter.
+						</Text>
+						{errorMessage ? (
+							<ErrorMessage className="mt-5">{errorMessage}</ErrorMessage>
+						) : null}
+						{errorMessage ||
+						content?.session.contentGenerationStatus === "failed" ? (
+							<Button
+								className="mt-8"
+								disabled={isBusy}
+								onPress={retrySessionPreparation}
+							>
+								{isBusy ? (
+									<ActivityIndicator
+										color={DAYOVA_DESIGN_SYSTEM.colors.light1}
+									/>
+								) : (
+									<Text>Erneut versuchen</Text>
+								)}
+							</Button>
+						) : null}
+						<Button className="mt-4" onPress={goBack} variant="neutral">
+							<Text>Zurück zum Lernplan</Text>
+						</Button>
 					</View>
 				) : showAnalysis ? (
 					<AnalysisView

--- a/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
@@ -139,6 +139,40 @@ describe("learning-plan path", () => {
 		expect(onOpen).toHaveBeenCalledTimes(1);
 	});
 
+	test("keeps a session closed while its content is being prepared", async () => {
+		const screen = await render(
+			<SessionPreviewCard
+				canOpen={false}
+				preparationState="preparing"
+				session={session("session_preparing")}
+				onOpen={() => undefined}
+			/>,
+		);
+
+		expect(
+			screen.getByText("Lerninhalte werden vorbereitet"),
+		).toBeOnTheScreen();
+		expect(screen.queryByText("Lernsession starten")).toBeNull();
+	});
+
+	test("offers a retry when content preparation fails", async () => {
+		const onRetryPreparation = jest.fn();
+		const screen = await render(
+			<SessionPreviewCard
+				canOpen={false}
+				preparationState="failed"
+				session={session("session_failed")}
+				onOpen={() => undefined}
+				onRetryPreparation={onRetryPreparation}
+			/>,
+		);
+
+		fireEvent.press(
+			screen.getByRole("button", { name: /Vorbereitung erneut/ }),
+		);
+		expect(onRetryPreparation).toHaveBeenCalledTimes(1);
+	});
+
 	test("keeps status and selection reason labels out of the preview card", async () => {
 		const screen = await render(
 			<SessionPreviewCard

--- a/src/features/learning-plans/theory-topic-page.tsx
+++ b/src/features/learning-plans/theory-topic-page.tsx
@@ -28,6 +28,7 @@ import { useDayovaTheme } from "~/lib/theme";
 import {
 	adaptTheoryTopic,
 	buildTheorySpeechText,
+	getTheoryPagePresentation,
 	getTheoryTopicNavigation,
 	splitTheorySpeechText,
 	type TheoryTopic,
@@ -156,6 +157,7 @@ export function TheoryTopicPage({
 	const { colors } = useDayovaTheme();
 	const reduceMotion = useReducedMotion();
 	const topic = adaptTheoryTopic(item, currentIndex);
+	const presentation = getTheoryPagePresentation(item.questionAngle);
 	const navigation = getTheoryTopicNavigation(currentIndex, total);
 	const [isSpeaking, setIsSpeaking] = useState(false);
 	const [speechError, setSpeechError] = useState<string | null>(null);
@@ -183,7 +185,7 @@ export function TheoryTopicPage({
 				if (speechRunRef.current !== nextRun) return;
 
 				const speechChunks = splitTheorySpeechText(
-					buildTheorySpeechText(topic),
+					buildTheorySpeechText(topic, item.questionAngle),
 					Speech.maxSpeechInputLength,
 				);
 				const speakChunk = (chunkIndex: number) => {
@@ -222,7 +224,7 @@ export function TheoryTopicPage({
 				setIsSpeaking(false);
 				setSpeechError(SPEECH_ERROR_MESSAGE);
 			});
-	}, [isSpeaking, stopSpeaking, topic]);
+	}, [isSpeaking, item.questionAngle, stopSpeaking, topic]);
 
 	const stopAndRun = (action: () => void) => {
 		stopSpeaking();
@@ -297,7 +299,7 @@ export function TheoryTopicPage({
 								/>
 							}
 						>
-							Das solltest du wissen
+							{presentation.sectionTitle}
 						</TopicSectionTitle>
 						<Text
 							selectable
@@ -305,7 +307,7 @@ export function TheoryTopicPage({
 						>
 							{topic.explanation}
 						</Text>
-						{topic.keyPoints.length > 0 ? (
+						{presentation.showKeyPoints && topic.keyPoints.length > 0 ? (
 							<View className="gap-3">
 								{topic.keyPoints.map((keyPoint) => (
 									<View key={keyPoint} className="flex-row gap-3">
@@ -322,7 +324,7 @@ export function TheoryTopicPage({
 						) : null}
 					</View>
 
-					{topic.example ? (
+					{presentation.showExample && topic.example ? (
 						<View className="gap-4 rounded-[32px] border border-primary/20 bg-system-subtle px-5 py-5">
 							<TopicSectionTitle
 								icon={
@@ -341,7 +343,7 @@ export function TheoryTopicPage({
 						</View>
 					) : null}
 
-					{topic.memoryCue ? (
+					{presentation.showMemoryCue && topic.memoryCue ? (
 						<View className="gap-4 rounded-[32px] bg-theorie-subtle px-5 py-5">
 							<TopicSectionTitle
 								icon={
@@ -360,7 +362,7 @@ export function TheoryTopicPage({
 						</View>
 					) : null}
 
-					{topic.commonMistake ? (
+					{presentation.showCommonMistake && topic.commonMistake ? (
 						<View className="gap-4 rounded-[32px] bg-wrong-subtle px-5 py-5">
 							<TopicSectionTitle
 								icon={

--- a/src/features/learning-plans/theory-topic.test.ts
+++ b/src/features/learning-plans/theory-topic.test.ts
@@ -3,6 +3,7 @@ import type { SessionContentItem } from "./types";
 import {
 	adaptTheoryTopic,
 	buildTheorySpeechText,
+	getTheoryPagePresentation,
 	getTheoryTopicNavigation,
 	runTheoryTopicPrimaryAction,
 	splitTheorySpeechText,
@@ -100,6 +101,45 @@ test("speech text includes every visible topic section in reading order", () => 
 	expect(speechText).toBe(
 		"Äquivalenzumformungen. Leitfrage: Warum bleibt die Lösungsmenge gleich? Erklärung: Auf beiden Seiten wird dieselbe Operation ausgeführt. Wichtig: Arbeite schrittweise. Mache eine Probe. Beispiel: x plus 3 ist 7, also ist x gleich 4. Merksatz: Links und rechts gehören zusammen. Typischer Fehler: Nur eine Seite verändern.",
 	);
+});
+
+test("focused theory pages only expose the sections needed for their role", () => {
+	expect(getTheoryPagePresentation("recall")).toMatchObject({
+		sectionTitle: "Kernidee",
+		showKeyPoints: true,
+		showExample: false,
+		showCommonMistake: false,
+	});
+	expect(getTheoryPagePresentation("apply")).toMatchObject({
+		sectionTitle: "So funktioniert es",
+		showKeyPoints: false,
+		showExample: true,
+		showMemoryCue: true,
+	});
+	expect(getTheoryPagePresentation("findError")).toMatchObject({
+		sectionTitle: "Darauf musst du achten",
+		showCommonMistake: true,
+	});
+});
+
+test("speech follows the focused page presentation", () => {
+	const speechText = buildTheorySpeechText(
+		{
+			conceptTitle: "Äquivalenzumformungen",
+			question: "Wie bleibt die Gleichung im Gleichgewicht?",
+			explanation: "Beide Seiten werden gleich behandelt.",
+			keyPoints: ["Führe dieselbe Operation aus."],
+			example: "Aus x plus 3 gleich 7 wird x gleich 4.",
+			memoryCue: "Links und rechts gehören zusammen.",
+			commonMistake: "Nur eine Seite verändern.",
+		},
+		"apply",
+	);
+
+	expect(speechText).toContain("Beispiel:");
+	expect(speechText).toContain("Merksatz:");
+	expect(speechText).not.toContain("Wichtig:");
+	expect(speechText).not.toContain("Typischer Fehler:");
 });
 
 test("speech chunks preserve the complete topic within the platform limit", () => {

--- a/src/features/learning-plans/theory-topic.ts
+++ b/src/features/learning-plans/theory-topic.ts
@@ -10,6 +10,61 @@ export type TheoryTopic = {
 	commonMistake?: string;
 };
 
+export type TheoryPagePresentation = {
+	sectionTitle: string;
+	showKeyPoints: boolean;
+	showExample: boolean;
+	showMemoryCue: boolean;
+	showCommonMistake: boolean;
+};
+
+export const getTheoryPagePresentation = (
+	questionAngle: string | undefined,
+): TheoryPagePresentation => {
+	switch (questionAngle) {
+		case "recall":
+			return {
+				sectionTitle: "Kernidee",
+				showKeyPoints: true,
+				showExample: false,
+				showMemoryCue: true,
+				showCommonMistake: false,
+			};
+		case "recognize":
+			return {
+				sectionTitle: "Woran du es erkennst",
+				showKeyPoints: true,
+				showExample: true,
+				showMemoryCue: false,
+				showCommonMistake: false,
+			};
+		case "apply":
+			return {
+				sectionTitle: "So funktioniert es",
+				showKeyPoints: false,
+				showExample: true,
+				showMemoryCue: true,
+				showCommonMistake: false,
+			};
+		case "findError":
+			return {
+				sectionTitle: "Darauf musst du achten",
+				showKeyPoints: false,
+				showExample: false,
+				showMemoryCue: true,
+				showCommonMistake: true,
+			};
+		default:
+			return {
+				sectionTitle: "Das solltest du wissen",
+				showKeyPoints: true,
+				showExample: true,
+				showMemoryCue: true,
+				showCommonMistake: true,
+			};
+	}
+};
+
 const isGenericLearningCardTitle = (title: string) =>
 	/^Lernkarte\s+\d+$/i.test(title.trim());
 
@@ -32,23 +87,32 @@ export const adaptTheoryTopic = (
 	};
 };
 
-export const buildTheorySpeechText = (topic: TheoryTopic) =>
-	[
+export const buildTheorySpeechText = (
+	topic: TheoryTopic,
+	questionAngle?: string,
+) => {
+	const presentation = getTheoryPagePresentation(questionAngle);
+	return [
 		topic.conceptTitle,
 		`Leitfrage: ${topic.question}`,
 		`Erklärung: ${topic.explanation}`,
-		topic.keyPoints.length > 0
+		presentation.showKeyPoints && topic.keyPoints.length > 0
 			? `Wichtig: ${topic.keyPoints.join(" ")}`
 			: undefined,
-		topic.example ? `Beispiel: ${topic.example}` : undefined,
-		topic.memoryCue ? `Merksatz: ${topic.memoryCue}` : undefined,
-		topic.commonMistake
+		presentation.showExample && topic.example
+			? `Beispiel: ${topic.example}`
+			: undefined,
+		presentation.showMemoryCue && topic.memoryCue
+			? `Merksatz: ${topic.memoryCue}`
+			: undefined,
+		presentation.showCommonMistake && topic.commonMistake
 			? `Typischer Fehler: ${topic.commonMistake}`
 			: undefined,
 	]
 		.filter((section): section is string => Boolean(section))
 		.map((section) => (/[.!?]$/.test(section) ? section : `${section}.`))
 		.join(" ");
+};
 
 export const splitTheorySpeechText = (text: string, maximumLength: number) => {
 	const remainingText = text.trim();

--- a/src/features/learning-plans/types.ts
+++ b/src/features/learning-plans/types.ts
@@ -40,6 +40,7 @@ export type PlanSession = {
 	contentGenerationStatus?: "queued" | "generating" | "ready" | "failed";
 	contentGenerationError?: string;
 	contentGeneratedAt?: number;
+	contentGenerationVersion?: number;
 	sortOrder: number;
 	completed: boolean;
 	executionStatus: SessionExecutionStatus;
@@ -136,6 +137,8 @@ export type LearningSessionContentSnapshot = {
 		compositionVariant: "control" | "split";
 		knowledgeValidationStatus?: "pending" | "completed" | "skipped";
 		knowledgeValidationConfidence?: "unsure" | "somewhatSure" | "sure";
+		contentGenerationStatus?: "queued" | "generating" | "ready" | "failed";
+		contentGenerationVersion?: number;
 		goal: string;
 		expectedOutcome: string;
 		completed: boolean;

--- a/src/features/learning-plans/use-prepare-session-content.ts
+++ b/src/features/learning-plans/use-prepare-session-content.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "convex/react";
+import { useAction } from "convex/react";
 import { useEffect, useEffectEvent, useRef } from "react";
 import { api } from "#convex/_generated/api";
 import type { Id } from "#convex/_generated/dataModel";
@@ -12,8 +12,8 @@ export function usePrepareSessionContent({
 	sessionId: Id<"learningPlanSessions"> | undefined;
 	onError: (error: unknown) => void;
 }) {
-	const ensureSessionContent = useMutation(
-		api.learningSessionContent.ensureSessionContent,
+	const ensureSessionContent = useAction(
+		api.learningPlanAi.ensureSessionContent,
 	);
 	const preparingSessionIdRef = useRef<Id<"learningPlanSessions"> | null>(null);
 	const preparedSessionIdRef = useRef<Id<"learningPlanSessions"> | null>(null);

--- a/src/features/learning-plans/use-prepare-session-content.ui.test.tsx
+++ b/src/features/learning-plans/use-prepare-session-content.ui.test.tsx
@@ -10,18 +10,18 @@ const mockEnsureSessionContent =
 			sessionId: Id<"learningPlanSessions">;
 		}) => Promise<{ itemCount: number }>
 	>();
-const mockUseMutation = jest.fn(
+const mockUseAction = jest.fn(
 	(_reference: unknown) => mockEnsureSessionContent,
 );
 
 jest.mock("convex/react", () => ({
-	useMutation: (reference: unknown) => mockUseMutation(reference),
+	useAction: (reference: unknown) => mockUseAction(reference),
 }));
 
 jest.mock("#convex/_generated/api", () => ({
 	api: {
-		learningSessionContent: {
-			ensureSessionContent: "fastEnsureSessionContent",
+		learningPlanAi: {
+			ensureSessionContent: "qualityEnsureSessionContent",
 		},
 	},
 }));
@@ -42,14 +42,14 @@ function PreparationProbe({
 }
 
 describe("session content preparation", () => {
-	test("uses the immediate Convex mutation once when the session opens", async () => {
+	test("uses the quality content action once when the session opens", async () => {
 		mockEnsureSessionContent.mockResolvedValue({ itemCount: 4 });
 		const onError = jest.fn();
 
 		const screen = await render(<PreparationProbe enabled onError={onError} />);
 
 		await waitFor(() => {
-			expect(mockUseMutation).toHaveBeenCalledWith("fastEnsureSessionContent");
+			expect(mockUseAction).toHaveBeenCalledWith("qualityEnsureSessionContent");
 			expect(mockEnsureSessionContent).toHaveBeenCalledWith({
 				sessionId: "session_1",
 			});


### PR DESCRIPTION
## Summary
- turn theory sessions into coherent four-page mini-lessons with focused page roles and stronger source grounding
- replace the immediate fallback-content race with AI preparation, version and safely upgrade untouched older theory sessions
- prewarm the next committed session and show clear preparing, retry, and return states while content is generated
- accept slightly overlong AI-generated multiple-choice answers and compact them deterministically to the UI limit instead of failing the practical session

## Validation
- pnpm test (94 Vitest files / 582 tests; 32 Jest suites / 98 tests)
- pnpm check
- pnpm format:check
- pnpm exec convex dev --once
- retried the original failed practical session js72z29326j2327s0nt31hmvn18bznxs: generated 4 items and reached ready
- focused in-app visual review on iOS Simulator