### PR TITLE
Fix learning plan countdown overflow

### DIFF
--- a/src/app/(app)/learning-plans.tsx
+++ b/src/app/(app)/learning-plans.tsx
@@ -37,6 +37,7 @@ import { Text } from "~/components/ui/text";
 import { ThemedStatusBar } from "~/components/ui/themed-status-bar";
 import { useAuthSession } from "~/context/AuthContext";
 import { learningPlanResumePath } from "~/features/learning-plans/creation-routes";
+import { LearningPlanCardFooter } from "~/features/learning-plans/learning-plan-card-footer";
 import { MaterialRequiredSheet } from "~/features/learning-plans/material-required-sheet";
 import { getRollingLearningWindowLabel } from "~/features/learning-plans/rolling-learning-window";
 import { createAsyncActionGate } from "~/lib/async-action-gate";
@@ -592,51 +593,11 @@ function LearningPlanCard({
 								kann.
 							</Text>
 						) : (
-							<View className="mt-4 w-full max-w-[300px] gap-1">
-								<View className="flex-row items-center">
-									<Text className="w-[198px] font-poppins text-body-5 text-secondary-text">
-										{rollingWindowLabel}
-									</Text>
-									<View className="flex-row items-center gap-1">
-										<ClipboardEdit
-											size={14}
-											color={colors.secondaryText}
-											strokeWidth={2}
-										/>
-										<Text className="font-poppins text-body-4 text-secondary-text">
-											{remainingDays === 1
-												? "noch 1 Tag"
-												: `noch ${remainingDays} Tage`}
-										</Text>
-									</View>
-								</View>
-								<View
-									accessibilityLabel={`${progress} Prozent abgeschlossen`}
-									accessibilityValue={{
-										max: 100,
-										min: 0,
-										now: progress,
-										text: `${progress} Prozent`,
-									}}
-									accessibilityRole="progressbar"
-									className="h-2 w-[258px] max-w-full overflow-hidden rounded-full bg-light-2"
-								>
-									<LinearGradient
-										colors={
-											DAYOVA_DESIGN_SYSTEM.gradients.primaryInteractive.colors
-										}
-										start={
-											DAYOVA_DESIGN_SYSTEM.gradients.primaryInteractive.start
-										}
-										end={DAYOVA_DESIGN_SYSTEM.gradients.primaryInteractive.end}
-										style={{
-											height: "100%",
-											width: `${Math.max(progress, progress > 0 ? 8 : 0)}%`,
-											borderRadius: 999,
-										}}
-									/>
-								</View>
-							</View>
+							<LearningPlanCardFooter
+								progress={progress}
+								remainingDays={remainingDays}
+								rollingWindowLabel={rollingWindowLabel}
+							/>
 						)}
 					</NotchedActionCard>
 				</Animated.View>

