### PR TITLE
DAY-343 Restore create-without-material action

### DIFF
--- a/src/app/(creation)/learning-plans/new.tsx
+++ b/src/app/(creation)/learning-plans/new.tsx
@@ -26,6 +26,7 @@ import {
 	MaterialUploadStep,
 	RequiredTopicsStep,
 } from "~/features/learning-plans/learning-plan-setup-steps";
+import { useLearningPlanSetupOrigin } from "~/features/learning-plans/learning-plan-setup-origin";
 import type {
 	LearningPlanSnapshot,
 	UploadAsset,
@@ -105,6 +106,7 @@ export default function NewLearningPlanScreen() {
 	const initialLearningPlanId = params.learningPlanId as
 		| Id<"learningPlans">
 		| undefined;
+	const setupOrigin = useLearningPlanSetupOrigin(initialLearningPlanId);
 
 	const [learningPlanId, setLearningPlanId] =
 		useState<Id<"learningPlans"> | null>(initialLearningPlanId ?? null);
@@ -617,7 +619,7 @@ export default function NewLearningPlanScreen() {
 							onRemoveDocument={(id) => void removeUploadedDocument(id)}
 							onSkip={finishWithMaterialLater}
 							openingUploadAction={openingUploadAction}
-							showSkip={!initialLearningPlanId}
+							showSkip={setupOrigin === "newExam"}
 						/>
 					)}
 				</View>

--- a/src/components/ui/confirmation-sheet.tsx
+++ b/src/components/ui/confirmation-sheet.tsx
@@ -6,6 +6,9 @@ import { Text } from "~/components/ui/text";
 import { WarningBanner } from "~/components/ui/warning-banner";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 import { useDayovaTheme } from "~/lib/theme";
+import { cn } from "~/lib/utils";
+
+type ConfirmationActionLayout = "inline" | "stacked";
 
 type ConfirmationSheetProps = {
 	visible: boolean;
@@ -19,6 +22,7 @@ type ConfirmationSheetProps = {
 	errorMessage?: string | null;
 	confirmTone?: "primary" | "destructive";
 	closeAccessibilityLabel?: string;
+	actionLayout?: ConfirmationActionLayout;
 };
 
 function ConfirmationSheet({
@@ -33,11 +37,51 @@ function ConfirmationSheet({
 	errorMessage,
 	confirmTone = "destructive",
 	closeAccessibilityLabel = "Bestätigung schließen",
+	actionLayout = "inline",
 }: ConfirmationSheetProps) {
 	const { colors } = useDayovaTheme();
 	const safeClose = () => {
 		if (!isBusy) onClose();
 	};
+	const confirmButton = (
+		<Button
+			accessibilityLabel={
+				isBusy ? `${confirmLabel}, wird ausgeführt` : confirmLabel
+			}
+			accessibilityLiveRegion={isBusy ? "polite" : undefined}
+			accessibilityState={{ busy: isBusy, disabled: isBusy }}
+			className={actionLayout === "stacked" ? "w-full" : "flex-1"}
+			disabled={isBusy}
+			onPress={onConfirm}
+			variant={confirmTone === "destructive" ? "destructive" : "default"}
+		>
+			{isBusy ? (
+				<ActivityIndicator
+					color={
+						confirmTone === "destructive"
+							? colors.background
+							: DAYOVA_DESIGN_SYSTEM.colors.light1
+					}
+				/>
+			) : (
+				<Text>{confirmLabel}</Text>
+			)}
+		</Button>
+	);
+	const cancelButton = (
+		<Button
+			accessibilityLabel={cancelLabel}
+			className={cn(
+				"shadow-none",
+				actionLayout === "stacked" ? "w-full" : "flex-1",
+			)}
+			disabled={isBusy}
+			onPress={safeClose}
+			variant="neutral"
+		>
+			<Text>{cancelLabel}</Text>
+		</Button>
+	);
 
 	return (
 		<DayovaSheetFrame
@@ -57,39 +101,9 @@ function ConfirmationSheet({
 					description={errorMessage}
 				/>
 			) : null}
-			<View className="flex-row gap-3">
-				<Button
-					accessibilityLabel={cancelLabel}
-					className="flex-1 shadow-none"
-					disabled={isBusy}
-					onPress={safeClose}
-					variant="neutral"
-				>
-					<Text>{cancelLabel}</Text>
-				</Button>
-				<Button
-					accessibilityLabel={
-						isBusy ? `${confirmLabel}, wird ausgeführt` : confirmLabel
-					}
-					accessibilityLiveRegion={isBusy ? "polite" : undefined}
-					accessibilityState={{ busy: isBusy, disabled: isBusy }}
-					className="flex-1"
-					disabled={isBusy}
-					onPress={onConfirm}
-					variant={confirmTone === "destructive" ? "destructive" : "default"}
-				>
-					{isBusy ? (
-						<ActivityIndicator
-							color={
-								confirmTone === "destructive"
-									? colors.background
-									: DAYOVA_DESIGN_SYSTEM.colors.light1
-							}
-						/>
-					) : (
-						<Text>{confirmLabel}</Text>
-					)}
-				</Button>
+			<View className={cn("gap-3", actionLayout === "inline" && "flex-row")}>
+				{actionLayout === "stacked" ? confirmButton : cancelButton}
+				{actionLayout === "stacked" ? cancelButton : confirmButton}
 			</View>
 		</DayovaSheetFrame>
 	);

--- a/src/features/learning-plans/learning-plan-setup-origin.ts
+++ b/src/features/learning-plans/learning-plan-setup-origin.ts
@@ -1,0 +1,13 @@
+import type { Id } from "#convex/_generated/dataModel";
+import { useState } from "react";
+
+export type LearningPlanSetupOrigin = "newExam" | "resumedDraft";
+
+export function useLearningPlanSetupOrigin(
+	learningPlanId: Id<"learningPlans"> | undefined,
+): LearningPlanSetupOrigin {
+	const [origin] = useState<LearningPlanSetupOrigin>(() =>
+		learningPlanId ? "resumedDraft" : "newExam",
+	);
+	return origin;
+}

--- a/src/features/learning-plans/learning-plan-setup-origin.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-setup-origin.ui.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "@jest/globals";
+import { renderHook } from "@testing-library/react-native";
+import type { Id } from "#convex/_generated/dataModel";
+import { useLearningPlanSetupOrigin } from "./learning-plan-setup-origin";
+
+describe("useLearningPlanSetupOrigin", () => {
+	test("keeps a new-exam flow new after its draft id is added to the route", async () => {
+		const screen = await renderHook(
+			({ learningPlanId }: { learningPlanId?: Id<"learningPlans"> }) =>
+				useLearningPlanSetupOrigin(learningPlanId),
+			{ initialProps: { learningPlanId: undefined } },
+		);
+
+		expect(screen.result.current).toBe("newExam");
+
+		await screen.rerender({
+			learningPlanId: "new-draft" as Id<"learningPlans">,
+		});
+
+		expect(screen.result.current).toBe("newExam");
+	});
+
+	test("marks a draft supplied on entry as resumed", async () => {
+		const screen = await renderHook(() =>
+			useLearningPlanSetupOrigin("existing-draft" as Id<"learningPlans">),
+		);
+
+		expect(screen.result.current).toBe("resumedDraft");
+	});
+});

--- a/src/features/learning-plans/learning-plan-setup-steps.tsx
+++ b/src/features/learning-plans/learning-plan-setup-steps.tsx
@@ -191,7 +191,7 @@ export function MaterialUploadStep({
 						disabled={!canUpload}
 						onPress={onSkip}
 					>
-						<Text>Material später hochladen</Text>
+						<Text>Ohne Lernmaterial erstellen</Text>
 					</Button>
 				) : null}
 			</View>

--- a/src/features/learning-plans/learning-plan-setup-steps.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-setup-steps.ui.test.tsx
@@ -88,7 +88,7 @@ describe("learning-plan setup steps", () => {
 		expect(screen.queryByRole("button", { name: "Weiter" })).toBeNull();
 		expect(
 			screen.getByRole("button", {
-				name: "Material später hochladen",
+				name: "Ohne Lernmaterial erstellen",
 			}),
 		).toBeOnTheScreen();
 
@@ -136,7 +136,7 @@ describe("learning-plan setup steps", () => {
 		).toBeNull();
 		expect(
 			screen.queryByRole("button", {
-				name: "Material später hochladen",
+				name: "Ohne Lernmaterial erstellen",
 			}),
 		).toBeNull();
 	});
@@ -169,7 +169,7 @@ describe("learning-plan setup steps", () => {
 		expect(screen.queryByRole("button", { name: "Weiter" })).toBeNull();
 		expect(screen.queryByText("Lernhilfe.pdf")).toBeNull();
 		expect(
-			screen.getByRole("button", { name: "Material später hochladen" }),
+			screen.getByRole("button", { name: "Ohne Lernmaterial erstellen" }),
 		).toBeOnTheScreen();
 	});
 
@@ -197,7 +197,7 @@ describe("learning-plan setup steps", () => {
 			),
 		).toBeOnTheScreen();
 		expect(
-			screen.queryByRole("button", { name: "Material später hochladen" }),
+			screen.queryByRole("button", { name: "Ohne Lernmaterial erstellen" }),
 		).toBeNull();
 	});
 

--- a/src/features/learning-plans/material-required-sheet.tsx
+++ b/src/features/learning-plans/material-required-sheet.tsx
@@ -34,6 +34,7 @@ export function MaterialRequiredSheet({
 
 	return (
 		<ConfirmationSheet
+			actionLayout="stacked"
 			cancelLabel="Später"
 			closeAccessibilityLabel="Materialhinweis schließen"
 			confirmLabel="Material hochladen"

--- a/src/features/learning-plans/material-required-sheet.ui.test.tsx
+++ b/src/features/learning-plans/material-required-sheet.ui.test.tsx
@@ -9,6 +9,7 @@ jest.mock("~/components/ui/confirmation-sheet", () => {
 
 	return {
 		ConfirmationSheet: ({
+			actionLayout,
 			cancelLabel,
 			confirmLabel,
 			description,
@@ -17,6 +18,7 @@ jest.mock("~/components/ui/confirmation-sheet", () => {
 			title,
 			visible,
 		}: {
+			actionLayout?: "inline" | "stacked";
 			cancelLabel: string;
 			confirmLabel: string;
 			description: import("react").ReactNode;
@@ -28,7 +30,10 @@ jest.mock("~/components/ui/confirmation-sheet", () => {
 			visible
 				? React.createElement(
 						Native.View,
-						{ accessibilityViewIsModal: true },
+						{
+							accessibilityViewIsModal: true,
+							testID: `confirmation-actions-${actionLayout ?? "inline"}`,
+						},
 						React.createElement(Native.Text, null, title),
 						React.createElement(Native.Text, null, description),
 						React.createElement(
@@ -63,6 +68,9 @@ describe("MaterialRequiredSheet", () => {
 
 		expect(
 			screen.getByText("Für diesen Lernplan fehlt Material"),
+		).toBeOnTheScreen();
+		expect(
+			screen.getByTestId("confirmation-actions-stacked"),
 		).toBeOnTheScreen();
 		expect(
 			screen.getByText(


### PR DESCRIPTION
## Summary
- keep the setup origin stable when a new exam receives its generated draft ID
- restore the `Ohne Lernmaterial erstellen` action for the active creation flow
- continue hiding that action when an older material-missing draft is resumed
- give the missing-material sheet a clear full-width action hierarchy: `Material hochladen` first, `Später` beneath it

## Root cause
The route adds `learningPlanId` immediately after the required topics are saved. The screen derived `showSkip` from that mutable route parameter, so the newly created flow was reclassified as a resumed draft and the action was unmounted.

The missing-material sheet also forced both actions into equal half-width columns. The primary `Material hochladen` label therefore wrapped into a cramped two-line pill.

## Validation
- Node 24: `node ./node_modules/jest/bin/jest.js src/features/learning-plans/material-required-sheet.ui.test.tsx --runInBand --no-cache --forceExit` (3 passed)
- `node ./node_modules/jest/bin/jest.js src/features/learning-plans/learning-plan-setup-origin.ui.test.tsx --runInBand --no-cache --forceExit` (2 passed)
- Node 24: `pnpm typecheck`
- `pnpm lint` (passes; one unrelated pre-existing unused-import warning in `src/features/auth/dayova-auth-flow.tsx`)

## Visual inspection
The current simulator account is behind the expired-trial gate, which blocks opening the affected learning-plan sheet. The shared button tokens, full-width layout, primary-before-secondary focus order, content-size resilience, interaction contract, and dark-theme usage were inspected in code and covered by the focused UI test. The original cramped layout is documented in DAY-343.