### PR TITLE
Replace exam date carousel with native calendar

### DIFF
--- a/src/app/(creation)/entry/new.tsx
+++ b/src/app/(creation)/entry/new.tsx
@@ -69,6 +69,7 @@ import { getErrorMessage } from "~/features/learning-plans/utils";
 import { createAsyncActionGate } from "~/lib/async-action-gate";
 import { getDayKey, parseDayKey, startOfLocalDay } from "~/lib/day-key";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
+import { getExamDatePickerRange } from "~/lib/exam-date";
 import { EXAM_TYPE_OPTIONS } from "~/lib/entry-options";
 import {
 	constrainEndTimeForStart,
@@ -782,12 +783,19 @@ export default function NewEntryScreen() {
 					: pickerTarget === "plannedEndTime"
 						? plannedEndTime
 						: plannedDate;
+		const isExamDatePicker = !isHomework && pickerTarget === "plannedDate";
+		const examDateRange = isExamDatePicker
+			? getExamDatePickerRange({ selectedDate: plannedDate })
+			: null;
 
 		return (
 			<DateTimePickerSheet
+				display={isExamDatePicker ? "inline" : undefined}
 				visible
 				value={value}
 				mode={mode}
+				minimumDate={examDateRange?.minimumDate}
+				maximumDate={examDateRange?.maximumDate}
 				onChange={handlePickerChange}
 				onClose={closePicker}
 			/>
@@ -972,7 +980,7 @@ export default function NewEntryScreen() {
 							{step === "basics" ? (
 								<ExamDateSelector
 									selectedDate={plannedDate}
-									onSelect={setPlannedDate}
+									onOpen={() => openPicker("plannedDate")}
 								/>
 							) : step === "learningAvailability" ? (
 								<LearningAvailabilityStep

--- a/src/components/entry/exam-flow.tsx
+++ b/src/components/entry/exam-flow.tsx
@@ -6,23 +6,23 @@ import Animated, {
 } from "react-native-reanimated";
 import {
 	Computer,
+	CalendarDays,
+	ChevronDown,
 	GraduationCap,
 	Mic,
 	NotebookPen,
 	Pencil,
 	Plus,
 } from "~/components/ui/icon";
-import { Input } from "~/components/ui/input";
-import { SnapCarouselSelector } from "~/components/ui/snap-carousel-selector";
-import { Text } from "~/components/ui/text";
-import { getDayKey } from "~/lib/day-key";
 import {
-	buildExamDateOptions,
-	findExamDateIndex,
-	formatAccessibleExamDate,
-	formatExamDateDay,
-	formatExamDateMonth,
-} from "~/lib/exam-date";
+	Field,
+	FieldAccessory,
+	FieldLabel,
+	FieldTrigger,
+} from "~/components/ui/field";
+import { Input } from "~/components/ui/input";
+import { Text } from "~/components/ui/text";
+import { formatAccessibleExamDate } from "~/lib/exam-date";
 import { useDayovaTheme } from "~/lib/theme";
 import { cn } from "~/lib/utils";
 
@@ -193,40 +193,44 @@ function RadioIndicator({
 
 function ExamDateSelector({
 	selectedDate,
-	onSelect,
+	onOpen,
 }: {
 	selectedDate: Date;
-	onSelect: (date: Date) => void;
+	onOpen: () => void;
 }) {
-	const [dateOptions] = useState(() => buildExamDateOptions({ selectedDate }));
-	const selectedIndex = findExamDateIndex(dateOptions, selectedDate);
+	const { colors } = useDayovaTheme();
+	const selectedDateLabel = formatAccessibleExamDate(selectedDate);
 
 	return (
-		<View className="mt-6 w-full items-center">
-			<View className="mb-3 flex-row items-baseline justify-center gap-2">
+		<Field className="mt-6 mb-0">
+			<FieldLabel>Prüfungsdatum</FieldLabel>
+			<FieldTrigger
+				accessibilityLabel="Prüfungsdatum ändern"
+				accessibilityRole="button"
+				accessibilityValue={{ text: selectedDateLabel }}
+				onPress={onOpen}
+			>
+				<View className="mr-4 h-9 w-9 items-center justify-center rounded-full bg-accent">
+					<CalendarDays size={20} color={colors.primary} strokeWidth={2.1} />
+				</View>
 				<Text
-					className="font-poppins font-semibold text-display-counter text-text"
-					// The day number is a counter, so tabular figures avoid width jumps.
-					style={{ fontVariant: ["tabular-nums"] }}
+					className="flex-1 font-poppins font-semibold text-body-2 text-text"
+					numberOfLines={2}
 				>
-					{formatExamDateDay(selectedDate)}
+					{selectedDateLabel}
 				</Text>
-				<Text className="font-poppins font-semibold text-heading-2 text-primary">
-					{formatExamDateMonth(selectedDate)}
-				</Text>
-			</View>
-			<SnapCarouselSelector
-				accessibilityLabel="Prüfungstag auswählen"
-				accessibilityValue={formatAccessibleExamDate(selectedDate)}
-				decrementLabel="Vorheriger Tag"
-				getItemKey={getDayKey}
-				incrementLabel="Nächster Tag"
-				items={dateOptions}
-				onSelect={onSelect}
-				selectedIndex={selectedIndex}
-				showValueBubble={false}
-			/>
-		</View>
+				<FieldAccessory>
+					<ChevronDown
+						size={20}
+						color={colors.secondaryText}
+						strokeWidth={2.1}
+					/>
+				</FieldAccessory>
+			</FieldTrigger>
+			<Text className="mt-2 ml-1 font-poppins text-body-4 text-secondary-text">
+				Im Kalender auswählen
+			</Text>
+		</Field>
 	);
 }
 

--- a/src/components/entry/exam-flow.ui.test.tsx
+++ b/src/components/entry/exam-flow.ui.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { fireEvent, render } from "@testing-library/react-native";
+import { ExamDateSelector } from "./exam-flow";
+
+jest.mock("react-native-reanimated", () => {
+	const ReactNative =
+		jest.requireActual<typeof import("react-native")>("react-native");
+	const animationBuilder = {
+		duration: () => animationBuilder,
+	};
+
+	return {
+		__esModule: true,
+		default: { View: ReactNative.View },
+		FadeInDown: animationBuilder,
+		LinearTransition: animationBuilder,
+	};
+});
+
+jest.mock("~/components/ui/icon", () => {
+	const React = jest.requireActual<typeof import("react")>("react");
+	const Icon = (props: Record<string, unknown>) =>
+		React.createElement("Icon", props);
+
+	return {
+		CalendarDays: Icon,
+		ChevronDown: Icon,
+		Computer: Icon,
+		GraduationCap: Icon,
+		Mic: Icon,
+		NotebookPen: Icon,
+		Pencil: Icon,
+		Plus: Icon,
+	};
+});
+
+jest.mock("~/lib/theme", () => ({
+	useDayovaTheme: () => ({
+		colors: { primary: "#00BAFF", secondaryText: "#697586" },
+	}),
+}));
+
+describe("ExamDateSelector", () => {
+	test("presents the selected date as an accessible calendar trigger", async () => {
+		const onOpen = jest.fn();
+		const screen = await render(
+			<ExamDateSelector selectedDate={new Date(2026, 7, 14)} onOpen={onOpen} />,
+		);
+
+		const trigger = screen.getByRole("button", {
+			name: "Prüfungsdatum ändern",
+		});
+		expect(trigger.props.accessibilityRole).toBe("button");
+		expect(trigger.props.accessibilityValue).toEqual({
+			text: "14. August 2026",
+		});
+		expect(screen.getByText("Im Kalender auswählen")).toBeOnTheScreen();
+
+		fireEvent.press(trigger);
+
+		expect(onOpen).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/components/ui/date-time-picker-sheet.android.ui.test.tsx
+++ b/src/components/ui/date-time-picker-sheet.android.ui.test.tsx
@@ -65,6 +65,28 @@ describe("Android DateTimePickerSheet", () => {
 		expect(onClose).toHaveBeenCalledTimes(1);
 	});
 
+	test("keeps calendar display and selectable date bounds", async () => {
+		const minimumDate = new Date(2026, 7, 14);
+		const maximumDate = new Date(2027, 7, 14);
+		const screen = await render(
+			<DateTimePickerSheet
+				display="inline"
+				maximumDate={maximumDate}
+				minimumDate={minimumDate}
+				mode="date"
+				onChange={jest.fn()}
+				onClose={jest.fn()}
+				value={minimumDate}
+				visible
+			/>,
+		);
+
+		expect(screen.getByTestId("date-picker-dialog").props).toMatchObject({
+			selectableDates: { start: minimumDate, end: maximumDate },
+			variant: "picker",
+		});
+	});
+
 	test("continues a datetime selection from date to time before closing", async () => {
 		const onChange = jest.fn();
 		const onClose = jest.fn();

--- a/src/components/ui/date-time-picker-sheet.tsx
+++ b/src/components/ui/date-time-picker-sheet.tsx
@@ -32,6 +32,13 @@ function DateTimePickerSheet({
 	onClose,
 }: DateTimePickerSheetProps) {
 	const { width } = useWindowDimensions();
+	const normalizedDisplay = normalizeIosDisplay(display);
+	const pickerHeight =
+		mode === "date" && normalizedDisplay === "inline"
+			? 340
+			: mode === "datetime"
+				? 260
+				: 216;
 	const accessibilityLabel = {
 		date: "Datum auswählen",
 		time: "Uhrzeit auswählen",
@@ -59,7 +66,7 @@ function DateTimePickerSheet({
 					accentColor={DAYOVA_PRIMARY}
 					value={value}
 					mode={mode}
-					display={normalizeIosDisplay(display)}
+					display={normalizedDisplay}
 					maximumDate={maximumDate}
 					minimumDate={minimumDate}
 					locale="de-DE"
@@ -67,7 +74,7 @@ function DateTimePickerSheet({
 					// Expo's native picker needs explicit measured dimensions.
 					style={{
 						width: Math.min(width, 560) - 48,
-						height: mode === "datetime" ? 260 : 216,
+						height: pickerHeight,
 					}}
 				/>
 			</View>

--- a/src/lib/exam-date.test.ts
+++ b/src/lib/exam-date.test.ts
@@ -1,63 +1,44 @@
 import { describe, expect, test } from "vitest";
 import { getDayKey } from "./day-key";
-import {
-	buildExamDateOptions,
-	findExamDateIndex,
-	formatExamDateDay,
-	formatExamDateMonth,
-} from "./exam-date";
+import { formatAccessibleExamDate, getExamDatePickerRange } from "./exam-date";
 
-describe("exam date slider", () => {
-	test("builds consecutive local calendar days starting today", () => {
-		const options = buildExamDateOptions({
+describe("exam date picker", () => {
+	test("starts today and keeps the configured future range", () => {
+		const range = getExamDatePickerRange({
 			selectedDate: new Date(2026, 6, 8),
 			today: new Date(2026, 6, 5, 22, 30),
 			futureDays: 3,
 		});
 
-		expect(options.map(getDayKey)).toEqual([
-			"2026-07-05",
-			"2026-07-06",
-			"2026-07-07",
-			"2026-07-08",
-		]);
-		expect(findExamDateIndex(options, new Date(2026, 6, 7))).toBe(2);
+		expect(getDayKey(range.minimumDate)).toBe("2026-07-05");
+		expect(getDayKey(range.maximumDate)).toBe("2026-07-08");
 	});
 
 	test("keeps an existing past selection reachable", () => {
-		const options = buildExamDateOptions({
+		const range = getExamDatePickerRange({
 			selectedDate: new Date(2026, 6, 2),
 			today: new Date(2026, 6, 5),
 			futureDays: 3,
 		});
 
-		expect(options.slice(0, 4).map(getDayKey)).toEqual([
-			"2026-07-02",
-			"2026-07-03",
-			"2026-07-04",
-			"2026-07-05",
-		]);
-		expect(options.map(getDayKey).at(-1)).toBe("2026-07-08");
+		expect(getDayKey(range.minimumDate)).toBe("2026-07-02");
+		expect(getDayKey(range.maximumDate)).toBe("2026-07-08");
 	});
 
 	test("keeps a selection beyond the default future range reachable", () => {
-		const options = buildExamDateOptions({
+		const range = getExamDatePickerRange({
 			selectedDate: new Date(2027, 6, 8),
 			today: new Date(2026, 6, 5),
 			futureDays: 3,
 		});
 
-		expect(options.map(getDayKey).at(0)).toBe("2026-07-05");
-		expect(options.map(getDayKey).at(-1)).toBe("2027-07-08");
-		expect(findExamDateIndex(options, new Date(2027, 6, 8))).toBe(
-			options.length - 1,
-		);
+		expect(getDayKey(range.minimumDate)).toBe("2026-07-05");
+		expect(getDayKey(range.maximumDate)).toBe("2027-07-08");
 	});
 
-	test("formats the selected date for the circular display", () => {
+	test("formats the selected date for the field and accessibility value", () => {
 		const date = new Date(2026, 6, 5);
 
-		expect(formatExamDateDay(date)).toBe("5");
-		expect(formatExamDateMonth(date)).toBe("Juli");
+		expect(formatAccessibleExamDate(date)).toBe("5. Juli 2026");
 	});
 });

--- a/src/lib/exam-date.ts
+++ b/src/lib/exam-date.ts
@@ -1,10 +1,6 @@
-import { addDays, getDayKey, startOfLocalDay } from "./day-key";
+import { addDays, startOfLocalDay } from "./day-key";
 
 const DEFAULT_EXAM_DATE_FUTURE_DAYS = 365;
-
-const germanMonthFormatter = new Intl.DateTimeFormat("de-DE", {
-	month: "long",
-});
 
 const germanAccessibleDateFormatter = new Intl.DateTimeFormat("de-DE", {
 	day: "numeric",
@@ -12,7 +8,7 @@ const germanAccessibleDateFormatter = new Intl.DateTimeFormat("de-DE", {
 	year: "numeric",
 });
 
-function buildExamDateOptions({
+function getExamDatePickerRange({
 	selectedDate,
 	today = new Date(),
 	futureDays = DEFAULT_EXAM_DATE_FUTURE_DAYS,
@@ -32,41 +28,11 @@ function buildExamDateOptions({
 		localSelectedDate.getTime() > defaultRangeEnd.getTime()
 			? localSelectedDate
 			: defaultRangeEnd;
-	const options: Date[] = [];
-
-	for (
-		let date = rangeStart;
-		date.getTime() <= rangeEnd.getTime();
-		date = addDays(date, 1)
-	) {
-		options.push(date);
-	}
-
-	return options;
-}
-
-function findExamDateIndex(options: readonly Date[], selectedDate: Date) {
-	const selectedDayKey = getDayKey(selectedDate);
-	const index = options.findIndex((date) => getDayKey(date) === selectedDayKey);
-	return index < 0 ? 0 : index;
-}
-
-function formatExamDateDay(date: Date) {
-	return `${date.getDate()}`;
-}
-
-function formatExamDateMonth(date: Date) {
-	return germanMonthFormatter.format(date);
+	return { minimumDate: rangeStart, maximumDate: rangeEnd };
 }
 
 function formatAccessibleExamDate(date: Date) {
 	return germanAccessibleDateFormatter.format(date);
 }
 
-export {
-	buildExamDateOptions,
-	findExamDateIndex,
-	formatAccessibleExamDate,
-	formatExamDateDay,
-	formatExamDateMonth,
-};
+export { getExamDatePickerRange, formatAccessibleExamDate };


### PR DESCRIPTION
## Summary
- replace the exam day carousel with an accessible Dayova date field
- open the shared native picker as an inline month calendar on iOS and a Material calendar dialog on Android
- preserve the existing today-to-one-year selection range while keeping restored out-of-range selections reachable
- add focused unit and UI coverage

Linear: [DAY-354](https://linear.app/dayova/issue/DAY-354/replace-the-exam-date-carousel-with-a-calendar-picker)

## Verification
- `pnpm typecheck`
- `pnpm lint` (passes; reports one pre-existing unused-import warning in `dayova-auth-flow.tsx`)
- 614 unit tests pass
- focused exam-calendar and Android date-picker UI suites pass
- Computer Use on iPhone 17 simulator in dark mode: opened August 2026 calendar, confirmed pre-today dates disabled, selected 21 August, closed the sheet, and observed `21. August 2026` retained in the field

## Known baseline failures
- repository format check is blocked by pre-existing formatting in `success-confirmation-screen.tsx`
- full UI run: 35/38 suites pass; three unrelated baseline failures remain in learning-plan setup, login/onboarding, and onboarding select