### PR TITLE
[DAY-60] Show existing-email error on the email step

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -116,6 +116,7 @@ interface AuthFlowContextType {
 	isLoading: boolean;
 	pendingVerification: PendingVerification | null;
 	login: (input: LoginInput) => Promise<AuthFlowResult>;
+	startRegistrationWithEmail: (email: string) => Promise<void>;
 	register: (input: RegisterInput) => Promise<AuthFlowResult>;
 	verifyEmailCode: (code: string) => Promise<AuthFlowResult>;
 	resendVerification: () => Promise<void>;
@@ -754,6 +755,26 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 			}
 		});
 
+	const startRegistrationWithEmail = async (email: string): Promise<void> =>
+		withSubmitting(async () => {
+			if (!clerk.client) {
+				throw new Error("Authentifizierung ist noch nicht bereit.");
+			}
+
+			try {
+				await clerk.client.signUp.upsert({
+					emailAddress: email.trim().toLowerCase(),
+				});
+			} catch (error) {
+				throw new Error(
+					getClerkErrorMessage(
+						error,
+						"E-Mail-Adresse konnte nicht geprüft werden. Bitte versuche es erneut.",
+					),
+				);
+			}
+		});
+
 	const register = async (input: RegisterInput): Promise<AuthFlowResult> =>
 		withSubmitting(async () => {
 			if (!clerk.client) {
@@ -764,7 +785,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 				prepareClerkRegistration(input);
 
 			try {
-				const signUp = await clerk.client.signUp.create(signUpParameters);
+				const signUp = await clerk.client.signUp.upsert(signUpParameters);
 
 				setPendingProfile(profile);
 
@@ -1193,6 +1214,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 					isLoading,
 					pendingVerification,
 					login,
+					startRegistrationWithEmail,
 					register,
 					verifyEmailCode,
 					resendVerification,

--- a/src/features/auth/dayova-auth-flow.tsx
+++ b/src/features/auth/dayova-auth-flow.tsx
@@ -458,8 +458,13 @@ export function OnboardingScreen({
 	const [verificationCode, setVerificationCode] = useState("");
 	const [passwordVisible, setPasswordVisible] = useState(false);
 	const [isRegistering, setIsRegistering] = useState(false);
-	const { register, verifyEmailCode, resendVerification, isLoading } =
-		useAuthFlow();
+	const {
+		startRegistrationWithEmail,
+		register,
+		verifyEmailCode,
+		resendVerification,
+		isLoading,
+	} = useAuthFlow();
 	const { user, isConvexAuthenticated, isPostAuthSyncing } = useAuthSession();
 	const { answers, hasAnswers } = useOnboarding();
 	const activeStep = FLOW_STEPS[activeIndex];
@@ -551,6 +556,24 @@ export function OnboardingScreen({
 
 		if (decision.error) {
 			setError(decision.error);
+			return;
+		}
+
+		if (activeStep.kind === "text" && activeStep.field === "email") {
+			await registrationActionGateRef.current.run(async () => {
+				try {
+					await startRegistrationWithEmail(answers.email);
+					setActiveIndex((current) =>
+						getNextOnboardingStepIndex(current, FLOW_STEPS.length),
+					);
+				} catch (emailError) {
+					setError(
+						emailError instanceof Error
+							? emailError.message
+							: "E-Mail-Adresse konnte nicht geprüft werden. Bitte versuche es erneut.",
+					);
+				}
+			});
 			return;
 		}
 
@@ -1003,7 +1026,7 @@ function QuestionStepView({
 			>
 				<DarkPillButton
 					label={continueLabel}
-					onPress={onContinue}
+					onPress={() => void onContinue()}
 					disabled={busy}
 					busy={busy}
 				/>

--- a/src/features/auth/login-screen.ui.test.tsx
+++ b/src/features/auth/login-screen.ui.test.tsx
@@ -23,6 +23,9 @@ const mockLogin = jest.fn<
 		{ status: "complete" } | { status: "needs_verification"; message: string }
 	>
 >(async () => ({ status: "complete" }));
+const mockStartRegistrationWithEmail = jest.fn<
+	(email: string) => Promise<void>
+>(async () => undefined);
 const mockRegister = jest.fn<
 	(input: {
 		birthDate: string;
@@ -200,20 +203,33 @@ jest.mock("~/components/ui/icon", () => {
 });
 
 jest.mock("~/context/AuthContext", () => ({
-	useAuthFlow: () => ({
-		cancelPasswordReset: mockCancelPasswordReset,
-		completePasswordReset: mockCompletePasswordReset,
-		isLoading: false,
-		login: mockLogin,
-		pendingVerification: null,
-		register: mockRegister,
-		resendPasswordResetCode: mockResendPasswordResetCode,
-		resendVerification: jest.fn(),
-		startPasswordReset: mockStartPasswordReset,
-		verifyEmailCode: jest.fn(),
-		verifyPasswordResetCode: mockVerifyPasswordResetCode,
-		verifyPasswordResetSecondFactor: jest.fn(),
-	}),
+	useAuthFlow: () => {
+		const React = jest.requireActual<typeof import("react")>("react");
+		const [isLoading, setIsLoading] = React.useState(false);
+
+		return {
+			cancelPasswordReset: mockCancelPasswordReset,
+			startRegistrationWithEmail: async (email: string) => {
+				setIsLoading(true);
+				try {
+					await mockStartRegistrationWithEmail(email);
+				} finally {
+					setIsLoading(false);
+				}
+			},
+			completePasswordReset: mockCompletePasswordReset,
+			isLoading,
+			login: mockLogin,
+			pendingVerification: null,
+			register: mockRegister,
+			resendPasswordResetCode: mockResendPasswordResetCode,
+			resendVerification: jest.fn(),
+			startPasswordReset: mockStartPasswordReset,
+			verifyEmailCode: jest.fn(),
+			verifyPasswordResetCode: mockVerifyPasswordResetCode,
+			verifyPasswordResetSecondFactor: jest.fn(),
+		};
+	},
 	useAuthSession: () => ({
 		isConvexAuthenticated: false,
 		isPostAuthSyncing: false,
@@ -493,6 +509,8 @@ describe("CreationLoaderScreen", () => {
 
 describe("OnboardingScreen", () => {
 	beforeEach(() => {
+		mockStartRegistrationWithEmail.mockReset();
+		mockStartRegistrationWithEmail.mockResolvedValue(undefined);
 		mockRegister.mockReset();
 		mockRegister.mockResolvedValue({
 			status: "needs_verification",
@@ -504,6 +522,7 @@ describe("OnboardingScreen", () => {
 		mockOnboarding.answers.schoolType = "prefer_not_to_say";
 		mockOnboarding.answers.grade = "9";
 		mockOnboarding.answers.birthDate = "09.09.2012";
+		mockOnboarding.answers.email = "test@example.com";
 	});
 
 	test("opens with the exact-exam promise and shows compact profile progress", async () => {
@@ -578,6 +597,61 @@ describe("OnboardingScreen", () => {
 			"birthDate",
 			expectedDefaultBirthDate,
 		);
+	});
+
+	test("shows an existing-account error before leaving the email step", async () => {
+		mockStartRegistrationWithEmail.mockRejectedValueOnce(
+			new Error("Für diese E-Mail-Adresse gibt es bereits ein Konto."),
+		);
+		mockOnboarding.answers.email = "existing@example.com";
+		const screen = await render(<OnboardingScreen initialStepId="email" />);
+
+		await fireEvent.press(screen.getByRole("button", { name: "Weiter" }));
+
+		expect(mockStartRegistrationWithEmail).toHaveBeenCalledWith(
+			"existing@example.com",
+		);
+		expect(
+			await screen.findByRole("alert", {
+				name: "Für diese E-Mail-Adresse gibt es bereits ein Konto.",
+			}),
+		).toBeOnTheScreen();
+		expect(
+			screen.getByRole("header", { name: "Wie lautet deine E-Mail-Adresse?" }),
+		).toBeOnTheScreen();
+		expect(
+			screen.queryByRole("header", { name: "Lege dein Passwort fest." }),
+		).toBeNull();
+	});
+
+	test("blocks duplicate email checks while availability is pending", async () => {
+		let finishEmailCheck!: () => void;
+		mockStartRegistrationWithEmail.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					finishEmailCheck = resolve;
+				}),
+		);
+		const screen = await render(<OnboardingScreen initialStepId="email" />);
+		const continueButton = screen.getByRole("button", { name: "Weiter" });
+
+		await fireEvent.press(continueButton);
+		await fireEvent.press(continueButton);
+
+		expect(mockStartRegistrationWithEmail).toHaveBeenCalledTimes(1);
+		const busyButton = await screen.findByRole("button", {
+			name: "Wird verarbeitet",
+		});
+		expect(busyButton.props.accessibilityState).toMatchObject({
+			busy: true,
+			disabled: true,
+		});
+
+		await act(async () => finishEmailCheck());
+
+		expect(
+			await screen.findByRole("header", { name: "Lege dein Passwort fest." }),
+		).toBeOnTheScreen();
 	});
 
 	test("keeps verification progress aligned with the profile steps", async () => {


### PR DESCRIPTION
## Summary

* start the Clerk registration when the learner submits the onboarding email step, so account-exists errors remain on that screen
* reuse the same progressive Clerk sign-up when the password and profile are submitted
* cover the existing-account error, synchronous duplicate submits, and accessible busy state with rendered UI tests

## Validation

* pnpm test — final commit: 94 unit test files / 589 tests and 32 UI suites / 100 tests passed
* pnpm check — repository ESLint and TypeScript passed
* independent Standards and Spec reviews — no remaining findings
* CodeRabbit reviewed final commit 800907d across all 3 changed files — no actionable comments; 5 pre-merge checks passed
* CodeRabbit’s optional hosted ESLint install failed; this is an environment/tooling warning, while the repository’s own pnpm check passed
* pnpm check:unused — still reports only pre-existing findings in unrelated files and dependencies

## Tracking

* Linear: Dayova/dayova-mvp#54
* Closes Dayova/dayova-mvp#54