### PR TITLE
Add minimal horizontally paged timetable editor

### DIFF
--- a/src/app/timetable/index.tsx
+++ b/src/app/timetable/index.tsx
@@ -2,7 +2,6 @@ import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
 import { fetch } from "expo/fetch";
 import * as DocumentPicker from "expo-document-picker";
 import { File } from "expo-file-system";
-import * as Haptics from "expo-haptics";
 import * as ImagePicker from "expo-image-picker";
 import { useRouter } from "expo-router";
 import { useMemo, useRef, useState } from "react";
@@ -46,6 +45,8 @@ import {
 	type TimetableLessonDraft,
 } from "~/features/timetable/timetable-editor";
 import { TimetableWeekEditor } from "~/features/timetable/timetable-week-editor";
+import { ROUTES } from "~/lib/routes";
+import { triggerSuccessHaptic } from "~/lib/safe-haptics";
 import { useDayovaTheme } from "~/lib/theme";
 import { validateUploadFile } from "~/lib/upload-policy";
 import { getUserFacingErrorMessage } from "~/lib/user-facing-errors";
@@ -461,7 +462,8 @@ export default function TimetableScreen() {
 				})),
 			});
 			setEditor(null);
-			await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+			router.replace(ROUTES.home);
+			void triggerSuccessHaptic({ platform: Platform.OS });
 		});
 	};
 

--- a/src/app/timetable/index.tsx
+++ b/src/app/timetable/index.tsx
@@ -9,8 +9,6 @@ import { useMemo, useRef, useState } from "react";
 import {
 	ActivityIndicator,
 	Platform,
-	Pressable,
-	type TextStyle,
 	type ViewStyle,
 	View,
 } from "react-native";
@@ -26,12 +24,10 @@ import {
 	Attachment,
 	CalendarDays,
 	Check,
-	Clock3,
 	ScanImage,
-	Trash2,
 } from "~/components/ui/icon";
-import { Input } from "~/components/ui/input";
 import { Screen, ScreenScroll } from "~/components/ui/screen";
+import { SelectSheet } from "~/components/ui/select-sheet";
 import { Text } from "~/components/ui/text";
 import { ThemedStatusBar } from "~/components/ui/themed-status-bar";
 import { useAuthSession } from "~/context/AuthContext";
@@ -44,6 +40,7 @@ import {
 	TIMETABLE_WEEKDAYS,
 	type TimetableLessonDraft,
 } from "~/features/timetable/timetable-editor";
+import { TimetableWeekEditor } from "~/features/timetable/timetable-week-editor";
 import { useDayovaTheme } from "~/lib/theme";
 import { validateUploadFile } from "~/lib/upload-policy";
 import { getUserFacingErrorMessage } from "~/lib/user-facing-errors";
