### PR TITLE
Fix iOS notification delivery and hide dev tools button

### DIFF
--- a/app.config.cts
+++ b/app.config.cts
@@ -91,6 +91,7 @@ const config: ExpoConfig = {
 	},
 	plugins: [
 		"expo-router",
+		["expo-dev-client", { toolsButton: false }],
 		"expo-status-bar",
 		"@clerk/expo",
 		[

--- a/src/lib/delivered-notification.test.ts
+++ b/src/lib/delivered-notification.test.ts
@@ -23,6 +23,21 @@ test("extracts a delivered Dayova notification", () => {
 	});
 });
 
+test("normalizes iOS notification timestamps expressed in Unix seconds", () => {
+	expect(
+		getDeliveredNotificationInput(
+			{
+				...notification,
+				date: notification.date / 1000,
+			},
+			"user-1",
+		),
+	).toEqual({
+		registrationId: "registration-1",
+		triggeredAt: "2026-06-09T18:06:21.750Z",
+	});
+});
+
 test("ignores notifications scheduled for another account", () => {
 	expect(getDeliveredNotificationInput(notification, "user-2")).toBeNull();
 });

--- a/src/lib/delivered-notification.ts
+++ b/src/lib/delivered-notification.ts
@@ -17,6 +17,8 @@ type NotificationLike = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	value !== null && typeof value === "object" && !Array.isArray(value);
 
+const unixSecondsUpperBound = 10_000_000_000;
+
 export const getDeliveredNotificationInput = (
 	notification: NotificationLike,
 	expectedOwnerId?: string,
@@ -35,7 +37,11 @@ export const getDeliveredNotificationInput = (
 		return null;
 	}
 
-	const triggeredAt = new Date(notification.date);
+	const timestampMilliseconds =
+		notification.date >= 0 && notification.date < unixSecondsUpperBound
+			? notification.date * 1000
+			: notification.date;
+	const triggeredAt = new Date(timestampMilliseconds);
 	if (!Number.isFinite(triggeredAt.getTime())) return null;
 
 	return {

--- a/tests/app-config-loading.test.ts
+++ b/tests/app-config-loading.test.ts
@@ -35,4 +35,38 @@ describe("Expo app config loading", () => {
 		);
 		expect(result.status, result.stderr).toBe(0);
 	});
+
+	it(
+		"disables the Expo Dev Menu floating tools button",
+		() => {
+			const result = spawnSync(
+				resolve(process.cwd(), "node_modules/.bin/expo"),
+				["config", "--type", "introspect", "--json"],
+				{
+					cwd: process.cwd(),
+					encoding: "utf8",
+					env: {
+						...process.env,
+						APP_VARIANT: "development",
+					},
+				},
+			);
+
+			expect(result.status, result.stderr).toBe(0);
+			const config = JSON.parse(result.stdout);
+			expect(config.ios.infoPlist.EXDevMenuShowFloatingActionButton).toBe(false);
+
+			const androidMetadata =
+				config._internal.modResults.android.manifest.manifest.application[0][
+					"meta-data"
+				];
+			expect(androidMetadata).toContainEqual({
+				$: {
+					"android:name": "EXDevMenuShowFloatingActionButton",
+					"android:value": "false",
+				},
+			});
+		},
+		15_000,
+	);
 });


### PR DESCRIPTION
## What changed

- normalize Expo notification delivery timestamps from Unix seconds to JavaScript milliseconds on iOS
- disable the Expo Dev Menu floating tools button in development clients
- add regression coverage for both native-platform behaviors

## Why

Expo Notifications serializes delivered-notification dates differently across platforms: iOS emits Unix seconds while Android emits milliseconds. Treating the iOS value as milliseconds produced a 1970 timestamp, causing `recordDeliveredNotification` to reject otherwise valid notifications with `Ungültige Mitteilung`.

The floating gear shown over learning questions belongs to Expo's development menu rather than Dayova. It has no learner-facing meaning, can be mistaken for a quiz control, obscures content, and exposes debugging UI from the product surface.

## Impact

- delivered notifications are reconciled successfully on iOS
- learning questions no longer show the unrelated developer gear after rebuilding the development client
- Android timestamp behavior remains unchanged

## Validation

- 586 Vitest tests passed
- TypeScript check passed
- Biome check passed
- clean native iOS rebuild installed and launched successfully
- simulator inspection confirmed the floating gear is absent
- live Convex logs confirmed the rebuilt client's `recordDeliveredNotification` mutations succeed
