### PR TITLE
DAY-344 Simplify learning-path session nodes

### DIFF
--- a/src/app/learning-plans/[planId]/index.tsx
+++ b/src/app/learning-plans/[planId]/index.tsx
@@ -520,17 +520,13 @@ function StepPuck({
 	} = STEP_PUCK_DIMENSIONS[locked ? "compact" : "prominent"];
 	const baseColor = isCompleted
 		? DAYOVA_DESIGN_SYSTEM.colors.path5
-		: locked
-			? DAYOVA_DESIGN_SYSTEM.colors.pathLockedBase
-			: DAYOVA_DESIGN_SYSTEM.colors.path4;
+		: DAYOVA_DESIGN_SYSTEM.colors.pathLockedBase;
 	const faceColor = isCompleted
 		? DAYOVA_DESIGN_SYSTEM.colors.path6
-		: locked
-			? DAYOVA_DESIGN_SYSTEM.colors.path1
-			: DAYOVA_DESIGN_SYSTEM.colors.path3;
-	const iconColor = locked
-		? DAYOVA_DESIGN_SYSTEM.colors.path3
-		: DAYOVA_DESIGN_SYSTEM.colors.light1;
+		: DAYOVA_DESIGN_SYSTEM.colors.path1;
+	const iconColor = isCompleted
+		? DAYOVA_DESIGN_SYSTEM.colors.light1
+		: DAYOVA_DESIGN_SYSTEM.colors.path3;
 
 	return (
 		<View
@@ -572,6 +568,7 @@ function StepPuck({
 				}}
 			>
 				<View
+					testID={`${testID}-face`}
 					style={{
 						position: "absolute",
 						left: 4,
@@ -594,7 +591,7 @@ function StepPuck({
 							backgroundColor: isCompleted
 								? DAYOVA_DESIGN_SYSTEM.colors.path7
 								: DAYOVA_DESIGN_SYSTEM.colors.light1,
-							opacity: locked ? 0.2 : isCompleted ? 0.68 : 0.16,
+							opacity: isCompleted ? 0.68 : 0.2,
 							transform: [{ rotate: "31deg" }],
 						}}
 					/>

--- a/src/app/learning-plans/[planId]/index.tsx
+++ b/src/app/learning-plans/[planId]/index.tsx
@@ -51,8 +51,6 @@ import {
 	getLearningPathNodePresentation,
 	LEARNING_PATH_BREATHING,
 	LEARNING_PATH_PHASE_ICON,
-	LEARNING_PATH_SEGMENTED_HALO_TONES,
-	type LearningPathNodeHalo,
 	type LearningPathNodeIcon,
 	type LearningPathNodeState,
 	type LearningPathNodeTone,
@@ -405,17 +403,13 @@ const STEP_SELECTION_HEIGHT = 86;
 const STEP_SELECTION_STROKE_WIDTH = 7;
 const STEP_HALO_PATH =
 	"M46 3.5C69.4721 3.5 88.5 21.1848 88.5 43C88.5 64.8152 69.4721 82.5 46 82.5C22.5279 82.5 3.5 64.8152 3.5 43C3.5 21.1848 22.5279 3.5 46 3.5Z";
-const STEP_SEGMENTED_HALO_PATHS = [
-	"M40 4C21.8 6.5 7.5 19.5 3.9 36.5",
-	"M52 4.1C69.5 6.2 83.5 18.8 87.6 35.2",
-	"M88.1 51.2C83.9 68.4 69.3 80.3 52 82",
-	"M39.7 81.4C22.1 78.8 8.1 66.2 4 49.8",
-] as const;
 
 function StepHalo({
-	variant,
+	testID,
+	tone,
 }: {
-	variant: Exclude<LearningPathNodeHalo, "none">;
+	testID: string;
+	tone: LearningPathNodeTone;
 }) {
 	return (
 		<Svg
@@ -425,37 +419,17 @@ function StepHalo({
 			viewBox={`0 0 ${STEP_SELECTION_WIDTH} ${STEP_SELECTION_HEIGHT}`}
 			style={{ position: "absolute", left: 0, top: 0 }}
 		>
-			{variant === "solid" ? (
-				<>
-					<Path
-						d={STEP_HALO_PATH}
-						fill="none"
-						stroke={DAYOVA_DESIGN_SYSTEM.colors.path4}
-						strokeWidth={STEP_SELECTION_STROKE_WIDTH}
-					/>
-					<Path
-						d={STEP_HALO_PATH}
-						fill="none"
-						stroke={DAYOVA_DESIGN_SYSTEM.colors.light1}
-						strokeWidth={3.5}
-					/>
-				</>
-			) : (
-				STEP_SEGMENTED_HALO_PATHS.map((path, index) => (
-					<Path
-						key={path}
-						d={path}
-						fill="none"
-						stroke={
-							LEARNING_PATH_SEGMENTED_HALO_TONES[index] === "blue"
-								? DAYOVA_DESIGN_SYSTEM.colors.path6
-								: DAYOVA_DESIGN_SYSTEM.colors.path1
-						}
-						strokeLinecap="round"
-						strokeWidth={STEP_SELECTION_STROKE_WIDTH}
-					/>
-				))
-			)}
+			<Path
+				d={STEP_HALO_PATH}
+				fill="none"
+				stroke={
+					tone === "blue"
+						? DAYOVA_DESIGN_SYSTEM.colors.path6
+						: DAYOVA_DESIGN_SYSTEM.colors.path1
+				}
+				strokeWidth={STEP_SELECTION_STROKE_WIDTH}
+				testID={testID}
+			/>
 		</Svg>
 	);
 }
@@ -660,13 +634,16 @@ function PathNode({
 			accessibilityHint={
 				isLocked
 					? "Zeigt den voraussichtlich folgenden Lernblock. Er kann sich nach der nächsten Session noch ändern."
-					: "Wählt diesen Lernblock aus. Über die Vorschau oben kannst du ihn starten oder ansehen."
+					: selected
+						? "Öffnet diesen Lernblock."
+						: "Wählt diesen Lernblock aus. Ein weiterer Tipp öffnet ihn."
 			}
 			accessibilityRole="button"
 			accessibilityState={{ selected }}
 			onPress={onPress}
 			className="absolute items-center justify-center"
 			style={position}
+			testID={`learning-path-node-${session.id}`}
 		>
 			<BreathingStep
 				enabled={presentation.motion === "breathe"}
@@ -674,7 +651,10 @@ function PathNode({
 				top={(frame.height - STEP_SELECTION_HEIGHT) / 2}
 			>
 				{presentation.halo !== "none" ? (
-					<StepHalo variant={presentation.halo} />
+					<StepHalo
+						testID={`learning-path-node-halo-${session.id}`}
+						tone={presentation.tone}
+					/>
 				) : null}
 				<View
 					style={{
@@ -694,6 +674,7 @@ function PathNode({
 export function LearningPath({
 	examCountdownLabel,
 	examDateLabel,
+	onOpenSession,
 	onSelectSession,
 	selectedSessionId,
 	sessions,
@@ -701,6 +682,7 @@ export function LearningPath({
 }: {
 	examCountdownLabel: string | null;
 	examDateLabel: string;
+	onOpenSession: (session: PlanSession) => void;
 	onSelectSession: (session: PlanSession) => void;
 	selectedSessionId: Id<"learningPlanSessions"> | null;
 	sessions: PlanSession[];
@@ -789,15 +771,22 @@ export function LearningPath({
 
 			{sessions.map((session, index) => {
 				const state = getPathNodeState(session, index, currentIndex);
+				const selected = session.id === selectedSessionId;
 
 				return (
 					<PathNode
 						key={session.id}
 						frame={getFigmaNodeFrame(index)}
-						selected={session.id === selectedSessionId}
+						selected={selected}
 						session={session}
 						state={state}
-						onPress={() => onSelectSession(session)}
+						onPress={() => {
+							if (selected && state !== "locked") {
+								onOpenSession(session);
+								return;
+							}
+							onSelectSession(session);
+						}}
 					/>
 				);
 			})}
@@ -1044,6 +1033,15 @@ export default function LearningPlanSessionsScreen() {
 						showsAdaptiveContinuation={
 							snapshot.plan.rollingPlanEnabled === true
 						}
+						onOpenSession={(session) => {
+							if (
+								!canOpenSelectedSession ||
+								session.id !== selectedSession.id
+							) {
+								return;
+							}
+							router.push(getSessionRoute(snapshot.plan.id, session.id));
+						}}
 						onSelectSession={(session) => setSelectedSessionId(session.id)}
 					/>
 				) : (

--- a/src/app/learning-plans/[planId]/index.tsx
+++ b/src/app/learning-plans/[planId]/index.tsx
@@ -391,16 +391,16 @@ const getPathNodeState = (
 };
 
 const STEP_PUCK_DIMENSIONS = {
-	blue: { faceHeight: 52, height: 59, width: 60 },
-	gray: { faceHeight: 46, height: 52, width: 52 },
+	compact: { faceHeight: 46, height: 52, width: 52 },
+	prominent: { faceHeight: 52, height: 59, width: 60 },
 } satisfies Record<
-	LearningPathNodeTone,
+	"compact" | "prominent",
 	{ faceHeight: number; height: number; width: number }
 >;
 const STEP_PUCK_LIP_OFFSET = 6;
 const STEP_SELECTION_WIDTH = 92;
 const STEP_SELECTION_HEIGHT = 86;
-const STEP_SELECTION_STROKE_WIDTH = 7;
+const STEP_SELECTION_STROKE_WIDTH = 4;
 const STEP_HALO_PATH =
 	"M46 3.5C69.4721 3.5 88.5 21.1848 88.5 43C88.5 64.8152 69.4721 82.5 46 82.5C22.5279 82.5 3.5 64.8152 3.5 43C3.5 21.1848 22.5279 3.5 46 3.5Z";
 
@@ -425,7 +425,7 @@ function StepHalo({
 				stroke={
 					tone === "blue"
 						? DAYOVA_DESIGN_SYSTEM.colors.path6
-						: DAYOVA_DESIGN_SYSTEM.colors.path1
+						: DAYOVA_DESIGN_SYSTEM.colors.path4
 				}
 				strokeWidth={STEP_SELECTION_STROKE_WIDTH}
 				testID={testID}
@@ -502,39 +502,50 @@ function BreathingStep({
 
 function StepPuck({
 	icon,
+	locked,
+	testID,
 	tone,
 }: {
 	icon: LearningPathNodeIcon;
+	locked: boolean;
+	testID: string;
 	tone: LearningPathNodeTone;
 }) {
-	const isLocked = tone === "gray";
+	const isCompleted = tone === "blue";
 	const Icon = LEARNING_PATH_ICON_COMPONENT[icon];
 	const {
 		faceHeight,
 		height: puckHeight,
 		width: puckWidth,
-	} = STEP_PUCK_DIMENSIONS[tone];
-	const baseColor = isLocked
-		? DAYOVA_DESIGN_SYSTEM.colors.pathLockedBase
-		: DAYOVA_DESIGN_SYSTEM.colors.path5;
-	const faceColor = isLocked
-		? DAYOVA_DESIGN_SYSTEM.colors.path1
-		: DAYOVA_DESIGN_SYSTEM.colors.path6;
-	const iconColor = isLocked
+	} = STEP_PUCK_DIMENSIONS[locked ? "compact" : "prominent"];
+	const baseColor = isCompleted
+		? DAYOVA_DESIGN_SYSTEM.colors.path5
+		: locked
+			? DAYOVA_DESIGN_SYSTEM.colors.pathLockedBase
+			: DAYOVA_DESIGN_SYSTEM.colors.path4;
+	const faceColor = isCompleted
+		? DAYOVA_DESIGN_SYSTEM.colors.path6
+		: locked
+			? DAYOVA_DESIGN_SYSTEM.colors.path1
+			: DAYOVA_DESIGN_SYSTEM.colors.path3;
+	const iconColor = locked
 		? DAYOVA_DESIGN_SYSTEM.colors.path3
 		: DAYOVA_DESIGN_SYSTEM.colors.light1;
 
 	return (
 		<View
 			pointerEvents="none"
+			testID={testID}
 			style={{
 				width: puckWidth,
 				height: puckHeight,
 				alignItems: "center",
 				borderRadius: puckHeight / 2,
-				boxShadow: isLocked
-					? "0 5px 8px rgba(105, 117, 134, 0.16)"
-					: "0 5px 9px rgba(0, 160, 230, 0.2)",
+				boxShadow: isCompleted
+					? "0 5px 9px rgba(0, 160, 230, 0.2)"
+					: locked
+						? "0 5px 8px rgba(105, 117, 134, 0.16)"
+						: "0 5px 9px rgba(105, 117, 134, 0.22)",
 			}}
 		>
 			<View
@@ -576,20 +587,20 @@ function StepPuck({
 						style={{
 							position: "absolute",
 							top: -9,
-							right: isLocked ? -5 : -2,
-							width: isLocked ? 17 : 21,
-							height: isLocked ? 42 : 48,
+							right: locked ? -5 : -2,
+							width: locked ? 17 : 21,
+							height: locked ? 42 : 48,
 							borderRadius: 12,
-							backgroundColor: isLocked
-								? DAYOVA_DESIGN_SYSTEM.colors.light1
-								: DAYOVA_DESIGN_SYSTEM.colors.path7,
-							opacity: isLocked ? 0.2 : 0.68,
+							backgroundColor: isCompleted
+								? DAYOVA_DESIGN_SYSTEM.colors.path7
+								: DAYOVA_DESIGN_SYSTEM.colors.light1,
+							opacity: locked ? 0.2 : isCompleted ? 0.68 : 0.16,
 							transform: [{ rotate: "31deg" }],
 						}}
 					/>
 				</View>
 				<Icon
-					size={isLocked ? 23 : 28}
+					size={locked ? 23 : 28}
 					color={iconColor}
 					strokeWidth={icon === "check" ? 3.6 : 2.75}
 					style={{ zIndex: 1 }}
@@ -618,7 +629,8 @@ function PathNode({
 		selected,
 		state,
 	});
-	const puckDimensions = STEP_PUCK_DIMENSIONS[presentation.tone];
+	const puckDimensions =
+		STEP_PUCK_DIMENSIONS[isLocked ? "compact" : "prominent"];
 	const title = formatGermanUiText(session.title);
 	const stateLabel = PATH_NODE_STATE_LABEL[state];
 	const position = {
@@ -664,7 +676,12 @@ function PathNode({
 						zIndex: 1,
 					}}
 				>
-					<StepPuck icon={presentation.icon} tone={presentation.tone} />
+					<StepPuck
+						icon={presentation.icon}
+						locked={isLocked}
+						testID={`learning-path-node-puck-${session.id}`}
+						tone={presentation.tone}
+					/>
 				</View>
 			</BreathingStep>
 		</Pressable>

--- a/src/features/learning-plans/learning-path-node-presentation.test.ts
+++ b/src/features/learning-plans/learning-path-node-presentation.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 import {
 	getLearningPathNodePresentation,
 	LEARNING_PATH_BREATHING,
-	LEARNING_PATH_SEGMENTED_HALO_TONES,
 } from "./learning-path-node-presentation";
 
 describe("getLearningPathNodePresentation", () => {
@@ -34,7 +33,7 @@ describe("getLearningPathNodePresentation", () => {
 		});
 	});
 
-	test("the current session keeps its phase icon inside the segmented breathing treatment", () => {
+	test("unfinished sessions stay gray and only show a continuous halo when selected", () => {
 		expect([
 			getLearningPathNodePresentation({
 				phase: "theory",
@@ -52,32 +51,23 @@ describe("getLearningPathNodePresentation", () => {
 				state: "current",
 			}),
 		]).toEqual([
-			{ halo: "segmented", icon: "note", motion: "breathe", tone: "blue" },
+			{ halo: "solid", icon: "note", motion: "breathe", tone: "gray" },
 			{
-				halo: "segmented",
+				halo: "none",
 				icon: "dumbbell",
 				motion: "breathe",
-				tone: "blue",
+				tone: "gray",
 			},
 			{
-				halo: "segmented",
+				halo: "none",
 				icon: "repeat",
 				motion: "breathe",
-				tone: "blue",
+				tone: "gray",
 			},
 		]);
 	});
 
-	test("the current-session halo alternates gray and blue across four separate arcs", () => {
-		expect(LEARNING_PATH_SEGMENTED_HALO_TONES).toEqual([
-			"gray",
-			"blue",
-			"gray",
-			"blue",
-		]);
-	});
-
-	test("locked sessions keep their phase icons on compact gray coins without motion or halos", () => {
+	test("locked sessions keep their phase icons on compact gray coins and use the same selected halo", () => {
 		expect([
 			getLearningPathNodePresentation({
 				phase: "theory",
@@ -96,7 +86,7 @@ describe("getLearningPathNodePresentation", () => {
 			}),
 		]).toEqual([
 			{ halo: "none", icon: "note", motion: "still", tone: "gray" },
-			{ halo: "none", icon: "dumbbell", motion: "still", tone: "gray" },
+			{ halo: "solid", icon: "dumbbell", motion: "still", tone: "gray" },
 			{ halo: "none", icon: "repeat", motion: "still", tone: "gray" },
 		]);
 	});

--- a/src/features/learning-plans/learning-path-node-presentation.ts
+++ b/src/features/learning-plans/learning-path-node-presentation.ts
@@ -2,7 +2,7 @@ import type { SessionPhase } from "~/features/learning-plans/types";
 
 export type LearningPathNodeState = "completed" | "current" | "locked";
 export type LearningPathNodeIcon = "check" | "dumbbell" | "note" | "repeat";
-export type LearningPathNodeHalo = "none" | "segmented" | "solid";
+export type LearningPathNodeHalo = "none" | "solid";
 type LearningPathNodeMotion = "breathe" | "still";
 export type LearningPathNodeTone = "blue" | "gray";
 
@@ -18,13 +18,6 @@ export const LEARNING_PATH_BREATHING = {
 	maxScale: 1.06,
 	minScale: 0.96,
 } as const;
-
-export const LEARNING_PATH_SEGMENTED_HALO_TONES = [
-	"gray",
-	"blue",
-	"gray",
-	"blue",
-] as const satisfies readonly LearningPathNodeTone[];
 
 export const LEARNING_PATH_PHASE_ICON: Record<
 	SessionPhase,
@@ -54,15 +47,15 @@ export const getLearningPathNodePresentation = ({
 	}
 	if (state === "current") {
 		return {
-			halo: "segmented",
+			halo: selected ? "solid" : "none",
 			icon: LEARNING_PATH_PHASE_ICON[phase],
 			motion: "breathe",
-			tone: "blue",
+			tone: "gray",
 		};
 	}
 
 	return {
-		halo: "none",
+		halo: selected ? "solid" : "none",
 		icon: LEARNING_PATH_PHASE_ICON[phase],
 		motion: "still",
 		tone: "gray",

--- a/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
@@ -257,7 +257,15 @@ describe("learning-plan path", () => {
 		expect(
 			screen.getByTestId("learning-path-node-halo-session_current").props.stroke
 				.payload,
-		).toEqual(processColor(DAYOVA_DESIGN_SYSTEM.colors.path1));
+		).toEqual(processColor(DAYOVA_DESIGN_SYSTEM.colors.path4));
+		expect(
+			screen.getByTestId("learning-path-node-puck-session_current").props.style
+				.width,
+		).toBe(60);
+		expect(
+			screen.getByTestId("learning-path-node-puck-session_preview").props.style
+				.width,
+		).toBe(52);
 		expect(
 			screen.queryByTestId("learning-path-node-halo-session_done"),
 		).toBeNull();

--- a/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
@@ -1,11 +1,13 @@
 import { describe, expect, jest, test } from "@jest/globals";
 import { fireEvent, render } from "@testing-library/react-native";
+import { processColor } from "react-native";
 import {
 	getExamCountdownLabel,
 	LearningPath,
 	SessionPreviewCard,
 } from "~/app/learning-plans/[planId]/index";
 import type { PlanSession } from "~/features/learning-plans/types";
+import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 
 jest.mock("expo-router", () => ({
 	Stack: { Screen: () => null },
@@ -209,6 +211,8 @@ describe("learning-plan path", () => {
 	});
 
 	test("keeps node details out of the path and connects it to the exam", async () => {
+		const onOpenSession = jest.fn();
+		const onSelectSession = jest.fn();
 		const sessions = [
 			session("session_done", {
 				completed: true,
@@ -226,7 +230,8 @@ describe("learning-plan path", () => {
 			<LearningPath
 				examCountdownLabel="Noch 14 Tage"
 				examDateLabel="18. August 2026"
-				onSelectSession={() => undefined}
+				onOpenSession={onOpenSession}
+				onSelectSession={onSelectSession}
 				selectedSessionId={sessions[1]?.id ?? null}
 				sessions={sessions}
 				showsAdaptiveContinuation
@@ -249,6 +254,25 @@ describe("learning-plan path", () => {
 		expect(screen.getByText("Dayova plant mit dir weiter")).toBeOnTheScreen();
 		expect(screen.getByText("18. August 2026")).toBeOnTheScreen();
 		expect(screen.getByText("Noch 14 Tage")).toBeOnTheScreen();
+		expect(
+			screen.getByTestId("learning-path-node-halo-session_current").props.stroke
+				.payload,
+		).toEqual(processColor(DAYOVA_DESIGN_SYSTEM.colors.path1));
+		expect(
+			screen.queryByTestId("learning-path-node-halo-session_done"),
+		).toBeNull();
+
+		await fireEvent.press(
+			screen.getByTestId("learning-path-node-session_current"),
+		);
+		expect(onOpenSession).toHaveBeenCalledWith(sessions[1]);
+		expect(onSelectSession).not.toHaveBeenCalled();
+
+		await fireEvent.press(
+			screen.getByTestId("learning-path-node-session_preview"),
+		);
+		expect(onOpenSession).toHaveBeenCalledTimes(1);
+		expect(onSelectSession).toHaveBeenCalledWith(sessions[2]);
 	});
 
 	test("formats the exam countdown for today and future dates", () => {

--- a/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
@@ -263,6 +263,10 @@ describe("learning-plan path", () => {
 				.width,
 		).toBe(60);
 		expect(
+			screen.getByTestId("learning-path-node-puck-session_current-face").props
+				.style.backgroundColor,
+		).toBe(DAYOVA_DESIGN_SYSTEM.colors.path1);
+		expect(
 			screen.getByTestId("learning-path-node-puck-session_preview").props.style
 				.width,
 		).toBe(52);


### PR DESCRIPTION
## Summary

- replace the four-part learning-path halo with one continuous status ring
- keep unfinished nodes grey and reserve blue for completed sessions
- open an available session when its already-focused node is pressed again while preserving locked-session guards
- update presentation and interaction coverage

## Validation

- `pnpm check`
- `pnpm test` (597 unit tests and 107 UI tests)

Linear: https://linear.app/dayova/issue/DAY-344/simplify-learning-path-session-node-ring-and-focused-node-interaction