@@ -57,14 +54,12 @@ const TIMETABLE_FILE_TYPES = [
 const UPLOAD_TIMEOUT_MS = 45_000;
 const UPLOAD_COMPLETION_FAILURE_MESSAGE =
 	"Die Datei wurde übertragen, aber Dayova konnte den Upload nicht abschließen. Bitte versuche es erneut.";
+const TIMETABLE_WEEKDAY_VALUES = TIMETABLE_WEEKDAYS.map((day) => day.value);
 
-// These are native rendering controls with no NativeWind equivalent.
+// This is a native rendering control with no NativeWind equivalent.
 const continuousBorderStyle = {
 	borderCurve: "continuous",
 } satisfies ViewStyle;
-const tabularNumberStyle = {
-	fontVariant: ["tabular-nums"],
-} satisfies TextStyle;
 
 type TimePickerTarget = {
 	lessonKey: string;
@@ -175,134 +170,42 @@ function TimetableStatus({
 	return null;
 }
 
-function TimeButton({
-	label,
-	value,
-	onPress,
+function TimetableSourceActions({
+	isBusy,
+	isProcessing,
+	onPickFile,
+	onTakePhoto,
 }: {
-	label: string;
-	value: string;
-	onPress: () => void;
+	isBusy: boolean;
+	isProcessing: boolean;
+	onPickFile: () => void;
+	onTakePhoto: () => void;
 }) {
 	const { colors } = useDayovaTheme();
+
 	return (
-		<View className="flex-1">
-			<Text className="mb-1 font-poppins text-body-5 text-secondary-text">
-				{label}
-			</Text>
-			<Pressable
-				accessibilityLabel={`${label}: ${value}`}
-				accessibilityRole="button"
-				className="h-12 flex-row items-center justify-between rounded-2xl bg-muted px-4 active:opacity-75"
-				onPress={onPress}
+		<View className="flex-row gap-3">
+			<Button
+				accessibilityLabel="Stundenplan als Datei auswählen"
+				className="flex-1 px-4"
+				size="sm"
+				disabled={isBusy || isProcessing}
+				onPress={onPickFile}
 			>
-				<Text
-					className="font-poppins font-semibold text-body-3 text-text"
-					style={tabularNumberStyle}
-				>
-					{value}
-				</Text>
-				<Clock3 size={17} color={colors.secondaryText} strokeWidth={2} />
-			</Pressable>
-		</View>
-	);
-}
-
-function LessonEditorCard({
-	lesson,
-	onChange,
-	onRemove,
-	onOpenTime,
-}: {
-	lesson: TimetableLessonDraft;
-	onChange: (patch: Partial<TimetableLessonDraft>) => void;
-	onRemove: () => void;
-	onOpenTime: (field: "startTime" | "endTime") => void;
-}) {
-	const { colors } = useDayovaTheme();
-
-	return (
-		<View
-			className="rounded-card border border-border bg-card p-5"
-			style={continuousBorderStyle}
-		>
-			<View className="flex-row items-center justify-between">
-				<Text className="font-poppins font-semibold text-body-3 text-text">
-					Unterrichtsstunde
-				</Text>
-				<Pressable
-					accessibilityLabel={`${lesson.subject || "Leere Stunde"} entfernen`}
-					accessibilityRole="button"
-					hitSlop={8}
-					className="h-11 w-11 items-center justify-center rounded-full bg-muted active:opacity-75"
-					onPress={onRemove}
-				>
-					<Trash2 size={18} color={colors.wrong} strokeWidth={2} />
-				</Pressable>
-			</View>
-
-			<View className="mt-4 flex-row flex-wrap gap-2">
-				{TIMETABLE_WEEKDAYS.map((day) => {
-					const selected = lesson.dayOfWeek === day.value;
-					return (
-						<Pressable
-							key={day.value}
-							accessibilityLabel={day.label}
-							accessibilityRole="radio"
-							accessibilityState={{ checked: selected }}
-							className={
-								selected
-									? "h-11 min-w-11 items-center justify-center rounded-full bg-primary px-3"
-									: "h-11 min-w-11 items-center justify-center rounded-full bg-muted px-3"
-							}
-							onPress={() => onChange({ dayOfWeek: day.value })}
-						>
-							<Text
-								className={
-									selected
-										? "font-poppins font-semibold text-body-4 text-white"
-										: "font-poppins font-semibold text-body-4 text-secondary-text"
-								}
-							>
-								{day.shortLabel}
-							</Text>
-						</Pressable>
-					);
-				})}
-			</View>
-
-			<View className="mt-4 h-14 justify-center rounded-2xl bg-muted px-4">
-				<Input
-					accessibilityLabel="Unterrichtsfach"
-					autoCapitalize="words"
-					maxLength={80}
-					placeholder="Fach, z. B. Mathematik"
-					value={lesson.subject}
-					onChangeText={(subject) => onChange({ subject })}
-				/>
-			</View>
-			<View className="mt-3 h-14 justify-center rounded-2xl bg-muted px-4">
-				<Input
-					accessibilityLabel="Raum, optional"
-					autoCapitalize="characters"
-					maxLength={40}
-					placeholder="Raum (optional)"
-					value={lesson.room}
-					onChangeText={(room) => onChange({ room })}
-				/>
-			</View>
-			<View className="mt-4 flex-row gap-3">
-				<TimeButton
-					label="Beginn"
-					value={lesson.startTime}
-					onPress={() => onOpenTime("startTime")}
-				/>
-				<TimeButton
-					label="Ende"
-					value={lesson.endTime}
-					onPress={() => onOpenTime("endTime")}
-				/>
-			</View>
+				<Attachment size={19} color="#FFFFFF" strokeWidth={2} />
+				<Text>Datei</Text>
+			</Button>
+			<Button
+				accessibilityLabel="Stundenplan fotografieren"
+				className="flex-1 px-4"
+				size="sm"
+				variant="neutral"
+				disabled={isBusy || isProcessing}
+				onPress={onTakePhoto}
+			>
+				<ScanImage size={19} color={colors.background} strokeWidth={2} />
+				<Text>Foto</Text>
+			</Button>
 		</View>
 	);
 }
@@ -310,7 +213,6 @@ function LessonEditorCard({
 export default function TimetableScreen() {
 	const router = useRouter();
 	const { user } = useAuthSession();
-	const { colors } = useDayovaTheme();
 	const { isAuthenticated } = useConvexAuth();
 	const timetableState = useQuery(
 		api.timetables.getMine,
@@ -330,6 +232,10 @@ export default function TimetableScreen() {
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [timePickerTarget, setTimePickerTarget] =
 		useState<TimePickerTarget | null>(null);
+	const [dayPickerLessonKey, setDayPickerLessonKey] = useState<string | null>(
+		null,
+	);
+	const [selectedDay, setSelectedDay] = useState(1);
 	const taskInFlightRef = useRef(false);
 	const manualLessonKeyRef = useRef(0);
 
@@ -369,6 +275,17 @@ export default function TimetableScreen() {
 			lessons: update(current),
 		});
 	};
+	const updateLesson = (
+		lessonKey: string,
+		patch: Partial<TimetableLessonDraft>,
+	) => {
+		if (!selectedTimetable) return;
+		updateLessons(selectedTimetable.id, (current) =>
+			current.map((lesson) =>
+				lesson.key === lessonKey ? { ...lesson, ...patch } : lesson,
+			),
+		);
+	};
 
 	const ensureDraft = async () => {
 		if (
@@ -400,7 +317,7 @@ export default function TimetableScreen() {
 		}
 	};
 
-	const addManualLesson = () => {
+	const addManualLesson = (dayOfWeek = selectedDay) => {
 		void runTask(async () => {
 			const timetableId = selectedTimetable?.id ?? (await ensureDraft());
 			manualLessonKeyRef.current += 1;
@@ -410,7 +327,10 @@ export default function TimetableScreen() {
 				timetableId,
 				lessons: [
 					...currentLessons,
-					createEmptyTimetableLesson(`manual-${manualLessonKeyRef.current}`),
+					createEmptyTimetableLesson(
+						`manual-${manualLessonKeyRef.current}`,
+						dayOfWeek,
+					),
 				],
 			});
 		});
@@ -543,6 +463,18 @@ export default function TimetableScreen() {
 		activePickerLesson && timePickerTarget
 			? activePickerLesson[timePickerTarget.field]
 			: "08:00";
+	const activeDayPickerLesson = dayPickerLessonKey
+		? lessons.find((lesson) => lesson.key === dayPickerLessonKey)
+		: null;
+	const isAddDisabled =
+		!isAuthenticated ||
+		isBusy ||
+		isProcessing ||
+		lessons.length >= MAX_TIMETABLE_LESSONS;
+	const saveAccessibilityLabel =
+		selectedTimetable?.status === "active"
+			? "Änderungen am Stundenplan speichern"
+			: "Stundenplan übernehmen";
 
 	const updateTime = (event: DateTimePickerEvent, selectedDate?: Date) => {
 		if (
@@ -568,9 +500,29 @@ export default function TimetableScreen() {
 		<Screen>
 			<ThemedStatusBar />
 			<ScreenScroll topPadding={64} bottomPadding={120} horizontalPadding={24}>
-				<ScreenHeader title="Stundenplan" onBack={() => router.back()} />
+				<ScreenHeader
+					title="Stundenplan"
+					onBack={() => router.back()}
+					right={
+						lessons.length > 0 ? (
+							<Button
+								accessibilityLabel={saveAccessibilityLabel}
+								accessibilityHint="Prüft und aktiviert den gesamten Stundenplan."
+								accessibilityState={{ busy: isBusy }}
+								disabled={!canSave}
+								size="icon"
+								onPress={save}
+							>
+								{isBusy ? (
+									<ActivityIndicator color="#FFFFFF" />
+								) : (
+									<Check size={20} color="#FFFFFF" strokeWidth={2.4} />
+								)}
+							</Button>
+						) : undefined
+					}
+				/>
 				<View className="gap-5">
-					<TimetableIntro />
 					{selectedTimetable ? (
 						<TimetableStatus
 							status={selectedTimetable.status}
@@ -588,109 +540,84 @@ export default function TimetableScreen() {
 						</View>
 					) : null}
 
-					<View className="flex-row gap-3">
-						<Button
-							accessibilityLabel="Stundenplan als Datei auswählen"
-							className="flex-1 px-4"
-							size="sm"
-							disabled={isBusy || isProcessing}
-							onPress={pickFile}
-						>
-							<Attachment size={19} color="#FFFFFF" strokeWidth={2} />
-							<Text>Datei</Text>
-						</Button>
-						<Button
-							accessibilityLabel="Stundenplan fotografieren"
-							className="flex-1 px-4"
-							size="sm"
-							variant="neutral"
-							disabled={isBusy || isProcessing}
-							onPress={takePhoto}
-						>
-							<ScanImage size={19} color={colors.background} strokeWidth={2} />
-							<Text>Foto</Text>
-						</Button>
-					</View>
-
-					{lessons.length > 0 ? (
-						<View className="pt-3">
-							<Text className="font-poppins font-semibold text-heading-2 text-text">
-								Stunden prüfen
-							</Text>
-							<Text className="mt-1 font-poppins text-body-4 text-secondary-text">
-								Kontrolliere Fach, Wochentag und Uhrzeit. Erst danach wird der
-								Stundenplan aktiv.
-							</Text>
-						</View>
-					) : null}
-
-					{sortTimetableLessons(lessons).map((lesson) => (
-						<LessonEditorCard
-							key={lesson.key}
-							lesson={lesson}
-							onChange={(patch) => {
-								if (!selectedTimetable) return;
-								updateLessons(selectedTimetable.id, (current) =>
-									current.map((item) =>
-										item.key === lesson.key ? { ...item, ...patch } : item,
-									),
-								);
-							}}
-							onRemove={() => {
-								if (!selectedTimetable) return;
-								updateLessons(selectedTimetable.id, (current) =>
-									current.filter((item) => item.key !== lesson.key),
-								);
-							}}
-							onOpenTime={(field) =>
-								setTimePickerTarget({ lessonKey: lesson.key, field })
-							}
-						/>
-					))}
-
-					<Button
-						accessibilityLabel={
-							lessons.length > 0
-								? "Weitere Unterrichtsstunde hinzufügen"
-								: "Unterrichtsstunde manuell hinzufügen"
-						}
-						disabled={
-							!isAuthenticated ||
-							isBusy ||
-							isProcessing ||
-							lessons.length >= MAX_TIMETABLE_LESSONS
-						}
-						size="sm"
-						variant="outline"
-						onPress={addManualLesson}
-					>
-						<Text>
-							{lessons.length > 0
-								? "Weitere Stunde hinzufügen"
-								: "Stunde manuell hinzufügen"}
-						</Text>
-					</Button>
-
-					{lessons.length > 0 ? (
-						<View>
-							<Button disabled={!canSave} onPress={save}>
-								{isBusy ? (
-									<ActivityIndicator color="#FFFFFF" />
-								) : (
-									<Text>
-										{selectedTimetable?.status === "active"
-											? "Änderungen speichern"
-											: "Stundenplan übernehmen"}
-									</Text>
-								)}
+					{lessons.length === 0 ? (
+						<>
+							<TimetableIntro />
+							<TimetableSourceActions
+								isBusy={isBusy}
+								isProcessing={isProcessing}
+								onPickFile={pickFile}
+								onTakePhoto={takePhoto}
+							/>
+							<Button
+								accessibilityLabel="Unterrichtsstunde manuell hinzufügen"
+								disabled={isAddDisabled}
+								size="sm"
+								variant="outline"
+								onPress={() => addManualLesson(selectedDay)}
+							>
+								<Text>Stunde manuell hinzufügen</Text>
 							</Button>
-							{validationError ? (
-								<Text className="mt-3 text-center font-poppins text-body-4 text-secondary-text">
-									{validationError}
+						</>
+					) : (
+						<>
+							<View>
+								<Text className="font-poppins font-semibold text-heading-2 text-text">
+									Stunden prüfen
 								</Text>
+								<Text className="mt-1 font-poppins text-body-4 text-secondary-text">
+									Prüfe jeden Wochentag und bestätige den gesamten Stundenplan
+									oben mit dem Haken.
+								</Text>
+							</View>
+
+							{validationError ? (
+								<View
+									accessibilityLiveRegion="polite"
+									accessibilityRole="alert"
+									className="rounded-3xl bg-wrong-subtle px-5 py-4"
+								>
+									<Text className="font-poppins text-body-4 text-text">
+										{validationError}
+									</Text>
+								</View>
 							) : null}
-						</View>
-					) : null}
+
+							<TimetableWeekEditor
+								lessons={lessons}
+								selectedDay={selectedDay}
+								isAddDisabled={isAddDisabled}
+								onSelectedDayChange={setSelectedDay}
+								onAddLesson={addManualLesson}
+								onChangeLesson={updateLesson}
+								onRemoveLesson={(lessonKey) => {
+									if (!selectedTimetable) return;
+									updateLessons(selectedTimetable.id, (current) =>
+										current.filter((lesson) => lesson.key !== lessonKey),
+									);
+								}}
+								onOpenTime={(lessonKey, field) =>
+									setTimePickerTarget({ lessonKey, field })
+								}
+								onOpenDayPicker={setDayPickerLessonKey}
+							/>
+
+							<View className="border-border border-t pt-5">
+								<Text className="font-poppins font-semibold text-body-3 text-text">
+									Stundenplan neu einlesen
+								</Text>
+								<Text className="mt-1 mb-4 font-poppins text-body-4 text-secondary-text">
+									Ersetze die aktuellen Stunden durch ein neues Bild oder PDF.
+								</Text>
+								<TimetableSourceActions
+									isBusy={isBusy}
+									isProcessing={isProcessing}
+									onPickFile={pickFile}
+									onTakePhoto={takePhoto}
+								/>
+							</View>
+						</>
+					)}
 				</View>
 			</ScreenScroll>
 
@@ -701,6 +628,23 @@ export default function TimetableScreen() {
 				display="spinner"
 				onChange={updateTime}
 				onClose={() => setTimePickerTarget(null)}
+			/>
+
+			<SelectSheet
+				visible={Boolean(activeDayPickerLesson)}
+				title="Wochentag ändern"
+				options={TIMETABLE_WEEKDAY_VALUES}
+				selectedValue={activeDayPickerLesson?.dayOfWeek ?? ""}
+				formatOptionLabel={(value) =>
+					TIMETABLE_WEEKDAYS.find((day) => day.value === value)?.label ??
+					String(value)
+				}
+				onSelect={(dayOfWeek) => {
+					if (!activeDayPickerLesson) return;
+					updateLesson(activeDayPickerLesson.key, { dayOfWeek });
+					setSelectedDay(dayOfWeek);
+				}}
+				onClose={() => setDayPickerLessonKey(null)}
 			/>
 		</Screen>
 	);

--- a/src/app/timetable/index.tsx
+++ b/src/app/timetable/index.tsx
@@ -9,9 +9,10 @@ import { useMemo, useRef, useState } from "react";
 import {
 	ActivityIndicator,
 	Platform,
-	type ViewStyle,
 	View,
+	type ViewStyle,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { api } from "#convex/_generated/api";
 import type { Id } from "#convex/_generated/dataModel";
 import { ScreenHeader } from "~/components/screen-header";
@@ -26,6 +27,10 @@ import {
 	Check,
 	ScanImage,
 } from "~/components/ui/icon";
+import {
+	PortraitContent,
+	useContentSizeLayout,
+} from "~/components/ui/portrait-content";
 import { Screen, ScreenScroll } from "~/components/ui/screen";
 import { SelectSheet } from "~/components/ui/select-sheet";
 import { Text } from "~/components/ui/text";
@@ -212,6 +217,10 @@ function TimetableSourceActions({
 
 export default function TimetableScreen() {
 	const router = useRouter();
+	const insets = useSafeAreaInsets();
+	const contentSizeLayout = useContentSizeLayout({
+		requestedHorizontalPadding: 24,
+	});
 	const { user } = useAuthSession();
 	const { isAuthenticated } = useConvexAuth();
 	const timetableState = useQuery(
@@ -499,8 +508,16 @@ export default function TimetableScreen() {
 	return (
 		<Screen>
 			<ThemedStatusBar />
-			<ScreenScroll topPadding={64} bottomPadding={120} horizontalPadding={24}>
+			<PortraitContent
+				className="bg-background"
+				style={{
+					// Safe-area and responsive horizontal padding are runtime layout data.
+					paddingHorizontal: contentSizeLayout.horizontalPadding,
+					paddingTop: Math.max(insets.top + 28, 64),
+				}}
+			>
 				<ScreenHeader
+					className="mb-5"
 					title="Stundenplan"
 					onBack={() => router.back()}
 					right={
@@ -522,6 +539,13 @@ export default function TimetableScreen() {
 						) : undefined
 					}
 				/>
+			</PortraitContent>
+			<ScreenScroll
+				includeTopSafeArea={false}
+				topPadding={0}
+				bottomPadding={120}
+				horizontalPadding={24}
+			>
 				<View className="gap-5">
 					{selectedTimetable ? (
 						<TimetableStatus
@@ -561,16 +585,6 @@ export default function TimetableScreen() {
 						</>
 					) : (
 						<>
-							<View>
-								<Text className="font-poppins font-semibold text-heading-2 text-text">
-									Stunden prüfen
-								</Text>
-								<Text className="mt-1 font-poppins text-body-4 text-secondary-text">
-									Prüfe jeden Wochentag und bestätige den gesamten Stundenplan
-									oben mit dem Haken.
-								</Text>
-							</View>
-
 							{validationError ? (
 								<View
 									accessibilityLiveRegion="polite"
@@ -603,12 +617,6 @@ export default function TimetableScreen() {
 							/>
 
 							<View className="border-border border-t pt-5">
-								<Text className="font-poppins font-semibold text-body-3 text-text">
-									Stundenplan neu einlesen
-								</Text>
-								<Text className="mt-1 mb-4 font-poppins text-body-4 text-secondary-text">
-									Ersetze die aktuellen Stunden durch ein neues Bild oder PDF.
-								</Text>
 								<TimetableSourceActions
 									isBusy={isBusy}
 									isProcessing={isProcessing}

--- a/src/features/timetable/timetable-editor.test.ts
+++ b/src/features/timetable/timetable-editor.test.ts
@@ -15,6 +15,13 @@ const lesson = (
 });
 
 describe("timetable lesson editor", () => {
+	test("creates a manual lesson for the visible weekday", () => {
+		expect(createEmptyTimetableLesson("lesson", 4)).toMatchObject({
+			key: "lesson",
+			dayOfWeek: 4,
+		});
+	});
+
 	test("requires a verified lesson", () => {
 		expect(getTimetableLessonError([])).toBe(
 			"Füge mindestens eine Unterrichtsstunde hinzu.",

--- a/src/features/timetable/timetable-editor.ts
+++ b/src/features/timetable/timetable-editor.ts
@@ -87,9 +87,10 @@ export const sortTimetableLessons = (
 
 export const createEmptyTimetableLesson = (
 	key: string,
+	dayOfWeek = 1,
 ): TimetableLessonDraft => ({
 	key,
-	dayOfWeek: 1,
+	dayOfWeek,
 	subject: "",
 	startTime: "08:00",
 	endTime: "08:45",

--- a/src/features/timetable/timetable-week-editor.tsx
+++ b/src/features/timetable/timetable-week-editor.tsx
@@ -1,0 +1,356 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+	type LayoutChangeEvent,
+	type NativeScrollEvent,
+	type NativeSyntheticEvent,
+	Pressable,
+	ScrollView,
+	type TextStyle,
+	type ViewStyle,
+	View,
+} from "react-native";
+import { Button } from "~/components/ui/button";
+import { CalendarDays, Clock3, Trash2 } from "~/components/ui/icon";
+import { Input } from "~/components/ui/input";
+import { Text } from "~/components/ui/text";
+import {
+	sortTimetableLessons,
+	TIMETABLE_WEEKDAYS,
+	type TimetableLessonDraft,
+} from "~/features/timetable/timetable-editor";
+import { useDayovaTheme } from "~/lib/theme";
+import { cn } from "~/lib/utils";
+
+// These are native rendering controls with no NativeWind equivalent.
+const continuousBorderStyle = {
+	borderCurve: "continuous",
+} satisfies ViewStyle;
+const tabularNumberStyle = {
+	fontVariant: ["tabular-nums"],
+} satisfies TextStyle;
+
+type TimetableWeekEditorProps = {
+	lessons: TimetableLessonDraft[];
+	selectedDay: number;
+	isAddDisabled: boolean;
+	onSelectedDayChange: (dayOfWeek: number) => void;
+	onAddLesson: (dayOfWeek: number) => void;
+	onChangeLesson: (
+		lessonKey: string,
+		patch: Partial<TimetableLessonDraft>,
+	) => void;
+	onRemoveLesson: (lessonKey: string) => void;
+	onOpenTime: (lessonKey: string, field: "startTime" | "endTime") => void;
+	onOpenDayPicker: (lessonKey: string) => void;
+};
+
+function TimeButton({
+	label,
+	value,
+	onPress,
+}: {
+	label: string;
+	value: string;
+	onPress: () => void;
+}) {
+	const { colors } = useDayovaTheme();
+
+	return (
+		<View className="flex-1">
+			<Text className="mb-1 font-poppins text-body-5 text-secondary-text">
+				{label}
+			</Text>
+			<Pressable
+				accessibilityLabel={`${label}: ${value}`}
+				accessibilityRole="button"
+				className="h-12 flex-row items-center justify-between rounded-2xl bg-muted px-4 active:opacity-75"
+				onPress={onPress}
+			>
+				<Text
+					className="font-poppins font-semibold text-body-3 text-text"
+					style={tabularNumberStyle}
+				>
+					{value}
+				</Text>
+				<Clock3 size={17} color={colors.secondaryText} strokeWidth={2} />
+			</Pressable>
+		</View>
+	);
+}
+
+function LessonEditorCard({
+	lesson,
+	position,
+	onChange,
+	onRemove,
+	onOpenTime,
+	onOpenDayPicker,
+}: {
+	lesson: TimetableLessonDraft;
+	position: number;
+	onChange: (patch: Partial<TimetableLessonDraft>) => void;
+	onRemove: () => void;
+	onOpenTime: (field: "startTime" | "endTime") => void;
+	onOpenDayPicker: () => void;
+}) {
+	const { colors } = useDayovaTheme();
+	const weekday =
+		TIMETABLE_WEEKDAYS.find((day) => day.value === lesson.dayOfWeek) ??
+		TIMETABLE_WEEKDAYS[0];
+	const lessonLabel = lesson.subject.trim() || "Leere Stunde";
+
+	return (
+		<View
+			className="rounded-card border border-border bg-card p-5"
+			style={continuousBorderStyle}
+		>
+			<View className="flex-row items-center justify-between gap-3">
+				<Text className="flex-1 font-poppins font-semibold text-body-3 text-text">
+					{position}. Stunde
+				</Text>
+				<View className="flex-row gap-2">
+					<Pressable
+						accessibilityLabel={`Wochentag für ${lessonLabel} ändern. Aktuell ${weekday.label}`}
+						accessibilityRole="button"
+						hitSlop={4}
+						className="h-11 flex-row items-center gap-2 rounded-full bg-muted px-3 active:opacity-75"
+						onPress={onOpenDayPicker}
+					>
+						<CalendarDays
+							size={17}
+							color={colors.secondaryText}
+							strokeWidth={2}
+						/>
+						<Text className="font-poppins font-semibold text-body-4 text-secondary-text">
+							{weekday.shortLabel}
+						</Text>
+					</Pressable>
+					<Pressable
+						accessibilityLabel={`${lessonLabel} entfernen`}
+						accessibilityRole="button"
+						hitSlop={4}
+						className="h-11 w-11 items-center justify-center rounded-full bg-muted active:opacity-75"
+						onPress={onRemove}
+					>
+						<Trash2 size={18} color={colors.wrong} strokeWidth={2} />
+					</Pressable>
+				</View>
+			</View>
+
+			<View className="mt-4 h-14 justify-center rounded-2xl bg-muted px-4">
+				<Input
+					accessibilityLabel="Unterrichtsfach"
+					autoCapitalize="words"
+					maxLength={80}
+					placeholder="Fach, z. B. Mathematik"
+					value={lesson.subject}
+					onChangeText={(subject) => onChange({ subject })}
+				/>
+			</View>
+			<View className="mt-3 h-14 justify-center rounded-2xl bg-muted px-4">
+				<Input
+					accessibilityLabel="Raum, optional"
+					autoCapitalize="characters"
+					maxLength={40}
+					placeholder="Raum (optional)"
+					value={lesson.room}
+					onChangeText={(room) => onChange({ room })}
+				/>
+			</View>
+			<View className="mt-4 flex-row gap-3">
+				<TimeButton
+					label="Beginn"
+					value={lesson.startTime}
+					onPress={() => onOpenTime("startTime")}
+				/>
+				<TimeButton
+					label="Ende"
+					value={lesson.endTime}
+					onPress={() => onOpenTime("endTime")}
+				/>
+			</View>
+		</View>
+	);
+}
+
+function TimetableWeekEditor({
+	lessons,
+	selectedDay,
+	isAddDisabled,
+	onSelectedDayChange,
+	onAddLesson,
+	onChangeLesson,
+	onRemoveLesson,
+	onOpenTime,
+	onOpenDayPicker,
+}: TimetableWeekEditorProps) {
+	const pagerRef = useRef<ScrollView>(null);
+	const [pagerWidth, setPagerWidth] = useState(0);
+	const lessonsByDay = useMemo(
+		() =>
+			TIMETABLE_WEEKDAYS.map((day) => ({
+				...day,
+				lessons: sortTimetableLessons(
+					lessons.filter((lesson) => lesson.dayOfWeek === day.value),
+				),
+			})),
+		[lessons],
+	);
+	const selectedDayIndex = Math.max(
+		0,
+		TIMETABLE_WEEKDAYS.findIndex((day) => day.value === selectedDay),
+	);
+
+	useEffect(() => {
+		if (pagerWidth <= 0) return;
+		pagerRef.current?.scrollTo({
+			x: selectedDayIndex * pagerWidth,
+			animated: false,
+		});
+	}, [pagerWidth, selectedDayIndex]);
+
+	const handlePagerLayout = (event: LayoutChangeEvent) => {
+		setPagerWidth(event.nativeEvent.layout.width);
+	};
+
+	const handlePageChange = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+		if (pagerWidth <= 0) return;
+		const nextIndex = Math.max(
+			0,
+			Math.min(
+				TIMETABLE_WEEKDAYS.length - 1,
+				Math.round(event.nativeEvent.contentOffset.x / pagerWidth),
+			),
+		);
+		const nextDay = TIMETABLE_WEEKDAYS[nextIndex];
+		if (nextDay && nextDay.value !== selectedDay) {
+			onSelectedDayChange(nextDay.value);
+		}
+	};
+
+	return (
+		<View className="gap-4">
+			<ScrollView
+				horizontal
+				accessibilityLabel="Wochentag auswählen"
+				showsHorizontalScrollIndicator={false}
+			>
+				<View className="flex-row gap-2">
+					{lessonsByDay.map((day) => {
+						const selected = day.value === selectedDay;
+						const lessonCount = day.lessons.length;
+
+						return (
+							<Pressable
+								key={day.value}
+								accessible
+								accessibilityLabel={`${day.label}, ${lessonCount} ${lessonCount === 1 ? "Stunde" : "Stunden"}`}
+								accessibilityRole="button"
+								accessibilityState={{ selected }}
+								className={cn(
+									"h-11 min-w-11 items-center justify-center rounded-full px-3 active:opacity-75",
+									selected ? "bg-primary" : "bg-muted",
+								)}
+								onPress={() => onSelectedDayChange(day.value)}
+							>
+								<Text
+									className={cn(
+										"font-poppins font-semibold text-body-4",
+										selected ? "text-white" : "text-secondary-text",
+									)}
+								>
+									{day.shortLabel}
+								</Text>
+							</Pressable>
+						);
+					})}
+				</View>
+			</ScrollView>
+
+			<Text className="font-poppins text-body-4 text-secondary-text">
+				Wische nach links oder rechts, um den Tag zu wechseln.
+			</Text>
+
+			<View
+				testID="timetable-week-pager-frame"
+				className="overflow-hidden"
+				onLayout={handlePagerLayout}
+			>
+				<ScrollView
+					ref={pagerRef}
+					testID="timetable-week-pager"
+					horizontal
+					pagingEnabled
+					accessibilityLabel="Stunden nach Wochentag"
+					accessibilityHint="Wische nach links oder rechts, um den Wochentag zu wechseln."
+					onMomentumScrollEnd={handlePageChange}
+					scrollEventThrottle={16}
+					showsHorizontalScrollIndicator={false}
+				>
+					{lessonsByDay.map((day) => {
+						const isSelectedDay = day.value === selectedDay;
+
+						return (
+							<View
+								key={day.value}
+								accessibilityElementsHidden={!isSelectedDay}
+								importantForAccessibility={
+									isSelectedDay ? "yes" : "no-hide-descendants"
+								}
+								className="gap-4 pr-1"
+								// Horizontal paging requires each page to match the measured viewport.
+								style={{ width: pagerWidth }}
+							>
+								<View className="flex-row items-baseline justify-between gap-4">
+									<Text className="font-poppins font-semibold text-heading-2 text-text">
+										{day.label}
+									</Text>
+									<Text className="font-poppins text-body-4 text-secondary-text">
+										{day.lessons.length}{" "}
+										{day.lessons.length === 1 ? "Stunde" : "Stunden"}
+									</Text>
+								</View>
+
+								{day.lessons.length === 0 ? (
+									<View className="rounded-card border border-border bg-card px-5 py-6">
+										<Text className="font-poppins font-semibold text-body-3 text-text">
+											Noch keine Stunden
+										</Text>
+										<Text className="mt-2 font-poppins text-body-4 text-secondary-text">
+											Für {day.label} ist noch kein Unterricht eingetragen.
+										</Text>
+									</View>
+								) : (
+									day.lessons.map((lesson, index) => (
+										<LessonEditorCard
+											key={lesson.key}
+											lesson={lesson}
+											position={index + 1}
+											onChange={(patch) => onChangeLesson(lesson.key, patch)}
+											onRemove={() => onRemoveLesson(lesson.key)}
+											onOpenTime={(field) => onOpenTime(lesson.key, field)}
+											onOpenDayPicker={() => onOpenDayPicker(lesson.key)}
+										/>
+									))
+								)}
+
+								<Button
+									accessibilityLabel={`Unterrichtsstunde für ${day.label} hinzufügen`}
+									disabled={isAddDisabled}
+									size="sm"
+									variant="outline"
+									onPress={() => onAddLesson(day.value)}
+								>
+									<Text>Stunde für {day.label} hinzufügen</Text>
+								</Button>
+							</View>
+						);
+					})}
+				</ScrollView>
+			</View>
+		</View>
+	);
+}
+
+export { TimetableWeekEditor };
+export type { TimetableWeekEditorProps };

--- a/src/features/timetable/timetable-week-editor.tsx
+++ b/src/features/timetable/timetable-week-editor.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-	type LayoutChangeEvent,
 	type NativeScrollEvent,
 	type NativeSyntheticEvent,
 	Pressable,
 	ScrollView,
 	type TextStyle,
-	type ViewStyle,
 	View,
+	type ViewStyle,
 } from "react-native";
 import { Button } from "~/components/ui/button";
 import { CalendarDays, Clock3, Trash2 } from "~/components/ui/icon";
@@ -184,8 +183,12 @@ function TimetableWeekEditor({
 	onOpenTime,
 	onOpenDayPicker,
 }: TimetableWeekEditorProps) {
-	const pagerRef = useRef<ScrollView>(null);
-	const [pagerWidth, setPagerWidth] = useState(0);
+	const lessonPagerRef = useRef<ScrollView>(null);
+	const shouldAnimateLessonScrollRef = useRef(false);
+	const [lessonPagerWidth, setLessonPagerWidth] = useState(0);
+	const [lessonIndexByDay, setLessonIndexByDay] = useState<
+		Record<number, number>
+	>({});
 	const lessonsByDay = useMemo(
 		() =>
 			TIMETABLE_WEEKDAYS.map((day) => ({
@@ -200,157 +203,170 @@ function TimetableWeekEditor({
 		0,
 		TIMETABLE_WEEKDAYS.findIndex((day) => day.value === selectedDay),
 	);
+	const selectedDayData = lessonsByDay[selectedDayIndex] ?? lessonsByDay[0];
+	const selectedDayLessons = selectedDayData?.lessons ?? [];
+	const selectedLessonIndex = Math.max(
+		0,
+		Math.min(
+			lessonIndexByDay[selectedDay] ?? 0,
+			Math.max(0, selectedDayLessons.length - 1),
+		),
+	);
 
 	useEffect(() => {
-		if (pagerWidth <= 0) return;
-		pagerRef.current?.scrollTo({
-			x: selectedDayIndex * pagerWidth,
-			animated: false,
+		if (lessonPagerWidth <= 0) return;
+		lessonPagerRef.current?.scrollTo({
+			x: selectedLessonIndex * lessonPagerWidth,
+			animated: shouldAnimateLessonScrollRef.current,
 		});
-	}, [pagerWidth, selectedDayIndex]);
+		shouldAnimateLessonScrollRef.current = false;
+	}, [lessonPagerWidth, selectedLessonIndex]);
 
-	const handlePagerLayout = (event: LayoutChangeEvent) => {
-		setPagerWidth(event.nativeEvent.layout.width);
-	};
-
-	const handlePageChange = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-		if (pagerWidth <= 0) return;
+	const handleLessonPageChange = (
+		event: NativeSyntheticEvent<NativeScrollEvent>,
+	) => {
+		if (lessonPagerWidth <= 0) return;
 		const nextIndex = Math.max(
 			0,
 			Math.min(
-				TIMETABLE_WEEKDAYS.length - 1,
-				Math.round(event.nativeEvent.contentOffset.x / pagerWidth),
+				Math.max(0, selectedDayLessons.length - 1),
+				Math.round(event.nativeEvent.contentOffset.x / lessonPagerWidth),
 			),
 		);
-		const nextDay = TIMETABLE_WEEKDAYS[nextIndex];
-		if (nextDay && nextDay.value !== selectedDay) {
-			onSelectedDayChange(nextDay.value);
-		}
+		setLessonIndexByDay((current) => ({
+			...current,
+			[selectedDay]: nextIndex,
+		}));
+	};
+
+	const handleAddLesson = () => {
+		shouldAnimateLessonScrollRef.current = true;
+		setLessonIndexByDay((current) => ({
+			...current,
+			[selectedDay]: selectedDayLessons.length,
+		}));
+		onAddLesson(selectedDay);
 	};
 
 	return (
 		<View className="gap-4">
-			<ScrollView
-				horizontal
+			<View
 				accessibilityLabel="Wochentag auswählen"
-				showsHorizontalScrollIndicator={false}
+				className="flex-row justify-between gap-1"
 			>
-				<View className="flex-row gap-2">
-					{lessonsByDay.map((day) => {
-						const selected = day.value === selectedDay;
-						const lessonCount = day.lessons.length;
+				{lessonsByDay.map((day) => {
+					const selected = day.value === selectedDay;
+					const lessonCount = day.lessons.length;
 
-						return (
-							<Pressable
-								key={day.value}
-								accessible
-								accessibilityLabel={`${day.label}, ${lessonCount} ${lessonCount === 1 ? "Stunde" : "Stunden"}`}
-								accessibilityRole="button"
-								accessibilityState={{ selected }}
+					return (
+						<Pressable
+							key={day.value}
+							accessible
+							accessibilityLabel={`${day.label}, ${lessonCount} ${lessonCount === 1 ? "Stunde" : "Stunden"}`}
+							accessibilityRole="button"
+							accessibilityState={{ selected }}
+							className={cn(
+								"h-11 min-w-11 items-center justify-center rounded-full active:opacity-75",
+								selected ? "bg-primary" : "bg-muted",
+							)}
+							onPress={() => onSelectedDayChange(day.value)}
+						>
+							<Text
 								className={cn(
-									"h-11 min-w-11 items-center justify-center rounded-full px-3 active:opacity-75",
-									selected ? "bg-primary" : "bg-muted",
+									"font-poppins font-semibold text-body-4",
+									selected ? "text-white" : "text-secondary-text",
 								)}
-								onPress={() => onSelectedDayChange(day.value)}
 							>
-								<Text
-									className={cn(
-										"font-poppins font-semibold text-body-4",
-										selected ? "text-white" : "text-secondary-text",
-									)}
-								>
-									{day.shortLabel}
-								</Text>
-							</Pressable>
-						);
-					})}
-				</View>
-			</ScrollView>
+								{day.shortLabel}
+							</Text>
+						</Pressable>
+					);
+				})}
+			</View>
 
 			<Text className="font-poppins text-body-4 text-secondary-text">
-				Wische nach links oder rechts, um den Tag zu wechseln.
+				Wische nach links oder rechts, um die Stunden zu prüfen.
 			</Text>
 
-			<View
-				testID="timetable-week-pager-frame"
-				className="overflow-hidden"
-				onLayout={handlePagerLayout}
-			>
-				<ScrollView
-					ref={pagerRef}
-					testID="timetable-week-pager"
-					horizontal
-					pagingEnabled
-					accessibilityLabel="Stunden nach Wochentag"
-					accessibilityHint="Wische nach links oder rechts, um den Wochentag zu wechseln."
-					onMomentumScrollEnd={handlePageChange}
-					scrollEventThrottle={16}
-					showsHorizontalScrollIndicator={false}
+			<View className="flex-row items-baseline justify-between gap-4">
+				<Text className="font-poppins font-semibold text-heading-2 text-text">
+					{selectedDayData?.label}
+				</Text>
+				<Text
+					accessibilityLiveRegion="polite"
+					className="font-poppins text-body-4 text-secondary-text"
 				>
-					{lessonsByDay.map((day) => {
-						const isSelectedDay = day.value === selectedDay;
-
-						return (
-							<View
-								key={day.value}
-								accessibilityElementsHidden={!isSelectedDay}
-								importantForAccessibility={
-									isSelectedDay ? "yes" : "no-hide-descendants"
-								}
-								className="gap-4 pr-1"
-								// Horizontal paging requires each page to match the measured viewport.
-								style={{ width: pagerWidth }}
-							>
-								<View className="flex-row items-baseline justify-between gap-4">
-									<Text className="font-poppins font-semibold text-heading-2 text-text">
-										{day.label}
-									</Text>
-									<Text className="font-poppins text-body-4 text-secondary-text">
-										{day.lessons.length}{" "}
-										{day.lessons.length === 1 ? "Stunde" : "Stunden"}
-									</Text>
-								</View>
-
-								{day.lessons.length === 0 ? (
-									<View className="rounded-card border border-border bg-card px-5 py-6">
-										<Text className="font-poppins font-semibold text-body-3 text-text">
-											Noch keine Stunden
-										</Text>
-										<Text className="mt-2 font-poppins text-body-4 text-secondary-text">
-											Für {day.label} ist noch kein Unterricht eingetragen.
-										</Text>
-									</View>
-								) : (
-									day.lessons.map((lesson, index) => (
-										<LessonEditorCard
-											key={lesson.key}
-											lesson={lesson}
-											position={index + 1}
-											onChange={(patch) => onChangeLesson(lesson.key, patch)}
-											onRemove={() => onRemoveLesson(lesson.key)}
-											onOpenTime={(field) => onOpenTime(lesson.key, field)}
-											onOpenDayPicker={() => onOpenDayPicker(lesson.key)}
-										/>
-									))
-								)}
-
-								<Button
-									accessibilityLabel={`Unterrichtsstunde für ${day.label} hinzufügen`}
-									disabled={isAddDisabled}
-									size="sm"
-									variant="outline"
-									onPress={() => onAddLesson(day.value)}
-								>
-									<Text>Stunde für {day.label} hinzufügen</Text>
-								</Button>
-							</View>
-						);
-					})}
-				</ScrollView>
+					{selectedDayLessons.length === 0
+						? "0 Stunden"
+						: `${selectedLessonIndex + 1} / ${selectedDayLessons.length}`}
+				</Text>
 			</View>
+
+			{selectedDayLessons.length === 0 ? (
+				<View className="rounded-card border border-border bg-card px-5 py-6">
+					<Text className="font-poppins font-semibold text-body-3 text-text">
+						Noch keine Stunden
+					</Text>
+					<Text className="mt-2 font-poppins text-body-4 text-secondary-text">
+						Für {selectedDayData?.label} ist noch kein Unterricht eingetragen.
+					</Text>
+				</View>
+			) : (
+				<View
+					testID="timetable-lesson-pager-frame"
+					className="overflow-hidden"
+					onLayout={(event) =>
+						setLessonPagerWidth(event.nativeEvent.layout.width)
+					}
+				>
+					<ScrollView
+						ref={lessonPagerRef}
+						testID="timetable-lesson-pager"
+						horizontal
+						pagingEnabled
+						accessibilityLabel={`Stunden für ${selectedDayData?.label}`}
+						accessibilityHint="Wische nach links oder rechts, um zwischen den Stunden zu wechseln."
+						onMomentumScrollEnd={handleLessonPageChange}
+						scrollEventThrottle={16}
+						showsHorizontalScrollIndicator={false}
+					>
+						{selectedDayLessons.map((lesson, index) => (
+							<View
+								key={lesson.key}
+								accessibilityElementsHidden={index !== selectedLessonIndex}
+								importantForAccessibility={
+									index === selectedLessonIndex ? "yes" : "no-hide-descendants"
+								}
+								className="pr-1"
+								// Horizontal paging requires each page to match the measured viewport.
+								style={{ width: lessonPagerWidth }}
+							>
+								<LessonEditorCard
+									lesson={lesson}
+									position={index + 1}
+									onChange={(patch) => onChangeLesson(lesson.key, patch)}
+									onRemove={() => onRemoveLesson(lesson.key)}
+									onOpenTime={(field) => onOpenTime(lesson.key, field)}
+									onOpenDayPicker={() => onOpenDayPicker(lesson.key)}
+								/>
+							</View>
+						))}
+					</ScrollView>
+				</View>
+			)}
+
+			<Button
+				accessibilityLabel={`Unterrichtsstunde für ${selectedDayData?.label} hinzufügen`}
+				disabled={isAddDisabled}
+				size="sm"
+				variant="outline"
+				onPress={handleAddLesson}
+			>
+				<Text>Stunde für {selectedDayData?.label} hinzufügen</Text>
+			</Button>
 		</View>
 	);
 }
 
-export { TimetableWeekEditor };
 export type { TimetableWeekEditorProps };
+export { TimetableWeekEditor };

--- a/src/features/timetable/timetable-week-editor.tsx
+++ b/src/features/timetable/timetable-week-editor.tsx
@@ -284,10 +284,6 @@ function TimetableWeekEditor({
 				})}
 			</View>
 
-			<Text className="font-poppins text-body-4 text-secondary-text">
-				Wische nach links oder rechts, um die Stunden zu prüfen.
-			</Text>
-
 			<View className="flex-row items-baseline justify-between gap-4">
 				<Text className="font-poppins font-semibold text-heading-2 text-text">
 					{selectedDayData?.label}

--- a/src/features/timetable/timetable-week-editor.ui.test.tsx
+++ b/src/features/timetable/timetable-week-editor.ui.test.tsx
@@ -98,6 +98,11 @@ describe("TimetableWeekEditor", () => {
 		const { screen } = await renderEditor();
 		const pager = screen.getByTestId("timetable-lesson-pager");
 
+		expect(
+			screen.queryByText(
+				"Wische nach links oder rechts, um die Stunden zu prüfen.",
+			),
+		).toBeNull();
 		expect(pager.props.horizontal).toBe(true);
 		expect(pager.props.pagingEnabled).toBe(true);
 		expect(screen.getByText("1 / 2")).toBeTruthy();

--- a/src/features/timetable/timetable-week-editor.ui.test.tsx
+++ b/src/features/timetable/timetable-week-editor.ui.test.tsx
@@ -1,0 +1,117 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { fireEvent, render } from "@testing-library/react-native";
+import { TimetableWeekEditor } from "./timetable-week-editor";
+
+jest.mock("~/components/ui/icon", () => {
+	const React = jest.requireActual<typeof import("react")>("react");
+	const Icon = (props: Record<string, unknown>) =>
+		React.createElement("Icon", props);
+
+	return {
+		ArrowLeft: Icon,
+		CalendarDays: Icon,
+		Clock3: Icon,
+		Trash2: Icon,
+	};
+});
+
+jest.mock("~/lib/theme", () => ({
+	useDayovaTheme: () => ({
+		colors: {
+			secondaryText: "#697586",
+			wrong: "#FF9500",
+		},
+	}),
+}));
+
+const lessons = [
+	{
+		key: "math",
+		dayOfWeek: 1,
+		subject: "Mathematik",
+		startTime: "08:00",
+		endTime: "08:45",
+		room: "A1",
+	},
+	{
+		key: "german",
+		dayOfWeek: 2,
+		subject: "Deutsch",
+		startTime: "09:00",
+		endTime: "09:45",
+		room: "B2",
+	},
+];
+
+const renderEditor = async (selectedDay = 1) => {
+	const callbacks = {
+		onSelectedDayChange: jest.fn(),
+		onAddLesson: jest.fn(),
+		onChangeLesson: jest.fn(),
+		onRemoveLesson: jest.fn(),
+		onOpenTime: jest.fn(),
+		onOpenDayPicker: jest.fn(),
+	};
+	const screen = await render(
+		<TimetableWeekEditor
+			lessons={lessons}
+			selectedDay={selectedDay}
+			isAddDisabled={false}
+			{...callbacks}
+		/>,
+	);
+
+	return { screen, callbacks };
+};
+
+describe("TimetableWeekEditor", () => {
+	test("navigates by weekday tabs and adds to the visible day", async () => {
+		const { screen, callbacks } = await renderEditor();
+		const monday = screen.getByRole("button", { name: "Montag, 1 Stunde" });
+		const tuesday = screen.getByRole("button", {
+			name: "Dienstag, 1 Stunde",
+		});
+
+		expect(monday.props.accessibilityState).toEqual({ selected: true });
+		expect(tuesday.props.accessibilityState).toEqual({ selected: false });
+
+		await fireEvent.press(tuesday);
+		expect(callbacks.onSelectedDayChange).toHaveBeenCalledWith(2);
+
+		await fireEvent.press(
+			screen.getByRole("button", {
+				name: "Unterrichtsstunde für Montag hinzufügen",
+			}),
+		);
+		expect(callbacks.onAddLesson).toHaveBeenCalledWith(1);
+	});
+
+	test("changes the visible weekday after a horizontal page swipe", async () => {
+		const { screen, callbacks } = await renderEditor();
+
+		await fireEvent(
+			screen.getByTestId("timetable-week-pager-frame"),
+			"layout",
+			{ nativeEvent: { layout: { width: 320, height: 500, x: 0, y: 0 } } },
+		);
+		await fireEvent(
+			screen.getByTestId("timetable-week-pager"),
+			"momentumScrollEnd",
+			{ nativeEvent: { contentOffset: { x: 320, y: 0 } } },
+		);
+
+		expect(callbacks.onSelectedDayChange).toHaveBeenCalledWith(2);
+	});
+
+	test("keeps weekday correction available without seven controls per card", async () => {
+		const { screen, callbacks } = await renderEditor();
+
+		await fireEvent.press(
+			screen.getByRole("button", {
+				name: "Wochentag für Mathematik ändern. Aktuell Montag",
+			}),
+		);
+
+		expect(callbacks.onOpenDayPicker).toHaveBeenCalledWith("math");
+	});
+});

--- a/src/features/timetable/timetable-week-editor.ui.test.tsx
+++ b/src/features/timetable/timetable-week-editor.ui.test.tsx
@@ -34,6 +34,14 @@ const lessons = [
 		room: "A1",
 	},
 	{
+		key: "science",
+		dayOfWeek: 1,
+		subject: "Naturwissenschaften",
+		startTime: "08:50",
+		endTime: "09:35",
+		room: "A2",
+	},
+	{
 		key: "german",
 		dayOfWeek: 2,
 		subject: "Deutsch",
@@ -67,7 +75,7 @@ const renderEditor = async (selectedDay = 1) => {
 describe("TimetableWeekEditor", () => {
 	test("navigates by weekday tabs and adds to the visible day", async () => {
 		const { screen, callbacks } = await renderEditor();
-		const monday = screen.getByRole("button", { name: "Montag, 1 Stunde" });
+		const monday = screen.getByRole("button", { name: "Montag, 2 Stunden" });
 		const tuesday = screen.getByRole("button", {
 			name: "Dienstag, 1 Stunde",
 		});
@@ -86,21 +94,24 @@ describe("TimetableWeekEditor", () => {
 		expect(callbacks.onAddLesson).toHaveBeenCalledWith(1);
 	});
 
-	test("changes the visible weekday after a horizontal page swipe", async () => {
-		const { screen, callbacks } = await renderEditor();
+	test("pages horizontally through one lesson card at a time", async () => {
+		const { screen } = await renderEditor();
+		const pager = screen.getByTestId("timetable-lesson-pager");
+
+		expect(pager.props.horizontal).toBe(true);
+		expect(pager.props.pagingEnabled).toBe(true);
+		expect(screen.getByText("1 / 2")).toBeTruthy();
 
 		await fireEvent(
-			screen.getByTestId("timetable-week-pager-frame"),
+			screen.getByTestId("timetable-lesson-pager-frame"),
 			"layout",
 			{ nativeEvent: { layout: { width: 320, height: 500, x: 0, y: 0 } } },
 		);
-		await fireEvent(
-			screen.getByTestId("timetable-week-pager"),
-			"momentumScrollEnd",
-			{ nativeEvent: { contentOffset: { x: 320, y: 0 } } },
-		);
+		await fireEvent(pager, "momentumScrollEnd", {
+			nativeEvent: { contentOffset: { x: 320, y: 0 } },
+		});
 
-		expect(callbacks.onSelectedDayChange).toHaveBeenCalledWith(2);
+		expect(screen.getByText("2 / 2")).toBeTruthy();
 	});
 
 	test("keeps weekday correction available without seven controls per card", async () => {


### PR DESCRIPTION
## Summary

- keep the back, title, and check action in a fixed safe-area header outside the scrolling editor content
- remove the redundant editor intro, swipe instruction, and re-import explanatory copy
- keep Monday–Sunday as direct weekday navigation
- show one lesson editor card at a time and page lessons horizontally with a current/total cue
- after a successful save/activation, replace the editor with the canonical `/home` start route
- run success haptics as a non-blocking enhancement so feedback cannot prevent navigation
- retain compact file/photo replacement actions, validation/error states, and accessible off-screen-card handling

## Verification

- `pnpm exec biome check src/app/timetable/index.tsx src/features/timetable/timetable-week-editor.tsx src/features/timetable/timetable-week-editor.ui.test.tsx`
- `pnpm jest --runInBand src/features/timetable/timetable-week-editor.ui.test.tsx` (3/3)
- `pnpm vitest run src/lib/safe-haptics.test.ts` (5/5)
- `pnpm typecheck`
- `pnpm lint` (passes with one unrelated pre-existing unused-import warning in `src/features/auth/dayova-auth-flow.tsx`)
- `pnpm test:unit` (101 files, 615 tests)
- `git diff --check`
- Computer Use inspection on iPhone 17 dark mode confirms the streamlined one-viewport layout and fixed header
- Computer Use saved the active timetable and verified the resulting main dashboard at `/home`

## Verification note

The initial redirect attempt exposed that awaiting simulator haptics could block navigation even after the mutation succeeded. Navigation now runs immediately after the successful mutation, and safe haptics run without being awaited.

The Computer Use drag primitive did not reliably synthesize an iOS touch swipe. Horizontal paging and the `1 / 2` → `2 / 2` state transition are covered by the focused UI test.