### PR TITLE
Restore release-base validation hygiene

### DIFF
--- a/src/components/onboarding/onboarding-select.ui.test.tsx
+++ b/src/components/onboarding/onboarding-select.ui.test.tsx
@@ -73,7 +73,7 @@ describe("OnboardingSelect", () => {
 		);
 
 		const trigger = screen.getByRole("button", {
-			name: "Klassenstufe auswählen",
+			name: "Klassenstufe auswählen: 9. Klasse",
 		});
 		expect(trigger.props.accessibilityState).toEqual({ expanded: false });
 		expect(trigger.props.accessibilityValue).toEqual({ text: "9. Klasse" });

--- a/src/components/ui/success-confirmation-screen.tsx
+++ b/src/components/ui/success-confirmation-screen.tsx
@@ -95,55 +95,55 @@ function SuccessConfirmationScreen({
 	return (
 		<View className="flex-1 bg-background">
 			<PortraitContent className="flex-1 px-7">
-			<View className="items-center" style={{ paddingTop: successMarkTop }}>
-				<View className="h-36 w-36 items-center justify-center rounded-full bg-success-subtle">
-					<Check
-						size={64}
-						color={DAYOVA_DESIGN_SYSTEM.colors.success}
-						strokeWidth={2.2}
-					/>
-				</View>
+				<View className="items-center" style={{ paddingTop: successMarkTop }}>
+					<View className="h-36 w-36 items-center justify-center rounded-full bg-success-subtle">
+						<Check
+							size={64}
+							color={DAYOVA_DESIGN_SYSTEM.colors.success}
+							strokeWidth={2.2}
+						/>
+					</View>
 
-				<Text
-					accessibilityRole="header"
-					className="text-center font-poppins font-semibold text-heading-1 text-text"
-					style={{ marginTop: headlineTopMargin }}
-				>
-					{title}
-				</Text>
-
-				<View className="mt-6 items-center">
-					<Text className="text-center font-poppins text-body-2 text-text">
-						{detailLabel}
+					<Text
+						accessibilityRole="header"
+						className="text-center font-poppins font-semibold text-heading-1 text-text"
+						style={{ marginTop: headlineTopMargin }}
+					>
+						{title}
 					</Text>
-					{detailValue ? (
-						<Text
-							selectable
-							className="text-center font-poppins text-body-2 text-secondary-text"
-						>
-							{detailValue}
+
+					<View className="mt-6 items-center">
+						<Text className="text-center font-poppins text-body-2 text-text">
+							{detailLabel}
+						</Text>
+						{detailValue ? (
+							<Text
+								selectable
+								className="text-center font-poppins text-body-2 text-secondary-text"
+							>
+								{detailValue}
+							</Text>
+						) : null}
+					</View>
+					{description ? (
+						<Text className="mt-5 max-w-[320px] text-center font-poppins text-body-3 text-secondary-text">
+							{description}
 						</Text>
 					) : null}
 				</View>
-				{description ? (
-					<Text className="mt-5 max-w-[320px] text-center font-poppins text-body-3 text-secondary-text">
-						{description}
-					</Text>
-				) : null}
-			</View>
 
-			<View
-				className="absolute right-0 bottom-0 left-0 px-7"
-				style={{ paddingBottom: buttonBottomPadding }}
-			>
-				<Button
-					accessibilityLabel="Fertig"
-					className="w-full"
-					onPress={onFinish}
+				<View
+					className="absolute right-0 bottom-0 left-0 px-7"
+					style={{ paddingBottom: buttonBottomPadding }}
 				>
-					<Text>Fertig</Text>
-				</Button>
-			</View>
+					<Button
+						accessibilityLabel="Fertig"
+						className="w-full"
+						onPress={onFinish}
+					>
+						<Text>Fertig</Text>
+					</Button>
+				</View>
 			</PortraitContent>
 		</View>
 	);

--- a/src/features/learning-plans/learning-plan-setup-steps.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-setup-steps.ui.test.tsx
@@ -95,7 +95,7 @@ describe("learning-plan setup steps", () => {
 		await fireEvent.press(
 			screen.getByRole("button", { name: "Schulmaterial hinzufügen" }),
 		);
-		expect(onOpenUpload).toHaveBeenCalledWith();
+		expect(onOpenUpload).toHaveBeenCalledTimes(1);
 	});
 
 	test("reveals continue after school material is uploaded", async () => {


### PR DESCRIPTION
## Outcome

Restores deterministic validation on the current `production-app-release` base without changing product behavior:

- updates the Learning Plan assertion to accept React Native press-event forwarding;
- queries the onboarding select trigger by its intentional label-plus-selected-value accessibility name;
- applies the repository formatter to the pre-existing success confirmation screen.

## Validation

- Targeted Jest: 2 suites / 7 tests pass
- Biome lint/format: pass for the changed tests
- `git diff --check`: pass

This is intentionally separate from onboarding PR #458 so base validation hygiene is not mixed into that product diff.