### PR TITLE
Connect the existing paywall to RevenueCat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,8 @@ EXPO_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 #
 # The iOS and Android values are RevenueCat public SDK keys. They are safe to
 # ship in the app, but both are required for preview/production releases.
+# For local Test Store runs, put the same test_ key in both variables. Never
+# use a Test Store key in a preview or production build.
 #
 # Set the secret API key and webhook authorization only in Convex:
 #   npx convex env set REVENUECAT_SECRET_API_KEY "..."

--- a/app.config.cts
+++ b/app.config.cts
@@ -22,9 +22,14 @@ if (!["development", "preview", "production"].includes(APP_VARIANT)) {
 const isProduction = APP_VARIANT === "production";
 const isReleaseConfig =
 	process.env.EAS_BUILD === "true" || process.env.NODE_ENV === "production";
+const releasePlatform =
+	process.env.EAS_BUILD_PLATFORM === "android" ||
+	process.env.EAS_BUILD_PLATFORM === "ios"
+		? process.env.EAS_BUILD_PLATFORM
+		: undefined;
 
 if (isReleaseConfig) {
-	validatePublicEnvForRelease();
+	validatePublicEnvForRelease(undefined, { platform: releasePlatform });
 }
 
 const APP_VERSION = "1.0.3";

--- a/app.config.cts
+++ b/app.config.cts
@@ -77,7 +77,6 @@ const config: ExpoConfig = {
 		supportsTablet: true,
 		bundleIdentifier: isProduction ? "de.dayova.app" : "de.dayova.app-dev",
 		runtimeVersion: APP_VERSION,
-		usesAppleSignIn: true,
 		infoPlist: {
 			ITSAppUsesNonExemptEncryption: false,
 			...IOS_PRIVACY_PURPOSE_STRINGS,
@@ -97,7 +96,14 @@ const config: ExpoConfig = {
 	plugins: [
 		"expo-router",
 		"expo-status-bar",
-		"@clerk/expo",
+		[
+			"@clerk/expo",
+			{
+				// Dayova uses its own email/password authentication flow. Clerk's
+				// default would otherwise add an unused Sign in with Apple entitlement.
+				appleSignIn: false,
+			},
+		],
 		[
 			"expo-notifications",
 			{

--- a/docs/contexts/design-system/CONTEXT.md
+++ b/docs/contexts/design-system/CONTEXT.md
@@ -96,7 +96,9 @@ tabs, labels that need emphasis, and other highlighted text use SemiBold.
 Large numeric counters use `display-counter` 60/68. The supported content
 hierarchy is `heading-1` 32/48, `heading-2` 24/36, `body-1` 20/30, `body-2`
 16/24, `body-3` 14/21, `body-4` 12/18, and `body-5` 10/15, all with 0px letter
-spacing.
+spacing. Top-level page-intro groups use 12px between their heading and
+supporting copy. Compact navigation chrome, dense data rows, and headings inside
+cards may keep tighter spacing when the elements form one local unit.
 
 Light-mode pill buttons have exactly two visual appearances: the light-mode
 gradient button and the black button using the primary text color `#1A1A1A`.
@@ -112,10 +114,19 @@ subscription completion into two routes. Both use the shared
 saturated outer surface, and
 theme-independent light surfaces for content that needs primary and secondary
 text. Payer choices stay on the first route; they never expand subscription
-details in place. On the subscription route, selected plans and secondary
-actions use `systemSubtle`, payment details use `surface` with a primary-accent
-border, and checkout actions use `primaryStrong` instead of a black neutral
-surface. Reusing shared semantic values keeps both ends of the trial flow
+details in place, and the subscription route does not repeat the chosen payer
+as a summary row. On the subscription route, plan choices use a translucent
+white surface with a thin border, restrained inset highlight, and shadow, while
+their text stays dark in every app theme. The selected plan uses a dark outline
+and checked indicator instead of a tinted fill. The annual plan emphasizes its
+monthly equivalent and keeps the annual charge in the description. The
+subscription header pairs its back action with the current two-step progress in
+one compact row instead of isolating navigation above the page title. Secondary
+actions use `systemSubtle`,
+payment details use `surface` with a primary-accent border, the subscription
+checkout action uses the standard black treatment, and purchase restoration is
+an underlined white link. The parent-payment checkout link continues to use
+`primaryStrong`. Reusing shared semantic values keeps both ends of the trial flow
 synchronized with future Dayova color changes. This treatment is limited to
 focused access-setup moments and is not a third general-purpose light-mode
 button appearance. The trial-activation screen may use its white primary button
@@ -124,6 +135,12 @@ reusable third button appearance. The expired-trial screen passes the fixed
 shared light tokens through the native style API because the tracked Fabric
 variable-invalidation issue can otherwise leave newly mounted descendants with
 mixed light and dark tokens.
+
+The post-purchase confirmation route extends this focused access-flow exception:
+it uses the same `primaryInteractive` gradient and fixed light surfaces, then
+offers one forward-only action into the app. Show it after a newly completed
+purchase, not after restoring an existing subscription, so the celebration
+acknowledges a real transition without becoming recurring friction.
 
 The current app corner system is: info/small boxes use 24px, 345px-wide
 rectangles and card-like surfaces use 32px, and buttons use 44px. Device frame

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -70,6 +70,14 @@ function AppNavigator() {
 							}}
 						/>
 						<Stack.Screen
+							name="pro-welcome"
+							options={{
+								animation: "none",
+								gestureEnabled: false,
+								presentation: "card",
+							}}
+						/>
+						<Stack.Screen
 							name="learning-times/edit"
 							options={{
 								animation: "slide_from_right",

--- a/src/app/pro-welcome.tsx
+++ b/src/app/pro-welcome.tsx
@@ -1,0 +1,5 @@
+import { ProWelcomeScreen } from "~/features/access/pro-welcome-screen";
+
+export default function ProWelcomeRoute() {
+	return <ProWelcomeScreen />;
+}

--- a/src/app/timetable/index.tsx
+++ b/src/app/timetable/index.tsx
@@ -110,7 +110,7 @@ function TimetableIntro() {
 			<Text className="mt-5 font-poppins font-semibold text-heading-2 text-text">
 				Deine Schulzeiten im Tagesplan
 			</Text>
-			<Text className="mt-2 font-poppins text-body-3 text-secondary-text">
+			<Text className="mt-3 font-poppins text-body-3 text-secondary-text">
 				Lade ein Bild oder PDF hoch. Prüfe die erkannten Stunden, bevor sie bei
 				„Heute“ erscheinen und Lernzeiten blockieren.
 			</Text>

--- a/src/features/access/paywall-screen.tsx
+++ b/src/features/access/paywall-screen.tsx
@@ -1,6 +1,6 @@
 import { useUser } from "@clerk/expo";
-import { useRouter } from "expo-router";
 import { LinearGradient } from "expo-linear-gradient";
+import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useRef, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, View } from "react-native";
@@ -27,11 +27,19 @@ const BRAND_COLORS = DAYOVA_DESIGN_SYSTEM.colors;
 const WHITE = BRAND_COLORS.light1;
 // LinearGradient exposes its full-bleed geometry through the native style API.
 const gradientFillStyle = StyleSheet.absoluteFill;
-// This focused branded route intentionally keeps its utility surface light in
-// every app theme. Fixed shared tokens avoid stale CSS variables on Fabric.
+// This focused branded route intentionally keeps its primary payer and utility
+// surfaces light in every app theme. Fixed shared tokens avoid stale CSS
+// variables on Fabric.
 const utilitySurfaceStyle = {
 	backgroundColor: BRAND_COLORS.systemSubtle,
 	borderColor: BRAND_COLORS.primaryAccent,
+};
+const primaryPayerSurfaceStyle = {
+	backgroundColor: BRAND_COLORS.surface,
+	borderColor: BRAND_COLORS.light1,
+};
+const primaryPayerIconStyle = {
+	backgroundColor: BRAND_COLORS.primaryStrong,
 };
 
 export function PaywallScreen() {
@@ -145,16 +153,17 @@ export function PaywallScreen() {
 								</Text>
 								<View className="mt-4 gap-3">
 									<PayerButton
+										description="Direkt im App Store oder bei Google Play"
+										emphasis="primary"
+										icon={CreditCard}
+										label="Ich zahle selbst"
+										onPress={() => openSubscription("self")}
+									/>
+									<PayerButton
 										description="Zahlungslink oder QR-Code teilen"
 										icon={UserRound}
 										label="Meine Eltern zahlen"
 										onPress={() => openSubscription("parent")}
-									/>
-									<PayerButton
-										description="Direkt im App Store oder bei Google Play"
-										icon={CreditCard}
-										label="Ich zahle selbst"
-										onPress={() => openSubscription("self")}
 									/>
 								</View>
 							</View>
@@ -189,25 +198,7 @@ export function PaywallScreen() {
 							</View>
 						) : null}
 
-						<View
-							className="mt-8 rounded-card border px-5 py-2 shadow-black/10 shadow-sm"
-							style={utilitySurfaceStyle}
-							testID="paywall-utility-surface"
-						>
-							<EssentialAction
-								icon={<Logout size={19} color={BRAND_COLORS.secondaryText} />}
-								label="Abmelden oder Konto wechseln"
-								onPress={() => void logout()}
-							/>
-							<EssentialAction
-								icon={<Trash2 size={19} color={BRAND_COLORS.destructive} />}
-								label="Konto löschen"
-								destructive
-								onPress={openAccountDeletion}
-							/>
-						</View>
-
-						<View className="flex-row flex-wrap justify-center gap-x-4 gap-y-2 px-2 pt-5">
+						<View className="flex-row flex-wrap justify-center gap-x-4 gap-y-2 px-2 pt-6">
 							<LegalLink
 								label="Support"
 								url={env.EXPO_PUBLIC_SUPPORT_URL}
@@ -229,6 +220,26 @@ export function PaywallScreen() {
 								onOpen={openLink}
 							/>
 						</View>
+
+						<View
+							className="mt-4 flex-row rounded-3xl border px-2 py-1 shadow-black/5 shadow-sm"
+							style={utilitySurfaceStyle}
+							testID="paywall-utility-surface"
+						>
+							<EssentialAction
+								accessibilityLabel="Abmelden oder Konto wechseln"
+								icon={<Logout size={16} color={BRAND_COLORS.secondaryText} />}
+								label="Konto wechseln"
+								onPress={() => void logout()}
+							/>
+							<View className="my-2 w-px bg-border" />
+							<EssentialAction
+								icon={<Trash2 size={16} color={BRAND_COLORS.destructive} />}
+								label="Konto löschen"
+								destructive
+								onPress={openAccountDeletion}
+							/>
+						</View>
 					</View>
 				</ScrollView>
 			</View>
@@ -248,11 +259,13 @@ export function PaywallScreen() {
 
 function PayerButton({
 	description,
+	emphasis = "secondary",
 	icon,
 	label,
 	onPress,
 }: {
 	description: string;
+	emphasis?: "primary" | "secondary";
 	icon: React.ComponentType<{
 		color?: string;
 		size?: number;
@@ -262,33 +275,80 @@ function PayerButton({
 	onPress: () => void;
 }) {
 	const Icon = icon;
+	const isPrimary = emphasis === "primary";
 
 	return (
 		<Pressable
 			accessibilityLabel={`${label}. ${description}`}
 			accessibilityHint="Öffnet die passende Aboseite."
 			accessibilityRole="button"
-			className="min-h-[72px] flex-row items-center rounded-card border border-white/35 bg-white/20 px-4 py-3 active:opacity-80"
+			className={
+				isPrimary
+					? "min-h-20 flex-row items-center rounded-card border px-4 py-3 shadow-black/15 shadow-md active:opacity-90"
+					: "min-h-[72px] flex-row items-center rounded-card border border-white/50 bg-white/25 px-4 py-3 active:bg-white/30"
+			}
 			onPress={onPress}
+			style={isPrimary ? primaryPayerSurfaceStyle : undefined}
+			testID={`payer-${emphasis}-action`}
 		>
-			<View className="h-10 w-10 items-center justify-center rounded-full bg-white/15">
-				<Icon size={21} color={WHITE} strokeWidth={2.2} />
+			<View
+				className="h-11 w-11 items-center justify-center rounded-full bg-white/20"
+				style={isPrimary ? primaryPayerIconStyle : undefined}
+			>
+				<Icon
+					size={22}
+					color={isPrimary ? WHITE : BRAND_COLORS.light1}
+					strokeWidth={2.3}
+				/>
 			</View>
 			<View className="ml-3 flex-1">
-				<Text className="font-semibold text-body-3 text-white">{label}</Text>
-				<Text className="text-body-4 text-white/75">{description}</Text>
+				{isPrimary ? (
+					<Text className="font-semibold text-body-5 text-primary-strong">
+						SOFORT STARTEN
+					</Text>
+				) : null}
+				<Text
+					className={
+						isPrimary
+							? "font-semibold text-body-2"
+							: "font-semibold text-body-3"
+					}
+					style={{
+						color: isPrimary ? BRAND_COLORS.text : BRAND_COLORS.light1,
+					}}
+				>
+					{label}
+				</Text>
+				<Text
+					className="text-body-4"
+					style={{
+						color: isPrimary ? BRAND_COLORS.secondaryText : BRAND_COLORS.light1,
+					}}
+				>
+					{description}
+				</Text>
 			</View>
-			<ArrowRight size={19} color={WHITE} strokeWidth={2} />
+			<View
+				className={
+					isPrimary
+						? "h-9 w-9 items-center justify-center rounded-full bg-primary-strong"
+						: "h-9 w-9 items-center justify-center rounded-full bg-white/15"
+				}
+			>
+				<ArrowRight size={18} color={WHITE} strokeWidth={2.2} />
+			</View>
 		</Pressable>
 	);
 }
 
 function EssentialAction({
+	accessibilityLabel,
 	destructive = false,
 	icon,
 	label,
 	onPress,
 }: {
+	accessibilityLabel?: string;
 	destructive?: boolean;
 	icon: React.ReactNode;
 	label: string;
@@ -296,14 +356,15 @@ function EssentialAction({
 }) {
 	return (
 		<Pressable
+			accessibilityLabel={accessibilityLabel}
 			accessibilityRole="button"
-			className="min-h-12 flex-row items-center py-3"
+			className="min-h-11 flex-1 flex-row items-center justify-center px-2 py-2"
 			hitSlop={4}
 			onPress={onPress}
 		>
-			<View className="mr-3">{icon}</View>
+			<View className="mr-2.5">{icon}</View>
 			<Text
-				className="flex-1 text-body-3"
+				className="font-semibold text-body-5"
 				style={{
 					color: destructive
 						? BRAND_COLORS.destructive
@@ -312,7 +373,6 @@ function EssentialAction({
 			>
 				{label}
 			</Text>
-			<ArrowRight size={18} color={BRAND_COLORS.secondaryText} />
 		</Pressable>
 	);
 }

--- a/src/features/access/paywall-screen.tsx
+++ b/src/features/access/paywall-screen.tsx
@@ -166,16 +166,17 @@ export function PaywallScreen() {
 								<View className="mt-4 gap-3">
 									<PayerButton
 										description="Direkt im App Store oder bei Google Play"
-										emphasis="primary"
 										icon={CreditCard}
 										label="Ich zahle selbst"
 										onPress={() => openSubscription("self")}
+										testID="payer-self-action"
 									/>
 									<PayerButton
 										description="Zahlungslink oder QR-Code teilen"
 										icon={UserRound}
 										label="Meine Eltern zahlen"
 										onPress={() => openSubscription("parent")}
+										testID="payer-parent-action"
 									/>
 								</View>
 							</View>
@@ -279,13 +280,12 @@ export function PaywallScreen() {
 
 function PayerButton({
 	description,
-	emphasis = "secondary",
 	icon,
 	label,
 	onPress,
+	testID,
 }: {
 	description: string;
-	emphasis?: "primary" | "secondary";
 	icon: React.ComponentType<{
 		color?: string;
 		size?: number;
@@ -293,68 +293,44 @@ function PayerButton({
 	}>;
 	label: string;
 	onPress: () => void;
+	testID: string;
 }) {
 	const Icon = icon;
-	const isPrimary = emphasis === "primary";
 
 	return (
 		<Pressable
 			accessibilityLabel={`${label}. ${description}`}
 			accessibilityHint="Öffnet die passende Aboseite."
 			accessibilityRole="button"
-			className={
-				isPrimary
-					? "min-h-20 flex-row items-center rounded-card border px-4 py-3 shadow-black/15 shadow-md active:opacity-90"
-					: "min-h-[72px] flex-row items-center rounded-card border border-white/50 bg-white/25 px-4 py-3 active:bg-white/30"
-			}
+			className="min-h-20 flex-row items-center rounded-card border px-4 py-3 shadow-black/15 shadow-md active:opacity-90"
 			onPress={onPress}
-			style={isPrimary ? primaryPayerSurfaceStyle : undefined}
-			testID={`payer-${emphasis}-action`}
+			style={primaryPayerSurfaceStyle}
+			testID={testID}
 		>
 			<View
 				className="h-11 w-11 items-center justify-center rounded-full bg-white/20"
-				style={isPrimary ? primaryPayerIconStyle : undefined}
+				style={primaryPayerIconStyle}
 			>
-				<Icon
-					size={22}
-					color={isPrimary ? WHITE : BRAND_COLORS.light1}
-					strokeWidth={2.3}
-				/>
+				<Icon size={22} color={WHITE} strokeWidth={2.3} />
 			</View>
 			<View className="ml-3 flex-1">
-				{isPrimary ? (
-					<Text className="font-semibold text-body-5 text-primary-strong">
-						SOFORT STARTEN
-					</Text>
-				) : null}
+				<Text className="font-semibold text-body-5 text-primary-strong">
+					SOFORT STARTEN
+				</Text>
 				<Text
-					className={
-						isPrimary
-							? "font-semibold text-body-2"
-							: "font-semibold text-body-3"
-					}
-					style={{
-						color: isPrimary ? BRAND_COLORS.text : BRAND_COLORS.light1,
-					}}
+					className="font-semibold text-body-3"
+					style={{ color: BRAND_COLORS.text }}
 				>
 					{label}
 				</Text>
 				<Text
 					className="text-body-4"
-					style={{
-						color: isPrimary ? BRAND_COLORS.secondaryText : BRAND_COLORS.light1,
-					}}
+					style={{ color: BRAND_COLORS.secondaryText }}
 				>
 					{description}
 				</Text>
 			</View>
-			<View
-				className={
-					isPrimary
-						? "h-9 w-9 items-center justify-center rounded-full bg-primary-strong"
-						: "h-9 w-9 items-center justify-center rounded-full bg-white/15"
-				}
-			>
+			<View className="h-9 w-9 items-center justify-center rounded-full bg-primary-strong">
 				<ArrowRight size={18} color={WHITE} strokeWidth={2.2} />
 			</View>
 		</Pressable>

--- a/src/features/access/paywall-screen.tsx
+++ b/src/features/access/paywall-screen.tsx
@@ -247,16 +247,6 @@ export function PaywallScreen() {
 				onClose={() => setShowSubscriptionManagement(false)}
 				onDismiss={finishSubscriptionManagementDismissal}
 			>
-				<View className="mb-5 rounded-3xl bg-system-subtle px-4 py-4">
-					<Text className="font-semibold text-body-3 text-text">
-						Gut zu wissen
-					</Text>
-					<Text className="mt-1 text-body-4 text-secondary-text">
-						Bei einem Kontowechsel bleibt dein Lernstand erhalten. Ein
-						bestehendes Store-Abo verwaltest und kündigst du direkt im App Store
-						oder bei Google Play.
-					</Text>
-				</View>
 				<View className="overflow-hidden rounded-card border border-border/45 bg-card">
 					<ManagementAction
 						accessibilityLabel="Abmelden oder Konto wechseln"

--- a/src/features/access/paywall-screen.tsx
+++ b/src/features/access/paywall-screen.tsx
@@ -2,7 +2,7 @@ import { useUser } from "@clerk/expo";
 import { LinearGradient } from "expo-linear-gradient";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useRef, useState } from "react";
+import { type RefObject, useRef, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ConfirmationSheet } from "~/components/ui/confirmation-sheet";
@@ -47,7 +47,8 @@ export function PaywallScreen() {
 	const [error, setError] = useState<string | null>(null);
 	const [showSubscriptionManagement, setShowSubscriptionManagement] =
 		useState(false);
-	const pendingManagementActionRef = useRef<"delete" | null>(null);
+	const subscriptionManagementLinkRef = useRef<View>(null);
+	const pendingManagementActionRef = useRef<"delete" | "switch" | null>(null);
 	const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 	const [isDeletingAccount, setIsDeletingAccount] = useState(false);
 	const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -67,14 +68,19 @@ export function PaywallScreen() {
 	};
 
 	const finishSubscriptionManagementDismissal = () => {
-		if (pendingManagementActionRef.current !== "delete") return;
+		const pendingAction = pendingManagementActionRef.current;
 		pendingManagementActionRef.current = null;
-		setShowDeleteConfirmation(true);
+		if (pendingAction === "delete") {
+			setShowDeleteConfirmation(true);
+		}
+		if (pendingAction === "switch") {
+			void logout();
+		}
 	};
 
 	const switchAccount = () => {
+		pendingManagementActionRef.current = "switch";
 		setShowSubscriptionManagement(false);
-		void logout();
 	};
 
 	const deleteAccount = async () => {
@@ -233,6 +239,7 @@ export function PaywallScreen() {
 								onOpen={openLink}
 							/>
 							<LegalLink
+								buttonRef={subscriptionManagementLinkRef}
 								label="Abo verwalten"
 								onPress={() => setShowSubscriptionManagement(true)}
 							/>
@@ -247,6 +254,7 @@ export function PaywallScreen() {
 				closeAccessibilityLabel="Abo-Verwaltung schließen"
 				onClose={() => setShowSubscriptionManagement(false)}
 				onDismiss={finishSubscriptionManagementDismissal}
+				returnFocusRef={subscriptionManagementLinkRef}
 			>
 				<View className="overflow-hidden rounded-card border border-border/45 bg-card">
 					<ManagementAction
@@ -381,11 +389,13 @@ function ManagementAction({
 }
 
 function LegalLink({
+	buttonRef,
 	label,
 	onOpen,
 	onPress,
 	url,
 }: {
+	buttonRef?: RefObject<View | null>;
 	label: string;
 	onOpen?: (url?: string) => Promise<void>;
 	onPress?: () => void;
@@ -393,6 +403,7 @@ function LegalLink({
 }) {
 	return (
 		<Pressable
+			ref={buttonRef}
 			accessibilityRole="link"
 			disabled={!url && !onPress}
 			hitSlop={8}

--- a/src/features/access/paywall-screen.tsx
+++ b/src/features/access/paywall-screen.tsx
@@ -129,7 +129,7 @@ export function PaywallScreen() {
 					}}
 				>
 					<View className="px-7 pt-5">
-						<View className="gap-2 pb-7">
+						<View className="gap-3 pb-7">
 							<Text className="font-semibold text-body-4 text-white/85">
 								TESTPHASE BEENDET
 							</Text>

--- a/src/features/access/paywall-screen.tsx
+++ b/src/features/access/paywall-screen.tsx
@@ -6,6 +6,7 @@ import { useRef, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ConfirmationSheet } from "~/components/ui/confirmation-sheet";
+import { DayovaSheetFrame } from "~/components/ui/dayova-sheet-frame";
 import {
 	ArrowRight,
 	CreditCard,
@@ -27,13 +28,9 @@ const BRAND_COLORS = DAYOVA_DESIGN_SYSTEM.colors;
 const WHITE = BRAND_COLORS.light1;
 // LinearGradient exposes its full-bleed geometry through the native style API.
 const gradientFillStyle = StyleSheet.absoluteFill;
-// This focused branded route intentionally keeps its primary payer and utility
-// surfaces light in every app theme. Fixed shared tokens avoid stale CSS
-// variables on Fabric.
-const utilitySurfaceStyle = {
-	backgroundColor: BRAND_COLORS.systemSubtle,
-	borderColor: BRAND_COLORS.primaryAccent,
-};
+// This focused branded route intentionally keeps its primary payer surface
+// light in every app theme. Fixed shared tokens avoid stale CSS variables on
+// Fabric.
 const primaryPayerSurfaceStyle = {
 	backgroundColor: BRAND_COLORS.surface,
 	borderColor: BRAND_COLORS.light1,
@@ -48,6 +45,9 @@ export function PaywallScreen() {
 	const router = useRouter();
 	const insets = useSafeAreaInsets();
 	const [error, setError] = useState<string | null>(null);
+	const [showSubscriptionManagement, setShowSubscriptionManagement] =
+		useState(false);
+	const pendingManagementActionRef = useRef<"delete" | null>(null);
 	const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 	const [isDeletingAccount, setIsDeletingAccount] = useState(false);
 	const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -60,9 +60,21 @@ export function PaywallScreen() {
 		});
 	};
 
-	const openAccountDeletion = () => {
+	const requestAccountDeletion = () => {
 		setDeleteError(null);
+		pendingManagementActionRef.current = "delete";
+		setShowSubscriptionManagement(false);
+	};
+
+	const finishSubscriptionManagementDismissal = () => {
+		if (pendingManagementActionRef.current !== "delete") return;
+		pendingManagementActionRef.current = null;
 		setShowDeleteConfirmation(true);
+	};
+
+	const switchAccount = () => {
+		setShowSubscriptionManagement(false);
+		void logout();
 	};
 
 	const deleteAccount = async () => {
@@ -219,30 +231,48 @@ export function PaywallScreen() {
 								url={env.EXPO_PUBLIC_CANCELLATION_URL}
 								onOpen={openLink}
 							/>
-						</View>
-
-						<View
-							className="mt-4 flex-row rounded-3xl border px-2 py-1 shadow-black/5 shadow-sm"
-							style={utilitySurfaceStyle}
-							testID="paywall-utility-surface"
-						>
-							<EssentialAction
-								accessibilityLabel="Abmelden oder Konto wechseln"
-								icon={<Logout size={16} color={BRAND_COLORS.secondaryText} />}
-								label="Konto wechseln"
-								onPress={() => void logout()}
-							/>
-							<View className="my-2 w-px bg-border" />
-							<EssentialAction
-								icon={<Trash2 size={16} color={BRAND_COLORS.destructive} />}
-								label="Konto löschen"
-								destructive
-								onPress={openAccountDeletion}
+							<LegalLink
+								label="Abo verwalten"
+								onPress={() => setShowSubscriptionManagement(true)}
 							/>
 						</View>
 					</View>
 				</ScrollView>
 			</View>
+			<DayovaSheetFrame
+				visible={showSubscriptionManagement}
+				title="Abo verwalten"
+				description="Hier findest du Informationen zu deinem Zugang und kannst dein Dayova-Konto wechseln oder löschen."
+				closeAccessibilityLabel="Abo-Verwaltung schließen"
+				onClose={() => setShowSubscriptionManagement(false)}
+				onDismiss={finishSubscriptionManagementDismissal}
+			>
+				<View className="mb-5 rounded-3xl bg-system-subtle px-4 py-4">
+					<Text className="font-semibold text-body-3 text-text">
+						Gut zu wissen
+					</Text>
+					<Text className="mt-1 text-body-4 text-secondary-text">
+						Bei einem Kontowechsel bleibt dein Lernstand erhalten. Ein
+						bestehendes Store-Abo verwaltest und kündigst du direkt im App Store
+						oder bei Google Play.
+					</Text>
+				</View>
+				<View className="overflow-hidden rounded-card border border-border/45 bg-card">
+					<ManagementAction
+						accessibilityLabel="Abmelden oder Konto wechseln"
+						icon={<Logout size={20} color={BRAND_COLORS.primaryStrong} />}
+						label="Konto wechseln"
+						onPress={switchAccount}
+					/>
+					<View className="mx-4 h-px bg-border" />
+					<ManagementAction
+						destructive
+						icon={<Trash2 size={20} color={BRAND_COLORS.destructive} />}
+						label="Konto löschen"
+						onPress={requestAccountDeletion}
+					/>
+				</View>
+			</DayovaSheetFrame>
 			<ConfirmationSheet
 				visible={showDeleteConfirmation}
 				title="Konto wirklich löschen?"
@@ -341,7 +371,7 @@ function PayerButton({
 	);
 }
 
-function EssentialAction({
+function ManagementAction({
 	accessibilityLabel,
 	destructive = false,
 	icon,
@@ -358,21 +388,28 @@ function EssentialAction({
 		<Pressable
 			accessibilityLabel={accessibilityLabel}
 			accessibilityRole="button"
-			className="min-h-11 flex-1 flex-row items-center justify-center px-2 py-2"
-			hitSlop={4}
+			className="min-h-14 flex-row items-center px-4 py-3 active:bg-system-subtle"
 			onPress={onPress}
 		>
-			<View className="mr-2.5">{icon}</View>
+			<View className="mr-3 h-10 w-10 items-center justify-center rounded-full bg-system-subtle">
+				{icon}
+			</View>
 			<Text
-				className="font-semibold text-body-5"
-				style={{
-					color: destructive
-						? BRAND_COLORS.destructive
-						: BRAND_COLORS.secondaryText,
-				}}
+				className={
+					destructive
+						? "flex-1 font-semibold text-body-3 text-destructive"
+						: "flex-1 font-semibold text-body-3 text-text"
+				}
 			>
 				{label}
 			</Text>
+			<ArrowRight
+				size={18}
+				color={
+					destructive ? BRAND_COLORS.destructive : BRAND_COLORS.secondaryText
+				}
+				strokeWidth={2}
+			/>
 		</Pressable>
 	);
 }
@@ -380,18 +417,26 @@ function EssentialAction({
 function LegalLink({
 	label,
 	onOpen,
+	onPress,
 	url,
 }: {
 	label: string;
-	onOpen: (url?: string) => Promise<void>;
+	onOpen?: (url?: string) => Promise<void>;
+	onPress?: () => void;
 	url?: string;
 }) {
 	return (
 		<Pressable
 			accessibilityRole="link"
-			disabled={!url}
+			disabled={!url && !onPress}
 			hitSlop={8}
-			onPress={() => void onOpen(url)}
+			onPress={() => {
+				if (onPress) {
+					onPress();
+					return;
+				}
+				if (onOpen) void onOpen(url);
+			}}
 		>
 			<Text className="text-body-4 text-white underline">{label}</Text>
 		</Pressable>

--- a/src/features/access/paywall-screen.ui.test.tsx
+++ b/src/features/access/paywall-screen.ui.test.tsx
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
-import { fireEvent, render } from "@testing-library/react-native";
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
 import type { ReactNode } from "react";
 import { PaywallScreen } from "./paywall-screen";
 
 const mockPush = jest.fn();
+const mockLogout = jest.fn();
 
 beforeEach(() => {
 	jest.clearAllMocks();
@@ -44,13 +45,60 @@ jest.mock("react-native-safe-area-context", () => ({
 	useSafeAreaInsets: () => ({ bottom: 34, left: 0, right: 0, top: 59 }),
 }));
 
-jest.mock("~/components/ui/confirmation-sheet", () => ({
-	ConfirmationSheet: () => null,
-}));
+jest.mock("~/components/ui/confirmation-sheet", () => {
+	const React = jest.requireActual<typeof import("react")>("react");
+	const { Text: NativeText } =
+		jest.requireActual<typeof import("react-native")>("react-native");
+	return {
+		ConfirmationSheet: ({
+			title,
+			visible,
+		}: {
+			title: ReactNode;
+			visible: boolean;
+		}) => (visible ? React.createElement(NativeText, null, title) : null),
+	};
+});
+
+jest.mock("~/components/ui/dayova-sheet-frame", () => {
+	const React = jest.requireActual<typeof import("react")>("react");
+	const { Text: NativeText, View: NativeView } =
+		jest.requireActual<typeof import("react-native")>("react-native");
+	return {
+		DayovaSheetFrame: ({
+			children,
+			description,
+			onDismiss,
+			title,
+			visible,
+		}: {
+			children?: ReactNode;
+			description?: ReactNode;
+			onDismiss?: () => void;
+			title?: ReactNode;
+			visible: boolean;
+		}) => {
+			const wasVisible = React.useRef(false);
+			React.useEffect(() => {
+				if (wasVisible.current && !visible) onDismiss?.();
+				wasVisible.current = visible;
+			}, [onDismiss, visible]);
+
+			if (!visible) return null;
+			return React.createElement(
+				NativeView,
+				null,
+				title ? React.createElement(NativeText, null, title) : null,
+				description ? React.createElement(NativeText, null, description) : null,
+				children,
+			);
+		},
+	};
+});
 
 jest.mock("~/context/AuthContext", () => ({
 	useAccountActions: () => ({
-		logout: jest.fn(),
+		logout: mockLogout,
 	}),
 }));
 
@@ -70,15 +118,6 @@ describe("PaywallScreen", () => {
 		).toBeOnTheScreen();
 		expect(screen.getByText("Zugang freischalten")).toBeOnTheScreen();
 		expect(screen.queryByText("Tarif wählen")).not.toBeOnTheScreen();
-		expect(screen.getByTestId("paywall-utility-surface").props.style).toEqual(
-			expect.objectContaining({
-				backgroundColor: "#F1F7FB",
-				borderColor: "#4FD8FF",
-			}),
-		);
-		expect(
-			screen.getByTestId("paywall-utility-surface").props.className,
-		).toContain("rounded-3xl");
 		expect(screen.getByTestId("payer-primary-action").props.style).toEqual(
 			expect.objectContaining({
 				backgroundColor: "#FFFFFF",
@@ -93,9 +132,9 @@ describe("PaywallScreen", () => {
 		).toContain("bg-white/25");
 		expect(screen.getByText("SOFORT STARTEN")).toBeOnTheScreen();
 		expect(
-			screen.getByLabelText("Abmelden oder Konto wechseln"),
+			screen.getByRole("link", { name: "Abo verwalten" }),
 		).toBeOnTheScreen();
-		expect(screen.getByText("Konto wechseln")).toBeOnTheScreen();
+		expect(screen.queryByText("Konto wechseln")).toBeNull();
 	});
 
 	test("opens the separate subscription page for the chosen payer", async () => {
@@ -121,5 +160,35 @@ describe("PaywallScreen", () => {
 			params: { payer: "self" },
 		});
 		expect(screen.queryByText("Tarif wählen")).not.toBeOnTheScreen();
+	});
+
+	test("moves account actions into subscription management", async () => {
+		const screen = await render(<PaywallScreen />);
+
+		fireEvent.press(screen.getByRole("link", { name: "Abo verwalten" }));
+
+		expect(await screen.findByText("Gut zu wissen")).toBeOnTheScreen();
+		expect(screen.getByText(/Bei einem Kontowechsel/)).toBeOnTheScreen();
+		expect(
+			screen.getByLabelText("Abmelden oder Konto wechseln"),
+		).toBeOnTheScreen();
+		expect(screen.getByText("Konto löschen")).toBeOnTheScreen();
+
+		fireEvent.press(screen.getByLabelText("Abmelden oder Konto wechseln"));
+		expect(mockLogout).toHaveBeenCalledTimes(1);
+	});
+
+	test("keeps account deletion behind a separate confirmation", async () => {
+		const screen = await render(<PaywallScreen />);
+
+		fireEvent.press(screen.getByRole("link", { name: "Abo verwalten" }));
+		const deleteAccountButton = await screen.findByText("Konto löschen");
+		await act(async () => {
+			fireEvent.press(deleteAccountButton);
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText("Konto wirklich löschen?")).toBeOnTheScreen();
+		});
 	});
 });

--- a/src/features/access/paywall-screen.ui.test.tsx
+++ b/src/features/access/paywall-screen.ui.test.tsx
@@ -76,6 +76,26 @@ describe("PaywallScreen", () => {
 				borderColor: "#4FD8FF",
 			}),
 		);
+		expect(
+			screen.getByTestId("paywall-utility-surface").props.className,
+		).toContain("rounded-3xl");
+		expect(screen.getByTestId("payer-primary-action").props.style).toEqual(
+			expect.objectContaining({
+				backgroundColor: "#FFFFFF",
+				borderColor: "#FFFFFF",
+			}),
+		);
+		expect(
+			screen.getByTestId("payer-primary-action").props.className,
+		).toContain("shadow-md");
+		expect(
+			screen.getByTestId("payer-secondary-action").props.className,
+		).toContain("bg-white/25");
+		expect(screen.getByText("SOFORT STARTEN")).toBeOnTheScreen();
+		expect(
+			screen.getByLabelText("Abmelden oder Konto wechseln"),
+		).toBeOnTheScreen();
+		expect(screen.getByText("Konto wechseln")).toBeOnTheScreen();
 	});
 
 	test("opens the separate subscription page for the chosen payer", async () => {

--- a/src/features/access/paywall-screen.ui.test.tsx
+++ b/src/features/access/paywall-screen.ui.test.tsx
@@ -5,9 +5,18 @@ import { PaywallScreen } from "./paywall-screen";
 
 const mockPush = jest.fn();
 const mockLogout = jest.fn();
+const mockSubscriptionManagementSheet: {
+	onDismiss: null | (() => void);
+	returnFocusRef: null | { current: unknown };
+} = {
+	onDismiss: null,
+	returnFocusRef: null,
+};
 
 beforeEach(() => {
 	jest.clearAllMocks();
+	mockSubscriptionManagementSheet.onDismiss = null;
+	mockSubscriptionManagementSheet.returnFocusRef = null;
 });
 
 jest.mock("@clerk/expo", () => ({
@@ -69,20 +78,19 @@ jest.mock("~/components/ui/dayova-sheet-frame", () => {
 			children,
 			description,
 			onDismiss,
+			returnFocusRef,
 			title,
 			visible,
 		}: {
 			children?: ReactNode;
 			description?: ReactNode;
 			onDismiss?: () => void;
+			returnFocusRef?: { current: unknown };
 			title?: ReactNode;
 			visible: boolean;
 		}) => {
-			const wasVisible = React.useRef(false);
-			React.useEffect(() => {
-				if (wasVisible.current && !visible) onDismiss?.();
-				wasVisible.current = visible;
-			}, [onDismiss, visible]);
+			mockSubscriptionManagementSheet.onDismiss = onDismiss ?? null;
+			mockSubscriptionManagementSheet.returnFocusRef = returnFocusRef ?? null;
 
 			if (!visible) return null;
 			return React.createElement(
@@ -171,8 +179,28 @@ describe("PaywallScreen", () => {
 		).toBeOnTheScreen();
 		expect(screen.getByText("Konto löschen")).toBeOnTheScreen();
 
-		fireEvent.press(screen.getByLabelText("Abmelden oder Konto wechseln"));
+		await act(async () => {
+			fireEvent.press(screen.getByLabelText("Abmelden oder Konto wechseln"));
+		});
+		expect(screen.queryByText("Konto wechseln")).toBeNull();
+		expect(mockLogout).not.toHaveBeenCalled();
+
+		await act(async () => {
+			mockSubscriptionManagementSheet.onDismiss?.();
+		});
 		expect(mockLogout).toHaveBeenCalledTimes(1);
+	});
+
+	test("returns focus to the subscription management link", async () => {
+		const screen = await render(<PaywallScreen />);
+
+		fireEvent.press(screen.getByRole("link", { name: "Abo verwalten" }));
+		expect(await screen.findByText("Konto wechseln")).toBeOnTheScreen();
+
+		expect(mockSubscriptionManagementSheet.returnFocusRef).not.toBeNull();
+		expect(
+			mockSubscriptionManagementSheet.returnFocusRef?.current,
+		).not.toBeNull();
 	});
 
 	test("keeps account deletion behind a separate confirmation", async () => {
@@ -182,6 +210,11 @@ describe("PaywallScreen", () => {
 		const deleteAccountButton = await screen.findByText("Konto löschen");
 		await act(async () => {
 			fireEvent.press(deleteAccountButton);
+		});
+		expect(screen.queryByText("Konto wirklich löschen?")).toBeNull();
+
+		await act(async () => {
+			mockSubscriptionManagementSheet.onDismiss?.();
 		});
 
 		await waitFor(() => {

--- a/src/features/access/paywall-screen.ui.test.tsx
+++ b/src/features/access/paywall-screen.ui.test.tsx
@@ -167,8 +167,8 @@ describe("PaywallScreen", () => {
 
 		fireEvent.press(screen.getByRole("link", { name: "Abo verwalten" }));
 
-		expect(await screen.findByText("Gut zu wissen")).toBeOnTheScreen();
-		expect(screen.getByText(/Bei einem Kontowechsel/)).toBeOnTheScreen();
+		expect(await screen.findByText("Konto wechseln")).toBeOnTheScreen();
+		expect(screen.queryByText("Gut zu wissen")).toBeNull();
 		expect(
 			screen.getByLabelText("Abmelden oder Konto wechseln"),
 		).toBeOnTheScreen();

--- a/src/features/access/paywall-screen.ui.test.tsx
+++ b/src/features/access/paywall-screen.ui.test.tsx
@@ -118,19 +118,16 @@ describe("PaywallScreen", () => {
 		).toBeOnTheScreen();
 		expect(screen.getByText("Zugang freischalten")).toBeOnTheScreen();
 		expect(screen.queryByText("Tarif wählen")).not.toBeOnTheScreen();
-		expect(screen.getByTestId("payer-primary-action").props.style).toEqual(
-			expect.objectContaining({
-				backgroundColor: "#FFFFFF",
-				borderColor: "#FFFFFF",
-			}),
-		);
-		expect(
-			screen.getByTestId("payer-primary-action").props.className,
-		).toContain("shadow-md");
-		expect(
-			screen.getByTestId("payer-secondary-action").props.className,
-		).toContain("bg-white/25");
-		expect(screen.getByText("SOFORT STARTEN")).toBeOnTheScreen();
+		for (const testID of ["payer-self-action", "payer-parent-action"]) {
+			expect(screen.getByTestId(testID).props.style).toEqual(
+				expect.objectContaining({
+					backgroundColor: "#FFFFFF",
+					borderColor: "#FFFFFF",
+				}),
+			);
+			expect(screen.getByTestId(testID).props.className).toContain("shadow-md");
+		}
+		expect(screen.getAllByText("SOFORT STARTEN")).toHaveLength(2);
 		expect(
 			screen.getByRole("link", { name: "Abo verwalten" }),
 		).toBeOnTheScreen();

--- a/src/features/access/pro-welcome-screen.tsx
+++ b/src/features/access/pro-welcome-screen.tsx
@@ -1,0 +1,150 @@
+import { LinearGradient } from "expo-linear-gradient";
+import { useRouter } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+import { useEffect } from "react";
+import { ScrollView, StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Button } from "~/components/ui/button";
+import { ArrowRight, Check } from "~/components/ui/icon";
+import { Text } from "~/components/ui/text";
+import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
+import { triggerSuccessHaptic } from "~/lib/safe-haptics";
+
+const WELCOME_GRADIENT = DAYOVA_DESIGN_SYSTEM.gradients.primaryInteractive;
+const BRAND_COLORS = DAYOVA_DESIGN_SYSTEM.colors;
+const WHITE = BRAND_COLORS.light1;
+// LinearGradient exposes its full-bleed geometry through the native style API.
+const gradientFillStyle = StyleSheet.absoluteFill;
+// This branded access-completion route stays light in every app theme. Fixed
+// shared tokens avoid stale CSS variables on newly mounted Fabric descendants.
+const confirmationCardStyle = {
+	backgroundColor: BRAND_COLORS.surface,
+	borderColor: BRAND_COLORS.primaryAccent,
+};
+const welcomeActionStyle = {
+	backgroundColor: BRAND_COLORS.surface,
+	borderColor: WHITE,
+};
+const benefitIconStyle = {
+	backgroundColor: BRAND_COLORS.systemSubtle,
+};
+const primaryTextStyle = { color: BRAND_COLORS.text };
+const secondaryTextStyle = { color: BRAND_COLORS.secondaryText };
+
+export function ProWelcomeScreen() {
+	const router = useRouter();
+	const insets = useSafeAreaInsets();
+
+	useEffect(() => {
+		void triggerSuccessHaptic({ platform: process.env.EXPO_OS });
+	}, []);
+
+	return (
+		<View className="flex-1 bg-primary-strong">
+			<StatusBar style="light" />
+			<LinearGradient
+				pointerEvents="none"
+				colors={WELCOME_GRADIENT.colors}
+				start={WELCOME_GRADIENT.start}
+				end={WELCOME_GRADIENT.end}
+				style={gradientFillStyle}
+			/>
+			<ScrollView
+				alwaysBounceVertical={false}
+				className="flex-1"
+				contentInsetAdjustmentBehavior="never"
+				showsVerticalScrollIndicator={false}
+				// This full-screen route has no native header, so its scroll content
+				// owns the runtime safe-area values and minimum viewport height.
+				contentContainerStyle={{
+					flexGrow: 1,
+					paddingBottom: Math.max(insets.bottom, 28),
+					paddingTop: insets.top,
+				}}
+			>
+				<View className="flex-1 justify-between px-7 pt-10">
+					<View className="items-center">
+						<View className="mb-8 h-32 w-32 items-center justify-center rounded-full border border-white/70 bg-white shadow-black/5 shadow-sm">
+							<Check
+								size={62}
+								color={BRAND_COLORS.primaryStrong}
+								strokeWidth={2.4}
+							/>
+						</View>
+
+						<Text className="font-semibold text-body-4 text-white/85">
+							DAYOVA PRO
+						</Text>
+						<Text
+							accessibilityRole="header"
+							className="mt-3 max-w-[340px] text-center font-semibold text-heading-1 text-white leading-tight"
+						>
+							Willkommen bei Dayova Pro
+						</Text>
+						<Text className="mt-3 max-w-[340px] text-center text-body-3 text-white/90">
+							Dein Zugang ist freigeschaltet. Du kannst direkt dort
+							weitermachen, wo du aufgehört hast.
+						</Text>
+
+						<View
+							className="mt-8 w-full rounded-card border px-5 py-5 shadow-black/5 shadow-sm"
+							style={confirmationCardStyle}
+							testID="pro-welcome-confirmation-card"
+						>
+							<Text
+								className="font-semibold text-body-2"
+								style={primaryTextStyle}
+							>
+								Alles freigeschaltet
+							</Text>
+							<BenefitRow label="Dein Lernstand bleibt vollständig erhalten" />
+							<BenefitRow label="Alle Dayova-Funktionen sind jetzt verfügbar" />
+						</View>
+					</View>
+
+					<View className="pt-8">
+						<Button
+							accessibilityHint="Öffnet deine heutige Lernübersicht."
+							accessibilityLabel="Jetzt loslernen"
+							className="w-full"
+							variant="neutral"
+							style={welcomeActionStyle}
+							onPress={() => router.replace("/home")}
+						>
+							<Text
+								className="font-semibold text-body-2"
+								style={{ color: BRAND_COLORS.primaryStrong }}
+							>
+								Jetzt loslernen
+							</Text>
+							<ArrowRight
+								size={20}
+								color={BRAND_COLORS.primaryStrong}
+								strokeWidth={2.4}
+							/>
+						</Button>
+						<Text className="mt-3 text-center text-body-4 text-white/80">
+							Dein Abo kannst du jederzeit in den Einstellungen verwalten.
+						</Text>
+					</View>
+				</View>
+			</ScrollView>
+		</View>
+	);
+}
+
+function BenefitRow({ label }: { label: string }) {
+	return (
+		<View className="mt-4 flex-row items-center">
+			<View
+				className="mr-3 h-8 w-8 items-center justify-center rounded-full"
+				style={benefitIconStyle}
+			>
+				<Check size={17} color={BRAND_COLORS.primaryStrong} strokeWidth={2.4} />
+			</View>
+			<Text className="flex-1 text-body-3" style={secondaryTextStyle}>
+				{label}
+			</Text>
+		</View>
+	);
+}

--- a/src/features/access/pro-welcome-screen.ui.test.tsx
+++ b/src/features/access/pro-welcome-screen.ui.test.tsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { fireEvent, render } from "@testing-library/react-native";
+import type { ReactNode } from "react";
+import { ProWelcomeScreen } from "./pro-welcome-screen";
+
+const mockReplace = jest.fn();
+
+beforeEach(() => {
+	jest.clearAllMocks();
+});
+
+jest.mock("expo-router", () => ({
+	useRouter: () => ({ replace: mockReplace }),
+}));
+
+jest.mock("expo-linear-gradient", () => {
+	const React = jest.requireActual<typeof import("react")>("react");
+	return {
+		LinearGradient: ({
+			children,
+			...props
+		}: Record<string, unknown> & { children?: ReactNode }) =>
+			React.createElement("LinearGradient", props, children),
+	};
+});
+
+jest.mock("expo-status-bar", () => {
+	const React = jest.requireActual<typeof import("react")>("react");
+	return {
+		StatusBar: (props: Record<string, unknown>) =>
+			React.createElement("StatusBar", props),
+	};
+});
+
+jest.mock("react-native-safe-area-context", () => ({
+	useSafeAreaInsets: () => ({ bottom: 34, left: 0, right: 0, top: 59 }),
+}));
+
+jest.mock("~/lib/safe-haptics", () => ({
+	triggerSuccessHaptic: jest.fn(async () => undefined),
+}));
+
+describe("ProWelcomeScreen", () => {
+	test("celebrates the unlocked subscription in the paywall visual language", async () => {
+		const screen = await render(<ProWelcomeScreen />);
+
+		expect(screen.getByText("DAYOVA PRO")).toBeOnTheScreen();
+		expect(screen.getByRole("header")).toHaveTextContent(
+			"Willkommen bei Dayova Pro",
+		);
+		expect(screen.getByText("Alles freigeschaltet")).toBeOnTheScreen();
+		expect(
+			screen.getByText("Dein Lernstand bleibt vollständig erhalten"),
+		).toBeOnTheScreen();
+		expect(
+			screen.getByTestId("pro-welcome-confirmation-card").props.style,
+		).toEqual(
+			expect.objectContaining({
+				backgroundColor: "#FFFFFF",
+				borderColor: "#4FD8FF",
+			}),
+		);
+	});
+
+	test("continues to the dashboard without returning to checkout", async () => {
+		const screen = await render(<ProWelcomeScreen />);
+
+		fireEvent.press(screen.getByRole("button", { name: "Jetzt loslernen" }));
+		expect(mockReplace).toHaveBeenCalledWith("/home");
+	});
+});

--- a/src/features/access/subscription-screen.tsx
+++ b/src/features/access/subscription-screen.tsx
@@ -13,13 +13,7 @@ import {
 import QRCode from "react-native-qrcode-svg";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button } from "~/components/ui/button";
-import {
-	ArrowLeft,
-	ArrowRight,
-	CreditCard,
-	SquareLock,
-	UserRound,
-} from "~/components/ui/icon";
+import { ArrowLeft, ArrowRight, Check } from "~/components/ui/icon";
 import { Text } from "~/components/ui/text";
 import { useAccess } from "~/context/AccessContext";
 import { useAuthSession } from "~/context/AuthContext";
@@ -58,8 +52,14 @@ const primaryActionStyle = {
 	backgroundColor: BRAND_COLORS.primaryStrong,
 	borderColor: BRAND_COLORS.primaryAccent,
 };
+const subscribeActionStyle = {
+	backgroundColor: BRAND_COLORS.text,
+	borderColor: BRAND_COLORS.border,
+};
 const primaryTextStyle = { color: BRAND_COLORS.text };
 const secondaryTextStyle = { color: BRAND_COLORS.secondaryText };
+const planGlassSurface = "rgba(255, 255, 255, 0.8)";
+const planGlassBorder = "rgba(255, 255, 255, 0.6)";
 
 const getStoreApiKey = () =>
 	Platform.select({
@@ -152,6 +152,7 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 			| { status: "cancelled" }
 			| { status: "notEntitled" }
 		>,
+		successPath: "/home" | "/pro-welcome",
 	) => {
 		if (storeActionInFlightRef.current) return;
 		storeActionInFlightRef.current = true;
@@ -166,7 +167,7 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 			}
 			const active = await refreshPaidAccess();
 			if (active) {
-				router.replace("/home");
+				router.replace(successPath);
 			} else {
 				setError(
 					"Der Kauf wird noch bestätigt. Bitte tippe gleich auf „Käufe wiederherstellen“.",
@@ -190,7 +191,10 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 
 	const purchase = async () => {
 		if (!storeClient) return;
-		await finishStoreAction(() => storeClient.purchase(selectedBillingPeriod));
+		await finishStoreAction(
+			() => storeClient.purchase(selectedBillingPeriod),
+			"/pro-welcome",
+		);
 	};
 
 	const restore = async () => {
@@ -198,7 +202,7 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 			setError("Store-Käufe sind auf diesem Gerät nicht verfügbar.");
 			return;
 		}
-		await finishStoreAction(() => storeClient.restore());
+		await finishStoreAction(() => storeClient.restore(), "/home");
 	};
 
 	const openLink = async (url?: string) => {
@@ -245,25 +249,42 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 				}}
 			>
 				<View className="px-7 pt-4">
-					<Pressable
-						accessibilityHint="Kehrt zur Auswahl zurück, wer bezahlt."
-						accessibilityLabel="Zurück"
-						accessibilityRole="button"
-						className="h-12 w-12 items-center justify-center rounded-full bg-white active:opacity-80"
-						hitSlop={8}
-						onPress={returnToPayerChoice}
+					<View
+						className="flex-row items-center justify-between"
+						testID="subscription-header-row"
 					>
-						<ArrowLeft
-							size={21}
-							color={BRAND_COLORS.primaryStrong}
-							strokeWidth={2.4}
-						/>
-					</Pressable>
+						<Pressable
+							accessibilityHint="Kehrt zur Auswahl zurück, wer bezahlt."
+							accessibilityLabel="Zurück"
+							accessibilityRole="button"
+							className="h-12 w-12 items-center justify-center rounded-full bg-white active:opacity-80"
+							hitSlop={8}
+							onPress={returnToPayerChoice}
+						>
+							<ArrowLeft
+								size={21}
+								color={BRAND_COLORS.primaryStrong}
+								strokeWidth={2.4}
+							/>
+						</Pressable>
+						<View
+							accessible
+							accessibilityLabel="Schritt 2 von 2"
+							accessibilityRole="progressbar"
+							accessibilityValue={{ min: 0, max: 2, now: 2 }}
+							className="items-end gap-2"
+						>
+							<Text className="font-semibold text-body-4 text-white/85">
+								SCHRITT 2 VON 2
+							</Text>
+							<View className="flex-row gap-1.5">
+								<View className="h-1 w-8 rounded-full bg-white/55" />
+								<View className="h-1 w-8 rounded-full bg-white" />
+							</View>
+						</View>
+					</View>
 
-					<View className="gap-2 pt-6 pb-7">
-						<Text className="font-semibold text-body-4 text-white/85">
-							SCHRITT 2 VON 2
-						</Text>
+					<View className="gap-3 pt-5 pb-7" testID="subscription-page-intro">
 						<Text
 							variant="h1"
 							className="max-w-[330px] text-left font-semibold text-heading-1 text-white leading-tight"
@@ -277,35 +298,6 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 								? "Teile den sicheren Zahlungsweg. Dein Lernstand bleibt dabei erhalten."
 								: "Wähle den Tarif, der zu dir passt. Bezahlt wird sicher über deinen Store."}
 						</Text>
-					</View>
-
-					<View className="flex-row items-center pb-5">
-						<View className="h-12 w-12 items-center justify-center rounded-full bg-white">
-							{isParentPayment ? (
-								<UserRound
-									size={24}
-									color={BRAND_COLORS.primaryStrong}
-									strokeWidth={2.3}
-								/>
-							) : (
-								<CreditCard
-									size={24}
-									color={BRAND_COLORS.primaryStrong}
-									strokeWidth={2.3}
-								/>
-							)}
-						</View>
-						<View className="ml-4 flex-1">
-							<Text className="font-semibold text-body-2 text-white">
-								{isParentPayment ? "Meine Eltern zahlen" : "Ich zahle selbst"}
-							</Text>
-							<Text className="mt-1 text-body-4 text-white/80">
-								{isParentPayment
-									? "Zahlungslink oder QR-Code"
-									: "App Store oder Google Play"}
-							</Text>
-						</View>
-						<SquareLock size={22} color={WHITE} strokeWidth={2.2} />
 					</View>
 
 					{isParentPayment ? (
@@ -332,6 +324,7 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 											: "—"
 									}
 									selected={selectedBillingPeriod === "annual"}
+									testID="subscription-plan-annual"
 									onPress={() => setSelectedBillingPeriod("annual")}
 								/>
 								<PlanCard
@@ -347,6 +340,7 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 											: "—"
 									}
 									selected={selectedBillingPeriod === "monthly"}
+									testID="subscription-plan-monthly"
 									onPress={() => setSelectedBillingPeriod("monthly")}
 								/>
 							</View>
@@ -369,7 +363,8 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 									!planByBillingPeriod.has(selectedBillingPeriod)
 								}
 								variant="neutral"
-								style={primaryActionStyle}
+								style={subscribeActionStyle}
+								testID="subscription-checkout-button"
 								onPress={() => void purchase()}
 							>
 								{isLoadingPlans || isPurchasing ? (
@@ -378,6 +373,20 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 									<Text style={{ color: WHITE }}>Abonnieren</Text>
 								)}
 							</Button>
+							<Pressable
+								accessibilityRole="button"
+								className="min-h-12 items-center justify-center px-4"
+								hitSlop={4}
+								onPress={() => void restore()}
+								testID="restore-purchases-link"
+							>
+								<Text
+									className="text-body-4"
+									style={{ color: WHITE, textDecorationLine: "underline" }}
+								>
+									Käufe wiederherstellen
+								</Text>
+							</Pressable>
 						</View>
 					)}
 
@@ -393,23 +402,15 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 						</View>
 					) : null}
 
-					{!isParentPayment || access?.managementUrl ? (
+					{access?.managementUrl ? (
 						<View
 							className="mt-5 rounded-card border px-5 py-2 shadow-black/10 shadow-sm"
 							style={utilitySurfaceStyle}
 						>
-							{!isParentPayment ? (
-								<SubscriptionAction
-									label="Käufe wiederherstellen"
-									onPress={() => void restore()}
-								/>
-							) : null}
-							{access?.managementUrl ? (
-								<SubscriptionAction
-									label="Abo verwalten"
-									onPress={() => void openLink(access.managementUrl)}
-								/>
-							) : null}
+							<SubscriptionAction
+								label="Abo verwalten"
+								onPress={() => void openLink(access.managementUrl)}
+							/>
 						</View>
 					) : null}
 
@@ -504,12 +505,14 @@ function PlanCard({
 	onPress,
 	price,
 	selected,
+	testID,
 }: {
 	description: string;
 	label: string;
 	onPress: () => void;
 	price: string;
 	selected: boolean;
+	testID: string;
 }) {
 	return (
 		<Pressable
@@ -518,13 +521,14 @@ function PlanCard({
 			accessibilityState={{ checked: selected }}
 			className="rounded-3xl border px-5 py-4"
 			onPress={onPress}
+			testID={testID}
 			style={{
-				backgroundColor: selected
-					? BRAND_COLORS.systemSubtle
-					: BRAND_COLORS.surface,
-				borderColor: selected
-					? BRAND_COLORS.primaryStrong
-					: BRAND_COLORS.border,
+				backgroundColor: planGlassSurface,
+				borderColor: selected ? BRAND_COLORS.text : planGlassBorder,
+				borderWidth: 1,
+				boxShadow: selected
+					? "inset 0 1px 0 rgba(255, 255, 255, 0.64), 0 8px 20px rgba(9, 54, 78, 0.1)"
+					: "inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 6px 16px rgba(9, 54, 78, 0.08)",
 			}}
 		>
 			<View className="flex-row items-start">
@@ -536,12 +540,26 @@ function PlanCard({
 						{description}
 					</Text>
 				</View>
-				<Text
-					className="ml-3 font-semibold text-body-2"
-					style={primaryTextStyle}
-				>
-					{price}
-				</Text>
+				<View className="ml-3 flex-row items-center gap-3">
+					<Text className="font-semibold text-body-2" style={primaryTextStyle}>
+						{price}
+					</Text>
+					<View
+						accessible={false}
+						className="h-6 w-6 items-center justify-center rounded-full border"
+						style={{
+							backgroundColor: selected
+								? BRAND_COLORS.text
+								: BRAND_COLORS.surface,
+							borderColor: selected ? BRAND_COLORS.text : BRAND_COLORS.border,
+						}}
+						testID={`${testID}-indicator`}
+					>
+						{selected ? (
+							<Check size={14} color={WHITE} strokeWidth={3} />
+						) : null}
+					</View>
+				</View>
 			</View>
 		</Pressable>
 	);

--- a/src/features/access/subscription-screen.tsx
+++ b/src/features/access/subscription-screen.tsx
@@ -308,91 +308,78 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 						<SquareLock size={22} color={WHITE} strokeWidth={2.2} />
 					</View>
 
-					<View
-						className="rounded-card border px-5 py-6 shadow-black/10 shadow-sm"
-						style={contentSurfaceStyle}
-						testID="subscription-payment-surface"
-					>
-						{isParentPayment ? (
+					{isParentPayment ? (
+						<View
+							className="rounded-card border px-5 py-6 shadow-black/10 shadow-sm"
+							style={contentSurfaceStyle}
+							testID="subscription-payment-surface"
+						>
 							<ParentPayment onOpen={openLink} />
-						) : (
-							<>
-								<Text
-									className="mb-3 font-semibold text-body-2"
-									style={primaryTextStyle}
-								>
-									Tarif wählen
-								</Text>
-								<View className="gap-3">
-									<PlanCard
-										description={
-											annualPlan
-												? DAYOVA_SUBSCRIPTION_PRICING.annual.billingDescription
-												: unavailablePlanDescription
-										}
-										label="Jährlich"
-										price={
-											annualPlan
-												? DAYOVA_SUBSCRIPTION_PRICING.annual.displayPrice
-												: "—"
-										}
-										selected={selectedBillingPeriod === "annual"}
-										onPress={() => setSelectedBillingPeriod("annual")}
-									/>
-									<PlanCard
-										description={
-											monthlyPlan
-												? DAYOVA_SUBSCRIPTION_PRICING.monthly.billingDescription
-												: unavailablePlanDescription
-										}
-										label="Monatlich"
-										price={
-											monthlyPlan
-												? DAYOVA_SUBSCRIPTION_PRICING.monthly.displayPrice
-												: "—"
-										}
-										selected={selectedBillingPeriod === "monthly"}
-										onPress={() => setSelectedBillingPeriod("monthly")}
-									/>
-								</View>
-								{!storeClient ? (
-									<Text
-										accessibilityLiveRegion="polite"
-										className="mt-3 text-center text-body-4"
-										style={secondaryTextStyle}
-									>
-										{storeUnavailableMessage}
-									</Text>
-								) : null}
-								<Button
-									accessibilityHint="Öffnet den Kauf im App Store oder bei Google Play."
-									className="mt-5"
-									disabled={
-										isLoadingPlans ||
-										isPurchasing ||
-										!storeClient ||
-										!planByBillingPeriod.has(selectedBillingPeriod)
+						</View>
+					) : (
+						<View>
+							<View className="gap-3">
+								<PlanCard
+									description={
+										annualPlan
+											? DAYOVA_SUBSCRIPTION_PRICING.annual.billingDescription
+											: unavailablePlanDescription
 									}
-									variant="neutral"
-									style={primaryActionStyle}
-									onPress={() => void purchase()}
-								>
-									{isLoadingPlans || isPurchasing ? (
-										<ActivityIndicator color={WHITE} />
-									) : (
-										<Text style={{ color: WHITE }}>Im Store abonnieren</Text>
-									)}
-								</Button>
+									label="Jährlich"
+									price={
+										annualPlan
+											? DAYOVA_SUBSCRIPTION_PRICING.annual.displayPrice
+											: "—"
+									}
+									selected={selectedBillingPeriod === "annual"}
+									onPress={() => setSelectedBillingPeriod("annual")}
+								/>
+								<PlanCard
+									description={
+										monthlyPlan
+											? DAYOVA_SUBSCRIPTION_PRICING.monthly.billingDescription
+											: unavailablePlanDescription
+									}
+									label="Monatlich"
+									price={
+										monthlyPlan
+											? DAYOVA_SUBSCRIPTION_PRICING.monthly.displayPrice
+											: "—"
+									}
+									selected={selectedBillingPeriod === "monthly"}
+									onPress={() => setSelectedBillingPeriod("monthly")}
+								/>
+							</View>
+							{!storeClient ? (
 								<Text
+									accessibilityLiveRegion="polite"
 									className="mt-3 text-center text-body-4"
 									style={secondaryTextStyle}
 								>
-									Die Zahlung läuft über den App Store oder Google Play. Das Abo
-									verlängert sich dort bis zur Kündigung.
+									{storeUnavailableMessage}
 								</Text>
-							</>
-						)}
-					</View>
+							) : null}
+							<Button
+								accessibilityHint="Öffnet den Kauf im App Store oder bei Google Play."
+								className="mt-5"
+								disabled={
+									isLoadingPlans ||
+									isPurchasing ||
+									!storeClient ||
+									!planByBillingPeriod.has(selectedBillingPeriod)
+								}
+								variant="neutral"
+								style={primaryActionStyle}
+								onPress={() => void purchase()}
+							>
+								{isLoadingPlans || isPurchasing ? (
+									<ActivityIndicator color={WHITE} />
+								) : (
+									<Text style={{ color: WHITE }}>Abonnieren</Text>
+								)}
+							</Button>
+						</View>
+					)}
 
 					{error ? (
 						<View className="mt-4 rounded-3xl bg-white px-4 py-3">

--- a/src/features/access/subscription-screen.tsx
+++ b/src/features/access/subscription-screen.tsx
@@ -1,5 +1,5 @@
-import { useRouter } from "expo-router";
 import { LinearGradient } from "expo-linear-gradient";
+import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -31,11 +31,13 @@ import {
 	type DayovaStorePlan,
 } from "~/lib/revenuecat-client";
 import { env } from "~/lib/runtime-config";
+import {
+	DAYOVA_SUBSCRIPTION_PRICING,
+	type DayovaBillingPeriod,
+} from "~/lib/subscription-pricing";
 import type { SubscriptionPayer } from "./paywall-screen";
 
 export type { SubscriptionPayer } from "./paywall-screen";
-
-type ProductIdentifier = DayovaStorePlan["productIdentifier"];
 
 const SUBSCRIPTION_GRADIENT = DAYOVA_DESIGN_SYSTEM.gradients.primaryInteractive;
 const BRAND_COLORS = DAYOVA_DESIGN_SYSTEM.colors;
@@ -92,8 +94,8 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 	const storeUnavailableMessage = storeConnection.initializationError
 		? "Store-Käufe konnten auf diesem Gerät nicht gestartet werden. Bitte öffne die App erneut oder kontaktiere den Support."
 		: "Store-Käufe sind auf diesem Gerät noch nicht verfügbar.";
-	const [selectedProduct, setSelectedProduct] =
-		useState<ProductIdentifier>("dayova_monthly");
+	const [selectedBillingPeriod, setSelectedBillingPeriod] =
+		useState<DayovaBillingPeriod>("monthly");
 	const [plans, setPlans] = useState<DayovaStorePlan[]>([]);
 	const [isLoadingPlans, setIsLoadingPlans] = useState(
 		payer === "self" && Boolean(storeClient),
@@ -139,8 +141,8 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 		};
 	}, [payer, storeClient, storeConnection.initializationError]);
 
-	const planByProduct = useMemo(
-		() => new Map(plans.map((plan) => [plan.productIdentifier, plan])),
+	const planByBillingPeriod = useMemo(
+		() => new Map(plans.map((plan) => [plan.billingPeriod, plan])),
 		[plans],
 	);
 
@@ -186,7 +188,7 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 
 	const purchase = async () => {
 		if (!storeClient) return;
-		await finishStoreAction(() => storeClient.purchase(selectedProduct));
+		await finishStoreAction(() => storeClient.purchase(selectedBillingPeriod));
 	};
 
 	const restore = async () => {
@@ -206,8 +208,8 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 		}
 	};
 
-	const annualPlan = planByProduct.get("dayova_annual");
-	const monthlyPlan = planByProduct.get("dayova_monthly");
+	const annualPlan = planByBillingPeriod.get("annual");
+	const monthlyPlan = planByBillingPeriod.get("monthly");
 	const unavailablePlanDescription = isLoadingPlans
 		? "Preis wird geladen …"
 		: "Derzeit nicht im Store verfügbar";
@@ -322,27 +324,33 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 								<View className="gap-3">
 									<PlanCard
 										description={
-											annualPlan?.monthlyEquivalentPrice
-												? `${annualPlan.monthlyEquivalentPrice} pro Monat · jährlich abgerechnet`
-												: annualPlan
-													? "Jährlich abgerechnet"
-													: unavailablePlanDescription
+											annualPlan
+												? DAYOVA_SUBSCRIPTION_PRICING.annual.billingDescription
+												: unavailablePlanDescription
 										}
 										label="Jährlich"
-										price={annualPlan?.price ?? "—"}
-										selected={selectedProduct === "dayova_annual"}
-										onPress={() => setSelectedProduct("dayova_annual")}
+										price={
+											annualPlan
+												? DAYOVA_SUBSCRIPTION_PRICING.annual.displayPrice
+												: "—"
+										}
+										selected={selectedBillingPeriod === "annual"}
+										onPress={() => setSelectedBillingPeriod("annual")}
 									/>
 									<PlanCard
 										description={
 											monthlyPlan
-												? "Monatlich abgerechnet"
+												? DAYOVA_SUBSCRIPTION_PRICING.monthly.billingDescription
 												: unavailablePlanDescription
 										}
 										label="Monatlich"
-										price={monthlyPlan?.price ?? "—"}
-										selected={selectedProduct === "dayova_monthly"}
-										onPress={() => setSelectedProduct("dayova_monthly")}
+										price={
+											monthlyPlan
+												? DAYOVA_SUBSCRIPTION_PRICING.monthly.displayPrice
+												: "—"
+										}
+										selected={selectedBillingPeriod === "monthly"}
+										onPress={() => setSelectedBillingPeriod("monthly")}
 									/>
 								</View>
 								{!storeClient ? (
@@ -361,7 +369,7 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 										isLoadingPlans ||
 										isPurchasing ||
 										!storeClient ||
-										!planByProduct.has(selectedProduct)
+										!planByBillingPeriod.has(selectedBillingPeriod)
 									}
 									variant="neutral"
 									style={primaryActionStyle}

--- a/src/features/access/subscription-screen.tsx
+++ b/src/features/access/subscription-screen.tsx
@@ -165,7 +165,9 @@ export function SubscriptionScreen({ payer }: { payer: SubscriptionPayer }) {
 				return;
 			}
 			const active = await refreshPaidAccess();
-			if (!active) {
+			if (active) {
+				router.replace("/home");
+			} else {
 				setError(
 					"Der Kauf wird noch bestätigt. Bitte tippe gleich auf „Käufe wiederherstellen“.",
 				);

--- a/src/features/access/subscription-screen.ui.test.tsx
+++ b/src/features/access/subscription-screen.ui.test.tsx
@@ -5,13 +5,27 @@ import { SubscriptionScreen } from "./subscription-screen";
 
 const mockBack = jest.fn();
 const mockReplace = jest.fn();
-const mockGetPlans = jest.fn(async () => []);
+const storePlans = [
+	{
+		billingPeriod: "annual" as const,
+		packageIdentifier: "$rc_annual",
+		price: "$155.88",
+		productIdentifier: "test_store_annual",
+	},
+	{
+		billingPeriod: "monthly" as const,
+		packageIdentifier: "$rc_monthly",
+		price: "$14.99",
+		productIdentifier: "test_store_monthly",
+	},
+];
+const mockGetPlans = jest.fn(async () => storePlans);
 let mockCanGoBack = true;
 let mockStoreInitializationError: Error | null = null;
 
 beforeEach(() => {
 	jest.clearAllMocks();
-	mockGetPlans.mockResolvedValue([]);
+	mockGetPlans.mockResolvedValue(storePlans);
 	mockCanGoBack = true;
 	mockStoreInitializationError = null;
 });
@@ -106,6 +120,14 @@ describe("SubscriptionScreen", () => {
 		expect(
 			screen.getByRole("radio", { name: /Monatlich/ }).props.accessibilityState,
 		).toEqual({ checked: true });
+		expect(
+			screen.getByRole("radio", {
+				name: /Jährlich, 155,88 €. 12,99 € pro Monat · 155,88 € jährlich abgerechnet/,
+			}),
+		).toBeOnTheScreen();
+		expect(
+			screen.getByRole("radio", { name: /Monatlich, 14,99 €/ }),
+		).toBeOnTheScreen();
 		expect(
 			screen.getByTestId("subscription-payment-surface").props.style,
 		).toEqual(

--- a/src/features/access/subscription-screen.ui.test.tsx
+++ b/src/features/access/subscription-screen.ui.test.tsx
@@ -118,8 +118,17 @@ describe("SubscriptionScreen", () => {
 		expect(screen.getByText("Dein Dayova-Abo auswählen")).toBeOnTheScreen();
 		await waitFor(() => {
 			expect(mockGetPlans).toHaveBeenCalledTimes(1);
-			expect(screen.getByText("Tarif wählen")).toBeOnTheScreen();
+			expect(screen.getByText("Abonnieren")).toBeOnTheScreen();
 		});
+		expect(screen.queryByText("Tarif wählen")).not.toBeOnTheScreen();
+		expect(
+			screen.queryByTestId("subscription-payment-surface"),
+		).not.toBeOnTheScreen();
+		expect(
+			screen.queryByText(
+				"Die Zahlung läuft über den App Store oder Google Play. Das Abo verlängert sich dort bis zur Kündigung.",
+			),
+		).not.toBeOnTheScreen();
 		expect(
 			screen.getByRole("radio", { name: /Jährlich/ }).props.accessibilityState,
 		).toEqual({ checked: false });
@@ -134,14 +143,6 @@ describe("SubscriptionScreen", () => {
 		expect(
 			screen.getByRole("radio", { name: /Monatlich, 14,99 €/ }),
 		).toBeOnTheScreen();
-		expect(
-			screen.getByTestId("subscription-payment-surface").props.style,
-		).toEqual(
-			expect.objectContaining({
-				backgroundColor: "#FFFFFF",
-				borderColor: "#4FD8FF",
-			}),
-		);
 	});
 
 	test("shows the parent payment model on its own page", async () => {
@@ -153,6 +154,14 @@ describe("SubscriptionScreen", () => {
 		expect(
 			screen.getByText("Elternzahlung kommt mit der Dayova-Webzahlung"),
 		).toBeOnTheScreen();
+		expect(
+			screen.getByTestId("subscription-payment-surface").props.style,
+		).toEqual(
+			expect.objectContaining({
+				backgroundColor: "#FFFFFF",
+				borderColor: "#4FD8FF",
+			}),
+		);
 		expect(screen.queryByText("Tarif wählen")).not.toBeOnTheScreen();
 		expect(mockGetPlans).not.toHaveBeenCalled();
 	});
@@ -187,9 +196,9 @@ describe("SubscriptionScreen", () => {
 	test("redirects to the dashboard after a confirmed purchase", async () => {
 		const screen = await render(<SubscriptionScreen payer="self" />);
 
-		await screen.findByText("Im Store abonnieren");
+		await screen.findByText("Abonnieren");
 		await act(async () => {
-			fireEvent.press(screen.getByText("Im Store abonnieren"));
+			fireEvent.press(screen.getByText("Abonnieren"));
 		});
 
 		await waitFor(() => {

--- a/src/features/access/subscription-screen.ui.test.tsx
+++ b/src/features/access/subscription-screen.ui.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
-import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
 import type { ReactNode } from "react";
 import { SubscriptionScreen } from "./subscription-screen";
 
@@ -20,12 +20,18 @@ const storePlans = [
 	},
 ];
 const mockGetPlans = jest.fn(async () => storePlans);
+const mockPurchase = jest.fn(async () => ({ status: "purchased" as const }));
+const mockRestore = jest.fn(async () => ({ status: "purchased" as const }));
+const mockRefreshPaidAccess = jest.fn(async () => true);
 let mockCanGoBack = true;
 let mockStoreInitializationError: Error | null = null;
 
 beforeEach(() => {
 	jest.clearAllMocks();
 	mockGetPlans.mockResolvedValue(storePlans);
+	mockPurchase.mockResolvedValue({ status: "purchased" });
+	mockRestore.mockResolvedValue({ status: "purchased" });
+	mockRefreshPaidAccess.mockResolvedValue(true);
 	mockCanGoBack = true;
 	mockStoreInitializationError = null;
 });
@@ -73,7 +79,7 @@ jest.mock("react-native-safe-area-context", () => ({
 jest.mock("~/context/AccessContext", () => ({
 	useAccess: () => ({
 		access: null,
-		refreshPaidAccess: jest.fn(),
+		refreshPaidAccess: mockRefreshPaidAccess,
 	}),
 }));
 
@@ -88,8 +94,8 @@ jest.mock("~/lib/revenuecat-client", () => ({
 		if (mockStoreInitializationError) throw mockStoreInitializationError;
 		return {
 			getPlans: mockGetPlans,
-			purchase: jest.fn(),
-			restore: jest.fn(),
+			purchase: mockPurchase,
+			restore: mockRestore,
 		};
 	},
 }));
@@ -176,5 +182,20 @@ describe("SubscriptionScreen", () => {
 				"Store-Käufe konnten auf diesem Gerät nicht gestartet werden. Bitte öffne die App erneut oder kontaktiere den Support.",
 			),
 		).not.toHaveLength(0);
+	});
+
+	test("redirects to the dashboard after a confirmed purchase", async () => {
+		const screen = await render(<SubscriptionScreen payer="self" />);
+
+		await screen.findByText("Im Store abonnieren");
+		await act(async () => {
+			fireEvent.press(screen.getByText("Im Store abonnieren"));
+		});
+
+		await waitFor(() => {
+			expect(mockPurchase).toHaveBeenCalledWith("monthly");
+			expect(mockRefreshPaidAccess).toHaveBeenCalledTimes(1);
+			expect(mockReplace).toHaveBeenCalledWith("/home");
+		});
 	});
 });

--- a/src/features/access/subscription-screen.ui.test.tsx
+++ b/src/features/access/subscription-screen.ui.test.tsx
@@ -121,6 +121,13 @@ describe("SubscriptionScreen", () => {
 			expect(screen.getByText("Abonnieren")).toBeOnTheScreen();
 		});
 		expect(screen.queryByText("Tarif wählen")).not.toBeOnTheScreen();
+		expect(screen.queryByText("Ich zahle selbst")).not.toBeOnTheScreen();
+		expect(screen.getByLabelText("Zurück").parent).toBe(
+			screen.getByTestId("subscription-header-row"),
+		);
+		expect(
+			screen.getByRole("progressbar", { name: "Schritt 2 von 2" }),
+		).toBeOnTheScreen();
 		expect(
 			screen.queryByTestId("subscription-payment-surface"),
 		).not.toBeOnTheScreen();
@@ -135,14 +142,74 @@ describe("SubscriptionScreen", () => {
 		expect(
 			screen.getByRole("radio", { name: /Monatlich/ }).props.accessibilityState,
 		).toEqual({ checked: true });
+		expect(screen.getByTestId("subscription-plan-annual").props.style).toEqual(
+			expect.objectContaining({
+				backgroundColor: "rgba(255, 255, 255, 0.8)",
+				borderColor: "rgba(255, 255, 255, 0.6)",
+				borderWidth: 1,
+				boxShadow:
+					"inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 6px 16px rgba(9, 54, 78, 0.08)",
+			}),
+		);
+		expect(screen.getByTestId("subscription-plan-monthly").props.style).toEqual(
+			expect.objectContaining({
+				backgroundColor: "rgba(255, 255, 255, 0.8)",
+				borderColor: "#1A1A1A",
+				borderWidth: 1,
+				boxShadow:
+					"inset 0 1px 0 rgba(255, 255, 255, 0.64), 0 8px 20px rgba(9, 54, 78, 0.1)",
+			}),
+		);
+		expect(
+			screen.getByTestId("subscription-plan-monthly-indicator").props.style,
+		).toEqual(
+			expect.objectContaining({
+				backgroundColor: "#1A1A1A",
+				borderColor: "#1A1A1A",
+			}),
+		);
 		expect(
 			screen.getByRole("radio", {
-				name: /Jährlich, 155,88 €. 12,99 € pro Monat · 155,88 € jährlich abgerechnet/,
+				name: /Jährlich, 12,99 €. 155,88 € jährlich abgerechnet/,
 			}),
 		).toBeOnTheScreen();
 		expect(
 			screen.getByRole("radio", { name: /Monatlich, 14,99 €/ }),
 		).toBeOnTheScreen();
+		expect(
+			screen.getByTestId("subscription-checkout-button").props.style,
+		).toEqual(
+			expect.objectContaining({
+				backgroundColor: "#1A1A1A",
+				borderColor: "#DCE6EE",
+			}),
+		);
+		expect(screen.getByText("Käufe wiederherstellen").props.style).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					color: "#FFFFFF",
+					textDecorationLine: "underline",
+				}),
+			]),
+		);
+		expect(
+			screen.getByTestId("restore-purchases-link").props.accessibilityRole,
+		).toBe("button");
+
+		fireEvent.press(screen.getByRole("radio", { name: /Jährlich/ }));
+		await waitFor(() => {
+			expect(
+				screen.getByTestId("subscription-plan-annual").props.style,
+			).toEqual(
+				expect.objectContaining({
+					backgroundColor: "rgba(255, 255, 255, 0.8)",
+					borderColor: "#1A1A1A",
+					borderWidth: 1,
+					boxShadow:
+						"inset 0 1px 0 rgba(255, 255, 255, 0.64), 0 8px 20px rgba(9, 54, 78, 0.1)",
+				}),
+			);
+		});
 	});
 
 	test("shows the parent payment model on its own page", async () => {
@@ -151,6 +218,7 @@ describe("SubscriptionScreen", () => {
 		expect(
 			screen.getByText("Mit deinen Eltern freischalten"),
 		).toBeOnTheScreen();
+		expect(screen.queryByText("Meine Eltern zahlen")).not.toBeOnTheScreen();
 		expect(
 			screen.getByText("Elternzahlung kommt mit der Dayova-Webzahlung"),
 		).toBeOnTheScreen();
@@ -193,7 +261,7 @@ describe("SubscriptionScreen", () => {
 		).not.toHaveLength(0);
 	});
 
-	test("redirects to the dashboard after a confirmed purchase", async () => {
+	test("redirects to the Pro welcome screen after a confirmed purchase", async () => {
 		const screen = await render(<SubscriptionScreen payer="self" />);
 
 		await screen.findByText("Abonnieren");
@@ -203,6 +271,21 @@ describe("SubscriptionScreen", () => {
 
 		await waitFor(() => {
 			expect(mockPurchase).toHaveBeenCalledWith("monthly");
+			expect(mockRefreshPaidAccess).toHaveBeenCalledTimes(1);
+			expect(mockReplace).toHaveBeenCalledWith("/pro-welcome");
+		});
+	});
+
+	test("restores existing purchases without replaying the welcome screen", async () => {
+		const screen = await render(<SubscriptionScreen payer="self" />);
+
+		await screen.findByText("Käufe wiederherstellen");
+		await act(async () => {
+			fireEvent.press(screen.getByText("Käufe wiederherstellen"));
+		});
+
+		await waitFor(() => {
+			expect(mockRestore).toHaveBeenCalledTimes(1);
 			expect(mockRefreshPaidAccess).toHaveBeenCalledTimes(1);
 			expect(mockReplace).toHaveBeenCalledWith("/home");
 		});

--- a/src/features/access/trial-activation-screen.tsx
+++ b/src/features/access/trial-activation-screen.tsx
@@ -103,7 +103,7 @@ export function TrialActivationScreen() {
 				}}
 			>
 				<View className="flex-1 px-7 pt-5 pb-2">
-					<View className="gap-2 pb-7">
+					<View className="gap-3 pb-7">
 						<Text className="font-semibold text-body-4 text-white/85">
 							14 TAGE KOSTENLOS
 						</Text>

--- a/src/features/learning-plans/learning-availability-step.tsx
+++ b/src/features/learning-plans/learning-availability-step.tsx
@@ -41,7 +41,7 @@ export function LearningAvailabilityStep({
 								? "Deine Lernzeiten sind schon belegt"
 								: "Noch nicht genug Lernzeit"}
 				</Text>
-				<Text className="mt-2 font-poppins text-body-3 text-secondary-text">
+				<Text className="mt-3 font-poppins text-body-3 text-secondary-text">
 					{isLoading
 						? "Das dauert nur einen Moment."
 						: hasUsableLearningTime

--- a/src/lib/access-policy.test.ts
+++ b/src/lib/access-policy.test.ts
@@ -97,6 +97,28 @@ describe("resolveAccessRoute", () => {
 			}),
 		).toBe("/home");
 	});
+
+	it("keeps a newly paid account on the Pro welcome route", () => {
+		expect(
+			resolveAccessRoute({
+				accessState: "paid",
+				isSessionLoading: false,
+				pathname: "/pro-welcome",
+				user: { id: "user_1" },
+			}),
+		).toBeNull();
+	});
+
+	it("does not show the Pro welcome route to trial accounts", () => {
+		expect(
+			resolveAccessRoute({
+				accessState: "trial",
+				isSessionLoading: false,
+				pathname: "/pro-welcome",
+				user: { id: "user_1" },
+			}),
+		).toBe("/home");
+	});
 });
 
 describe("getOfflineAccess", () => {

--- a/src/lib/access-policy.ts
+++ b/src/lib/access-policy.ts
@@ -58,6 +58,7 @@ const ACCESS_BYPASS_PATHS = new Set([
 	PASSWORD_RESET_SUCCESS_PATH,
 	SESSION_TASK_RESET_PASSWORD_PATH,
 ]);
+const PRO_WELCOME_PATH = "/pro-welcome";
 
 export const resolveAccessRoute = ({
 	accessState,
@@ -82,6 +83,9 @@ export const resolveAccessRoute = ({
 	}
 	if (accessState === "expired") {
 		return EXPIRED_ACCESS_PATHS.has(pathname) ? null : "/paywall";
+	}
+	if (pathname === PRO_WELCOME_PATH) {
+		return accessState === "paid" ? null : "/home";
 	}
 	if (isAuthRoute || ACCESS_SETUP_PATHS.has(pathname)) {
 		return "/home";

--- a/src/lib/revenuecat-client.test.ts
+++ b/src/lib/revenuecat-client.test.ts
@@ -17,8 +17,8 @@ const annualPackage = {
 	packageType: "ANNUAL",
 	product: {
 		identifier: "dayova_annual",
-		pricePerMonthString: "13,33 €",
-		priceString: "159,99 €",
+		pricePerMonthString: "12,99 €",
+		priceString: "155,88 €",
 	},
 };
 
@@ -62,9 +62,8 @@ describe("createRevenueCatClient", () => {
 		await expect(client.getPlans()).resolves.toEqual([
 			{
 				billingPeriod: "annual",
-				monthlyEquivalentPrice: "13,33 €",
 				packageIdentifier: "$rc_annual",
-				price: "159,99 €",
+				price: "155,88 €",
 				productIdentifier: "dayova_annual",
 			},
 			{
@@ -87,7 +86,7 @@ describe("createRevenueCatClient", () => {
 			sdk: createSdk(),
 		});
 
-		await expect(client.purchase("dayova_monthly")).resolves.toEqual({
+		await expect(client.purchase("monthly")).resolves.toEqual({
 			status: "purchased",
 		});
 	});
@@ -103,7 +102,7 @@ describe("createRevenueCatClient", () => {
 			sdk,
 		});
 
-		await expect(client.purchase("dayova_monthly")).resolves.toEqual({
+		await expect(client.purchase("monthly")).resolves.toEqual({
 			status: "cancelled",
 		});
 	});

--- a/src/lib/revenuecat-client.ts
+++ b/src/lib/revenuecat-client.ts
@@ -1,5 +1,11 @@
+import type { DayovaBillingPeriod } from "./subscription-pricing";
+
 const ENTITLEMENT_ID = "dayova_full_access";
 const OFFERING_ID = "default";
+const PACKAGE_BILLING_PERIOD = {
+	$rc_annual: "annual",
+	$rc_monthly: "monthly",
+} as const;
 
 type RevenueCatPackage = {
 	identifier: string;
@@ -35,11 +41,10 @@ export type RevenueCatSdkBoundary = {
 };
 
 export type DayovaStorePlan = {
-	billingPeriod: "annual" | "monthly";
-	monthlyEquivalentPrice?: string;
-	packageIdentifier: string;
+	billingPeriod: DayovaBillingPeriod;
+	packageIdentifier: keyof typeof PACKAGE_BILLING_PERIOD;
 	price: string;
-	productIdentifier: "dayova_annual" | "dayova_monthly";
+	productIdentifier: string;
 };
 
 type PurchaseResult =
@@ -47,28 +52,22 @@ type PurchaseResult =
 	| { status: "cancelled" }
 	| { status: "notEntitled" };
 
-const isDayovaProduct = (
-	productIdentifier: string,
-): productIdentifier is DayovaStorePlan["productIdentifier"] =>
-	productIdentifier === "dayova_annual" ||
-	productIdentifier === "dayova_monthly";
+const isDayovaPackage = (
+	packageIdentifier: string,
+): packageIdentifier is DayovaStorePlan["packageIdentifier"] =>
+	packageIdentifier === "$rc_annual" || packageIdentifier === "$rc_monthly";
 
 const toStorePlan = (
 	revenueCatPackage: RevenueCatPackage,
 ): DayovaStorePlan | null => {
-	const productIdentifier = revenueCatPackage.product.identifier;
-	if (!isDayovaProduct(productIdentifier)) return null;
+	const packageIdentifier = revenueCatPackage.identifier;
+	if (!isDayovaPackage(packageIdentifier)) return null;
 
 	return {
-		billingPeriod: productIdentifier === "dayova_annual" ? "annual" : "monthly",
-		...(revenueCatPackage.product.pricePerMonthString
-			? {
-					monthlyEquivalentPrice: revenueCatPackage.product.pricePerMonthString,
-				}
-			: {}),
-		packageIdentifier: revenueCatPackage.identifier,
+		billingPeriod: PACKAGE_BILLING_PERIOD[packageIdentifier],
+		packageIdentifier,
 		price: revenueCatPackage.product.priceString,
-		productIdentifier,
+		productIdentifier: revenueCatPackage.product.identifier,
 	};
 };
 
@@ -120,12 +119,14 @@ export const createRevenueCatClient = ({
 				);
 		},
 		purchase: async (
-			productIdentifier: DayovaStorePlan["productIdentifier"],
+			billingPeriod: DayovaBillingPeriod,
 		): Promise<PurchaseResult> => {
 			await ready;
 			const packages = availablePackages ?? (await loadPackages());
 			const packageToPurchase = packages.find(
-				(candidate) => candidate.product.identifier === productIdentifier,
+				(candidate) =>
+					isDayovaPackage(candidate.identifier) &&
+					PACKAGE_BILLING_PERIOD[candidate.identifier] === billingPeriod,
 			);
 			if (!packageToPurchase) {
 				throw new Error("Der gewählte Tarif ist im Store nicht verfügbar.");

--- a/src/lib/runtime-config.test.ts
+++ b/src/lib/runtime-config.test.ts
@@ -143,4 +143,36 @@ describe("getMissingPublicRuntimeConfig", () => {
 			/Missing values: EXPO_PUBLIC_REVENUECAT_IOS_API_KEY, EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY, EXPO_PUBLIC_PRIVACY_URL, EXPO_PUBLIC_TERMS_URL, EXPO_PUBLIC_SUBSCRIPTION_TERMS_URL, EXPO_PUBLIC_CANCELLATION_URL, EXPO_PUBLIC_SUPPORT_URL/,
 		);
 	});
+
+	it("requires only the current platform store key during an EAS build", () => {
+		const sharedReleaseConfig = {
+			EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test_example",
+			EXPO_PUBLIC_CONVEX_URL: "https://example.convex.cloud",
+			EXPO_PUBLIC_PRIVACY_URL: "https://example.com/privacy",
+			EXPO_PUBLIC_TERMS_URL: "https://example.com/terms",
+			EXPO_PUBLIC_SUBSCRIPTION_TERMS_URL:
+				"https://example.com/subscription-terms",
+			EXPO_PUBLIC_CANCELLATION_URL: "https://example.com/cancellation",
+			EXPO_PUBLIC_SUPPORT_URL: "https://example.com/support",
+		};
+
+		expect(() =>
+			validatePublicEnvForRelease(
+				{
+					...sharedReleaseConfig,
+					EXPO_PUBLIC_REVENUECAT_IOS_API_KEY: "appl_test",
+				},
+				{ platform: "ios" },
+			),
+		).not.toThrow();
+		expect(() =>
+			validatePublicEnvForRelease(
+				{
+					...sharedReleaseConfig,
+					EXPO_PUBLIC_REVENUECAT_IOS_API_KEY: "appl_test",
+				},
+				{ platform: "android" },
+			),
+		).toThrowError(/EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY/);
+	});
 });

--- a/src/lib/runtime-config.ts
+++ b/src/lib/runtime-config.ts
@@ -18,6 +18,7 @@ const publicEnvSchema = {
 } as const;
 
 type PublicRuntimeConfigKey = keyof typeof publicEnvSchema;
+export type ReleasePlatform = "android" | "ios";
 
 export type PublicRuntimeConfigValues = Partial<
 	Record<PublicRuntimeConfigKey, string | undefined>
@@ -34,15 +35,16 @@ const requiredPublicEnvKeys = [
 	"EXPO_PUBLIC_CONVEX_URL",
 ] satisfies PublicRuntimeConfigKey[];
 const requiredReleasePublicEnvKeys = [
-	...requiredPublicEnvKeys,
-	"EXPO_PUBLIC_REVENUECAT_IOS_API_KEY",
-	"EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY",
 	"EXPO_PUBLIC_PRIVACY_URL",
 	"EXPO_PUBLIC_TERMS_URL",
 	"EXPO_PUBLIC_SUBSCRIPTION_TERMS_URL",
 	"EXPO_PUBLIC_CANCELLATION_URL",
 	"EXPO_PUBLIC_SUPPORT_URL",
 ] satisfies PublicRuntimeConfigKey[];
+const revenueCatPublicEnvKeyByPlatform = {
+	ios: "EXPO_PUBLIC_REVENUECAT_IOS_API_KEY",
+	android: "EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY",
+} as const satisfies Record<ReleasePlatform, PublicRuntimeConfigKey>;
 
 // Expo only inlines direct process.env.EXPO_PUBLIC_* member accesses.
 export const readPublicRuntimeConfig = (): StrictPublicRuntimeConfigValues => ({
@@ -79,7 +81,18 @@ export const getMissingPublicRuntimeConfig = (
 
 export const getMissingReleasePublicRuntimeConfig = (
 	config: PublicRuntimeConfigValues,
-) => requiredReleasePublicEnvKeys.filter((key) => !config[key]?.trim());
+	platform?: ReleasePlatform,
+) => {
+	const requiredStoreKeys = platform
+		? [revenueCatPublicEnvKeyByPlatform[platform]]
+		: Object.values(revenueCatPublicEnvKeyByPlatform);
+
+	return [
+		...requiredPublicEnvKeys,
+		...requiredStoreKeys,
+		...requiredReleasePublicEnvKeys,
+	].filter((key) => !config[key]?.trim());
+};
 
 export const missingPublicRuntimeConfig = getMissingPublicRuntimeConfig(
 	rawPublicRuntimeConfig,
@@ -96,16 +109,20 @@ const formatIssuePath = (issue: StandardSchemaV1.Issue) =>
 
 type CreatePublicEnvOptions = {
 	context: "app-runtime" | "release";
+	releasePlatform?: ReleasePlatform;
 };
 
 const createPublicEnvValidationError = (
 	runtimeEnv: PublicRuntimeConfigValues,
 	issues: readonly StandardSchemaV1.Issue[],
-	context: CreatePublicEnvOptions["context"],
+	options: CreatePublicEnvOptions,
 ) => {
 	const missing =
-		context === "release"
-			? getMissingReleasePublicRuntimeConfig(runtimeEnv)
+		options.context === "release"
+			? getMissingReleasePublicRuntimeConfig(
+					runtimeEnv,
+					options.releasePlatform,
+				)
 			: getMissingPublicRuntimeConfig(runtimeEnv);
 	const invalidIssues = issues.filter((issue) => {
 		const path = formatIssuePath(issue);
@@ -119,7 +136,7 @@ const createPublicEnvValidationError = (
 		.join("; ");
 	const invalid = details ? ` Invalid values: ${details}.` : "";
 
-	if (context === "release") {
+	if (options.context === "release") {
 		const missingMessage =
 			missing.length > 0 ? ` Missing values: ${missing.join(", ")}.` : "";
 
@@ -144,17 +161,27 @@ export const createPublicEnv = (
 			options.context === "app-runtime" &&
 			getMissingPublicRuntimeConfig(runtimeEnv).length > 0,
 		onValidationError: (issues) => {
-			throw createPublicEnvValidationError(runtimeEnv, issues, options.context);
+			throw createPublicEnvValidationError(runtimeEnv, issues, options);
 		},
 	});
 
 export const validatePublicEnvForRelease = (
 	runtimeEnv: PublicRuntimeConfigValues = readPublicRuntimeConfig(),
+	options: { platform?: ReleasePlatform } = {},
 ) => {
-	if (getMissingReleasePublicRuntimeConfig(runtimeEnv).length > 0) {
-		throw createPublicEnvValidationError(runtimeEnv, [], "release");
+	if (
+		getMissingReleasePublicRuntimeConfig(runtimeEnv, options.platform).length >
+		0
+	) {
+		throw createPublicEnvValidationError(runtimeEnv, [], {
+			context: "release",
+			releasePlatform: options.platform,
+		});
 	}
-	createPublicEnv(runtimeEnv, { context: "release" });
+	createPublicEnv(runtimeEnv, {
+		context: "release",
+		releasePlatform: options.platform,
+	});
 };
 
 export const env = createPublicEnv(rawPublicRuntimeConfig, {

--- a/src/lib/subscription-pricing.ts
+++ b/src/lib/subscription-pricing.ts
@@ -4,8 +4,8 @@ export type DayovaBillingPeriod = "annual" | "monthly";
 // Store products must use the same amounts before a production release.
 export const DAYOVA_SUBSCRIPTION_PRICING = {
 	annual: {
-		billingDescription: "12,99 € pro Monat · 155,88 € jährlich abgerechnet",
-		displayPrice: "155,88 €",
+		billingDescription: "155,88 € jährlich abgerechnet",
+		displayPrice: "12,99 €",
 	},
 	monthly: {
 		billingDescription: "Monatlich abgerechnet",

--- a/src/lib/subscription-pricing.ts
+++ b/src/lib/subscription-pricing.ts
@@ -1,0 +1,17 @@
+export type DayovaBillingPeriod = "annual" | "monthly";
+
+// Pricing decision PRICING-001, confirmed by Linear DAY-228.
+// Store products must use the same amounts before a production release.
+export const DAYOVA_SUBSCRIPTION_PRICING = {
+	annual: {
+		billingDescription: "12,99 € pro Monat · 155,88 € jährlich abgerechnet",
+		displayPrice: "155,88 €",
+	},
+	monthly: {
+		billingDescription: "Monatlich abgerechnet",
+		displayPrice: "14,99 €",
+	},
+} as const satisfies Record<
+	DayovaBillingPeriod,
+	{ billingDescription: string; displayPrice: string }
+>;

--- a/tests/ios-auth-capabilities.test.ts
+++ b/tests/ios-auth-capabilities.test.ts
@@ -1,0 +1,41 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const IOS_ENTITLEMENTS_PATH = resolve(
+	process.cwd(),
+	"ios/Dayova/Dayova.entitlements",
+);
+const SIGN_IN_WITH_APPLE_ENTITLEMENT = "com.apple.developer.applesignin";
+
+const readFinalExpoEntitlements = () => {
+	const output = execFileSync(
+		"npx",
+		["expo", "config", "--type", "introspect", "--json"],
+		{
+			cwd: process.cwd(),
+			encoding: "utf8",
+			env: {
+				...process.env,
+				APP_VARIANT: "production",
+			},
+		},
+	);
+
+	return JSON.parse(output).ios?.entitlements ?? {};
+};
+
+describe("iOS authentication capabilities", () => {
+	it("does not request Sign in with Apple for password-only authentication", () => {
+		const finalEntitlements = readFinalExpoEntitlements();
+
+		expect(finalEntitlements[SIGN_IN_WITH_APPLE_ENTITLEMENT]).toBeUndefined();
+
+		if (existsSync(IOS_ENTITLEMENTS_PATH)) {
+			expect(readFileSync(IOS_ENTITLEMENTS_PATH, "utf8")).not.toContain(
+				SIGN_IN_WITH_APPLE_ENTITLEMENT,
+			);
+		}
+	}, 15_000);
+});


### PR DESCRIPTION
## What changed

- keeps Dayova's existing two-step paywall and connects its self-payment screen to RevenueCat
- selects plans through the standard `$rc_monthly` and `$rc_annual` packages instead of hard-coded store product IDs
- pins the approved launch pricing in the UI: €14.99 monthly and €155.88 annually (€12.99/month)
- simplifies self-payment to two standalone plan options followed by the concise `Abonnieren` action
- adds UI and client coverage for the approved prices, purchase, cancellation, restore, and entitlement handling
- documents that the Test Store key is local-only and must never be used for preview/production

## Why

The earlier Test Store setup used obsolete €159.99/€13.33 annual pricing and generic product identifiers. It also risked coupling the app to one store's SKU names. The approved pricing source is PRICING-001 / DAY-228.

RevenueCat dashboard configuration was updated separately to use:
- offering: `default`
- packages: `$rc_monthly`, `$rc_annual`
- entitlement: `dayova_full_access`
- products: `dayova_monthly`, `dayova_annual`

## Validation

- `pnpm test` — 589 unit tests and 98 UI tests passed
- `pnpm check` — Biome, ESLint, and TypeScript passed
- `pnpm exec jest src/features/access/subscription-screen.ui.test.tsx --runInBand` — 7 tests passed
- `pnpm exec biome check src/features/access/subscription-screen.tsx src/features/access/subscription-screen.ui.test.tsx` — passed
- `pnpm exec tsc --noEmit` — passed
- visually inspected the updated self-payment screen in the iOS Simulator
- RevenueCat webhook test reached the Convex endpoint with HTTP 202 (expected for RevenueCat's synthetic unlinked test user)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Pro welcome screen confirming newly unlocked benefits and providing a direct path to start learning.
  - Added annual and monthly subscription plan selection with clearer pricing and checkout flows.
  - Added post-purchase routing and improved purchase restoration behavior.

- **Improvements**
  - Simplified subscription management, account switching, and account deletion from the paywall.
  - Refined payment surfaces, labels, spacing, and visual styling across access screens.
  - Improved release configuration guidance for platform-specific RevenueCat keys and authentication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->