### PR TITLE
DAY-343 Keep material-missing learning plan drafts

### DIFF
--- a/convex/learningPlans.test.ts
+++ b/convex/learningPlans.test.ts
@@ -129,7 +129,7 @@ test("lists a materialless draft so the upload can be resumed", async () => {
 		examDateKey: "2026-08-12",
 		examDateLabel: "12. August 2026",
 		durationMinutes: 90,
-		topicDescription: "",
+		topicDescription: "Lineare Funktionen, Steigung und Nullstellen",
 	});
 
 	await expect(t.query(api.learningPlans.listOverview, {})).resolves.toEqual([
@@ -137,6 +137,7 @@ test("lists a materialless draft so the upload can be resumed", async () => {
 			id: learningPlanId,
 			status: "draft",
 			needsSchoolMaterial: true,
+			topicDescription: "Lineare Funktionen, Steigung und Nullstellen",
 		}),
 	]);
 });

--- a/convex/learningPlans.ts
+++ b/convex/learningPlans.ts
@@ -1328,6 +1328,7 @@ export const listOverview = query({
 				id: plan._id,
 				subject: plan.subject,
 				examTypeLabel: plan.examTypeLabel,
+				topicDescription: plan.topicDescription,
 				status: plan.status,
 				needsSchoolMaterial: plan.status === "draft",
 				progressPercent,

--- a/docs/contexts/product/CONTEXT.md
+++ b/docs/contexts/product/CONTEXT.md
@@ -143,8 +143,8 @@ _Avoid_: Treating Generalprobe as a fourth learner-facing phase separate from Pr
 
 ## Contracts and Constraints
 
-- Saving an exam is independent from creating a `Persönlicher Lernplan`. Without uploaded school material, keep the exam and explain that uploading an `Interne Schulquelle` unlocks a plan; do not create plan sessions.
-- Learning-plan setup asks the learner for the required exam topics before school-material upload. Persist that answer on the exam entry so back navigation and later resume retain it. Do not retain a `learningPlans` record, analyze material, or generate plan sessions unless the learner successfully uploads at least one `Interne Schulquelle`; clean up a newly created upload draft when its first upload fails or its last school document is removed.
+- Saving an exam is independent from generating a `Persönlicher Lernplan`. Without uploaded school material, keep the exam and a resumable material-missing plan draft in the overview; do not analyze material or create plan sessions.
+- Learning-plan setup asks the learner for the required exam topics before school-material upload. Persist that answer on both the exam entry and its material-missing plan draft so back navigation and later resume retain it. The missing-material prompt maps those topics into concrete upload guidance. Retain the draft when an upload fails or the last school document is removed.
 - External learning aids and typed teacher guidance may enrich a plan but never satisfy the school-material requirement.
 - The confirmed exam scope should be an exhaustive map of distinct, assessable capabilities supported by internal school evidence, not a few broad chapter labels. Split broad areas into what the learner must explain and solve or apply, while never inventing or duplicating topics to reach a target count.
 - Learning-plan creation contains no knowledge-question or quiz step. Its first knowledge test is the scheduled, timed `Wissenscheck` with five to ten questions.

--- a/src/app/(app)/learning-plans.tsx
+++ b/src/app/(app)/learning-plans.tsx
@@ -65,6 +65,7 @@ type LearningPlanOverview = {
 	id: Id<"learningPlans">;
 	subject: string;
 	examTypeLabel: string;
+	topicDescription: string;
 	status: "draft" | "questionsReady" | "generated" | "accepted";
 	needsSchoolMaterial: boolean;
 	progressPercent: number;
@@ -992,6 +993,7 @@ export default function LearningPlansScreen() {
 				onClose={() => setMaterialUploadTarget(null)}
 				onUpload={continueToMaterialUpload}
 				subject={materialUploadTarget?.subject ?? null}
+				topicDescription={materialUploadTarget?.topicDescription ?? null}
 			/>
 			<ConfirmationSheet
 				visible={Boolean(deleteTarget)}

--- a/src/app/(creation)/learning-plans/new.tsx
+++ b/src/app/(creation)/learning-plans/new.tsx
@@ -85,7 +85,6 @@ export default function NewLearningPlanScreen() {
 	const { user } = useAuthSession();
 	const { capture } = useValidationAnalytics();
 	const { isAuthenticated: isConvexAuthenticated } = useConvexAuth();
-	const updateExamTopics = useMutation(api.dayEntries.updateExamTopics);
 	const createDraftPlan = useMutation(api.learningPlans.createDraft);
 	const updateRequiredTopics = useMutation(
 		api.learningPlans.updateRequiredTopics,
@@ -95,7 +94,6 @@ export default function NewLearningPlanScreen() {
 		api.learningPlans.registerUploadedDocument,
 	);
 	const removeDocument = useMutation(api.learningPlans.removeDocument);
-	const removePlan = useMutation(api.learningPlans.removePlan);
 
 	const subject = params.subject?.trim() || "Fach";
 	const examTypeLabel = params.examTypeLabel?.trim() || "Leistungskontrolle";
@@ -183,7 +181,7 @@ export default function NewLearningPlanScreen() {
 		topicDescription = params.topicDescription ?? "",
 	) => {
 		if (learningPlanId) {
-			return { id: learningPlanId, created: false };
+			return learningPlanId;
 		}
 
 		if (!examDayEntryId) {
@@ -204,13 +202,7 @@ export default function NewLearningPlanScreen() {
 		);
 		setLearningPlanId(id);
 		router.setParams({ learningPlanId: id, step: "material" });
-		return { id, created: true };
-	};
-
-	const discardNewMateriallessPlan = async (id: Id<"learningPlans">) => {
-		await retryOnceAfterAuthResume(() => removePlan({ id }));
-		setLearningPlanId(null);
-		router.setParams({ learningPlanId: undefined, step: "material" });
+		return id;
 	};
 
 	const runWithErrorHandling = async (
@@ -247,7 +239,7 @@ export default function NewLearningPlanScreen() {
 		existingLearningPlanId?: Id<"learningPlans">,
 	) => {
 		const id =
-			existingLearningPlanId ?? learningPlanId ?? (await ensurePlan(topics)).id;
+			existingLearningPlanId ?? learningPlanId ?? (await ensurePlan(topics));
 		const { asset, file, fileSizeBytes, fileType } = preparedAsset;
 
 		const uploadData = await retryOnceAfterAuthResume(() =>
@@ -389,18 +381,9 @@ export default function NewLearningPlanScreen() {
 							size: asset.size,
 						}),
 					);
-					const { id, created } = await ensurePlan(topics);
-					let uploadedAny = false;
-					try {
-						for (const asset of preparedAssets) {
-							await uploadLearningPlanAsset(asset, id);
-							uploadedAny = true;
-						}
-					} catch (error) {
-						if (created && !uploadedAny) {
-							await discardNewMateriallessPlan(id);
-						}
-						throw error;
+					const id = await ensurePlan(topics);
+					for (const asset of preparedAssets) {
+						await uploadLearningPlanAsset(asset, id);
 					}
 				},
 			);
@@ -445,21 +428,16 @@ export default function NewLearningPlanScreen() {
 			await runWithErrorHandling(
 				"Das Foto konnte nicht hochgeladen werden.",
 				async () => {
-					const { id, created } = await ensurePlan(topics);
-					try {
-						await uploadLearningPlanAsset(
-							prepareUploadAsset({
-								uri: asset.uri,
-								name: asset.fileName ?? `mitschrift-${Date.now()}.jpg`,
-								mimeType: asset.mimeType ?? "image/jpeg",
-								size: asset.fileSize,
-							}),
-							id,
-						);
-					} catch (error) {
-						if (created) await discardNewMateriallessPlan(id);
-						throw error;
-					}
+					const id = await ensurePlan(topics);
+					await uploadLearningPlanAsset(
+						prepareUploadAsset({
+							uri: asset.uri,
+							name: asset.fileName ?? `mitschrift-${Date.now()}.jpg`,
+							mimeType: asset.mimeType ?? "image/jpeg",
+							size: asset.fileSize,
+						}),
+						id,
+					);
 				},
 			);
 		} catch (error) {
@@ -514,14 +492,6 @@ export default function NewLearningPlanScreen() {
 			setIsBusy(true);
 			setErrorMessage(null);
 			try {
-				if (examDayEntryId) {
-					await retryOnceAfterAuthResume(() =>
-						updateExamTopics({
-							id: examDayEntryId,
-							topicDescription: topics,
-						}),
-					);
-				}
 				if (learningPlanId) {
 					await retryOnceAfterAuthResume(() =>
 						updateRequiredTopics({
@@ -529,9 +499,8 @@ export default function NewLearningPlanScreen() {
 							topicDescription: topics,
 						}),
 					);
-				}
-				if (!examDayEntryId && !learningPlanId) {
-					throw new Error("Prüfung nicht gefunden.");
+				} else {
+					await ensurePlan(topics);
 				}
 				router.setParams({
 					errorMessage: undefined,
@@ -552,11 +521,11 @@ export default function NewLearningPlanScreen() {
 		});
 	};
 
-	const finishWithoutPlan = () => {
+	const finishWithMaterialLater = () => {
 		void runWithErrorHandling(
-			"Die Prüfung konnte nicht ohne Lernplan abgeschlossen werden.",
+			"Der Lernplan-Entwurf konnte nicht gespeichert werden.",
 			async () => {
-				if (!examDayEntryId) throw new Error("Prüfung nicht gefunden.");
+				if (!learningPlanId) throw new Error("Lernplan nicht gefunden.");
 				if (!isMeaningfulTopicDescription(topics)) {
 					throw new Error("Prüfungsthemen fehlen.");
 				}
@@ -573,21 +542,7 @@ export default function NewLearningPlanScreen() {
 	const removeUploadedDocument = async (
 		documentId: Id<"learningPlanDocuments">,
 	) => {
-		const removedDocument = snapshot?.documents.find(
-			(document) => document.id === documentId,
-		);
-		const isLastSchoolDocument =
-			removedDocument?.sourceKind === "school" &&
-			snapshot?.documents.filter((document) => document.sourceKind === "school")
-				.length === 1;
 		await removeDocument({ id: documentId });
-		if (
-			learningPlanId &&
-			snapshot?.plan.status === "draft" &&
-			isLastSchoolDocument
-		) {
-			await discardNewMateriallessPlan(learningPlanId);
-		}
 	};
 
 	const goBack = () => {
@@ -660,7 +615,7 @@ export default function NewLearningPlanScreen() {
 							onContinue={continueToAnalysis}
 							onOpenUpload={() => setIsUploadSheetVisible(true)}
 							onRemoveDocument={(id) => void removeUploadedDocument(id)}
-							onSkip={finishWithoutPlan}
+							onSkip={finishWithMaterialLater}
 							openingUploadAction={openingUploadAction}
 							showSkip={!initialLearningPlanId}
 						/>

--- a/src/features/learning-plans/learning-plan-setup-steps.tsx
+++ b/src/features/learning-plans/learning-plan-setup-steps.tsx
@@ -150,7 +150,8 @@ export function MaterialUploadStep({
 
 			{showSkip && !hasSchoolMaterial ? (
 				<Text className="mt-3 font-poppins text-body-4 text-secondary-text">
-					Ohne Material wird nur deine Prüfung gespeichert.
+					Dein Lernplan-Entwurf bleibt gespeichert. Schulmaterial kannst du
+					später ergänzen.
 				</Text>
 			) : null}
 
@@ -185,12 +186,12 @@ export function MaterialUploadStep({
 					/>
 				) : showSkip ? (
 					<Button
-						accessibilityHint="Speichert die Prüfung ohne Lernplan. Material kann später hochgeladen werden."
+						accessibilityHint="Speichert den Lernplan-Entwurf. Material kann später hochgeladen werden."
 						variant="neutral"
 						disabled={!canUpload}
 						onPress={onSkip}
 					>
-						<Text>Ohne Lernplan abschließen</Text>
+						<Text>Material später hochladen</Text>
 					</Button>
 				) : null}
 			</View>

--- a/src/features/learning-plans/learning-plan-setup-steps.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-setup-steps.ui.test.tsx
@@ -76,7 +76,9 @@ describe("learning-plan setup steps", () => {
 			}),
 		).toBeEnabled();
 		expect(
-			screen.getByText("Ohne Material wird nur deine Prüfung gespeichert."),
+			screen.getByText(
+				"Dein Lernplan-Entwurf bleibt gespeichert. Schulmaterial kannst du später ergänzen.",
+			),
 		).toBeOnTheScreen();
 		expect(
 			screen.queryByRole("button", {
@@ -86,14 +88,14 @@ describe("learning-plan setup steps", () => {
 		expect(screen.queryByRole("button", { name: "Weiter" })).toBeNull();
 		expect(
 			screen.getByRole("button", {
-				name: "Ohne Lernplan abschließen",
+				name: "Material später hochladen",
 			}),
 		).toBeOnTheScreen();
 
 		await fireEvent.press(
 			screen.getByRole("button", { name: "Schulmaterial hinzufügen" }),
 		);
-		expect(onOpenUpload).toHaveBeenCalledWith("school");
+		expect(onOpenUpload).toHaveBeenCalledWith();
 	});
 
 	test("reveals continue after school material is uploaded", async () => {
@@ -134,7 +136,7 @@ describe("learning-plan setup steps", () => {
 		).toBeNull();
 		expect(
 			screen.queryByRole("button", {
-				name: "Ohne Lernplan abschließen",
+				name: "Material später hochladen",
 			}),
 		).toBeNull();
 	});
@@ -167,7 +169,7 @@ describe("learning-plan setup steps", () => {
 		expect(screen.queryByRole("button", { name: "Weiter" })).toBeNull();
 		expect(screen.queryByText("Lernhilfe.pdf")).toBeNull();
 		expect(
-			screen.getByRole("button", { name: "Ohne Lernplan abschließen" }),
+			screen.getByRole("button", { name: "Material später hochladen" }),
 		).toBeOnTheScreen();
 	});
 
@@ -195,7 +197,7 @@ describe("learning-plan setup steps", () => {
 			),
 		).toBeOnTheScreen();
 		expect(
-			screen.queryByRole("button", { name: "Ohne Lernplan abschließen" }),
+			screen.queryByRole("button", { name: "Material später hochladen" }),
 		).toBeNull();
 	});
 

--- a/src/features/learning-plans/material-required-sheet.tsx
+++ b/src/features/learning-plans/material-required-sheet.tsx
@@ -5,14 +5,32 @@ type MaterialRequiredSheetProps = {
 	onClose: () => void;
 	onUpload: () => void;
 	subject: string | null;
+	topicDescription: string | null;
 };
+
+const getRequiredTopics = (topicDescription: string | null) =>
+	(topicDescription ?? "")
+		.split(/[\n,;•]+/u)
+		.map((topic) => topic.trim())
+		.filter(Boolean);
 
 export function MaterialRequiredSheet({
 	onClose,
 	onUpload,
 	subject,
+	topicDescription,
 }: MaterialRequiredSheetProps) {
 	const formattedSubject = subject ? formatGermanUiText(subject) : null;
+	const requiredTopics = getRequiredTopics(topicDescription);
+	const subjectInstruction = formattedSubject
+		? `Lade mindestens eine Schulunterlage für ${formattedSubject} hoch.`
+		: "Lade mindestens eine Schulunterlage hoch.";
+	const topicInstruction =
+		requiredTopics.length > 0
+			? `\n\nDafür brauchst du Material:\n${requiredTopics
+					.map((topic) => `• ${formatGermanUiText(topic)}`)
+					.join("\n")}`
+			: "";
 
 	return (
 		<ConfirmationSheet
@@ -20,11 +38,7 @@ export function MaterialRequiredSheet({
 			closeAccessibilityLabel="Materialhinweis schließen"
 			confirmLabel="Material hochladen"
 			confirmTone="primary"
-			description={
-				formattedSubject
-					? `Lade mindestens eine Schulunterlage für ${formattedSubject} hoch. Danach kann Dayova deinen Lernplan erstellen.`
-					: "Lade mindestens eine Schulunterlage hoch. Danach kann Dayova deinen Lernplan erstellen."
-			}
+			description={`${subjectInstruction}${topicInstruction}\n\nDanach kann Dayova deinen Lernplan erstellen.`}
 			onClose={onClose}
 			onConfirm={onUpload}
 			title="Für diesen Lernplan fehlt Material"

--- a/src/features/learning-plans/material-required-sheet.ui.test.tsx
+++ b/src/features/learning-plans/material-required-sheet.ui.test.tsx
@@ -55,6 +55,9 @@ describe("MaterialRequiredSheet", () => {
 				onClose={onClose}
 				onUpload={onUpload}
 				subject="Mathe"
+				topicDescription={
+					"Lineare Funktionen, Steigung berechnen; Nullstellen\nbestimmen"
+				}
 			/>,
 		);
 
@@ -63,10 +66,9 @@ describe("MaterialRequiredSheet", () => {
 		).toBeOnTheScreen();
 		expect(
 			screen.getByText(
-				"Lade mindestens eine Schulunterlage für Mathe hoch. Danach kann Dayova deinen Lernplan erstellen.",
+				"Lade mindestens eine Schulunterlage für Mathe hoch.\n\nDafür brauchst du Material:\n• Lineare Funktionen\n• Steigung berechnen\n• Nullstellen\n• bestimmen\n\nDanach kann Dayova deinen Lernplan erstellen.",
 			),
 		).toBeOnTheScreen();
-
 		fireEvent.press(screen.getByRole("button", { name: "Material hochladen" }));
 		expect(onUpload).toHaveBeenCalledTimes(1);
 		expect(onClose).not.toHaveBeenCalled();
@@ -80,6 +82,7 @@ describe("MaterialRequiredSheet", () => {
 				onClose={onClose}
 				onUpload={onUpload}
 				subject="Biologie"
+				topicDescription="Zellbiologie"
 			/>,
 		);
 
@@ -94,6 +97,7 @@ describe("MaterialRequiredSheet", () => {
 				onClose={() => undefined}
 				onUpload={() => undefined}
 				subject={null}
+				topicDescription={null}
 			/>,
 		);
 


### PR DESCRIPTION
## Summary
- create and retain a resumable learning-plan draft as soon as required topics are saved
- show the saved required topics in the missing-material upload prompt
- keep failed uploads and last-document removal resumable instead of deleting the draft
- update the skip copy to make draft retention explicit

## Validation
- `pnpm exec vitest run convex/learningPlans.test.ts` (37 passed)
- `node ./node_modules/jest/bin/jest.js src/features/learning-plans/material-required-sheet.ui.test.tsx --runInBand --no-cache --forceExit` (3 passed)
- `pnpm typecheck`
- `pnpm lint` (passes; one pre-existing unused-import warning in `src/features/auth/dayova-auth-flow.tsx`)
- `pnpm exec convex dev --once`
- rendered and inspected the material-missing overview and topic-aware sheet on iPhone 17 / iOS 26.5