--- a/src/features/learning-plans/learning-plan-card-footer.tsx
+++ b/src/features/learning-plans/learning-plan-card-footer.tsx
@@ -1,0 +1,74 @@
+import { LinearGradient } from "expo-linear-gradient";
+import { View } from "react-native";
+import { ClipboardEdit } from "~/components/ui/icon";
+import { Text } from "~/components/ui/text";
+import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
+import { useDayovaTheme } from "~/lib/theme";
+
+// The card content ends 24 points from the edge. This keeps the footer another
+// 32 points inward so it clears the 48-point action and its notched border.
+const FOOTER_ACTION_INSET = 32;
+
+export function LearningPlanCardFooter({
+	progress,
+	remainingDays,
+	rollingWindowLabel,
+}: {
+	progress: number;
+	remainingDays: number;
+	rollingWindowLabel: string;
+}) {
+	const { colors } = useDayovaTheme();
+
+	return (
+		<View
+			className="mt-4 w-full max-w-[300px] gap-1"
+			style={{ paddingRight: FOOTER_ACTION_INSET }}
+			testID="plan-card-footer"
+		>
+			<View className="flex-row items-start">
+				<Text
+					className="font-poppins text-body-5 text-secondary-text"
+					style={{ flexGrow: 1, flexShrink: 1, minWidth: 0, paddingRight: 8 }}
+				>
+					{rollingWindowLabel}
+				</Text>
+				<View className="shrink-0 flex-row items-center gap-1">
+					<ClipboardEdit
+						size={14}
+						color={colors.secondaryText}
+						strokeWidth={2}
+					/>
+					<Text
+						className="font-poppins text-body-4 text-secondary-text"
+						numberOfLines={1}
+					>
+						{remainingDays === 1 ? "noch 1 Tag" : `noch ${remainingDays} Tage`}
+					</Text>
+				</View>
+			</View>
+			<View
+				accessibilityLabel={`${progress} Prozent abgeschlossen`}
+				accessibilityValue={{
+					max: 100,
+					min: 0,
+					now: progress,
+					text: `${progress} Prozent`,
+				}}
+				accessibilityRole="progressbar"
+				className="h-2 w-[258px] max-w-full overflow-hidden rounded-full bg-light-2"
+			>
+				<LinearGradient
+					colors={DAYOVA_DESIGN_SYSTEM.gradients.primaryInteractive.colors}
+					start={DAYOVA_DESIGN_SYSTEM.gradients.primaryInteractive.start}
+					end={DAYOVA_DESIGN_SYSTEM.gradients.primaryInteractive.end}
+					style={{
+						height: "100%",
+						width: `${Math.max(progress, progress > 0 ? 8 : 0)}%`,
+						borderRadius: 999,
+					}}
+				/>
+			</View>
+		</View>
+	);
+}

--- a/src/features/learning-plans/learning-plan-card-footer.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-card-footer.ui.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { render } from "@testing-library/react-native";
+import { StyleSheet } from "react-native";
+import { LearningPlanCardFooter } from "./learning-plan-card-footer";
+
+jest.mock("~/components/ui/icon", () => {
+	const React = jest.requireActual<typeof import("react")>("react");
+	const Native =
+		jest.requireActual<typeof import("react-native")>("react-native");
+	return {
+		ClipboardEdit: (props: Record<string, unknown>) =>
+			React.createElement(Native.View, props),
+	};
+});
+
+jest.mock("~/lib/theme", () => ({
+	useDayovaTheme: () => ({
+		colors: { secondaryText: "#697586" },
+	}),
+}));
+
+describe("LearningPlanCardFooter", () => {
+	test("keeps countdown text outside the notched action area", async () => {
+		const screen = await render(
+			<LearningPlanCardFooter
+				progress={40}
+				remainingDays={4}
+				rollingWindowLabel="2 abgeschlossen · 2 weitere Termine geplant"
+			/>,
+		);
+
+		const footerStyle = StyleSheet.flatten(
+			screen.getByTestId("plan-card-footer").props.style,
+		);
+		const rollingLabelStyle = StyleSheet.flatten(
+			screen.getByText("2 abgeschlossen · 2 weitere Termine geplant").props
+				.style,
+		);
+
+		expect(footerStyle?.paddingRight ?? 0).toBeGreaterThanOrEqual(32);
+		expect(rollingLabelStyle ?? {}).toMatchObject({
+			flexGrow: 1,
+			flexShrink: 1,
+			minWidth: 0,
+		});
+		expect(screen.getByText("noch 4 Tage").props.numberOfLines).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary
- reserve the notched action area in the learning-plan card footer
- let the rolling-window label shrink and wrap instead of pushing the countdown under the CTA
- add a regression test for the footer layout contract

## Validation
- `pnpm test:ui` (33 suites, 99 tests)
- `pnpm typecheck`
- targeted Biome and ESLint checks
- iOS simulator screenshot check: overlap changed from -22 px to +46.4 px clearance