### PR TITLE
Remove theory continuation action

### DIFF
--- a/src/features/learning-plans/learning-session-completion.tsx
+++ b/src/features/learning-plans/learning-session-completion.tsx
@@ -53,7 +53,7 @@ export function LearningSessionCompletion({
 	if (isTheory) {
 		title = "Theorie abgeschlossen";
 		description =
-			"Du hast alle Themen dieser Theorieeinheit geschafft. Wiederhole sie noch einmal oder gehe zum nächsten Schritt.";
+			"Du hast alle Themen dieser Theorieeinheit geschafft. Gehe jetzt zum nächsten Schritt.";
 		completionLabel = "Theorie geschafft";
 		Icon = BookOpen;
 		iconClassName = "bg-theorie-subtle";
@@ -115,7 +115,7 @@ export function LearningSessionCompletion({
 				</Text>
 			</View>
 
-			<View className="gap-3">
+			<View>
 				<Button className="w-full" disabled={isBusy} onPress={onPrimary}>
 					{isBusy ? (
 						<ActivityIndicator color={DAYOVA_DESIGN_SYSTEM.colors.light1} />
@@ -123,16 +123,6 @@ export function LearningSessionCompletion({
 						<Text>{primaryLabel}</Text>
 					)}
 				</Button>
-				{isTheory ? (
-					<Button
-						className="w-full"
-						disabled={isBusy}
-						variant="neutral"
-						onPress={onContinueLearning}
-					>
-						<Text>Noch 10 Min. weiterlernen</Text>
-					</Button>
-				) : null}
 			</View>
 		</Animated.View>
 	);

--- a/src/features/learning-plans/learning-session-completion.ui.test.tsx
+++ b/src/features/learning-plans/learning-session-completion.ui.test.tsx
@@ -59,6 +59,39 @@ jest.mock("react-native-reanimated", () => {
 });
 
 describe("learning session completion", () => {
+	test("finishes theory without offering another learning block", async () => {
+		const onPrimary = jest.fn();
+		const onContinueLearning = jest.fn();
+		const screen = await render(
+			<LearningSessionCompletion
+				attemptCount={0}
+				correctCount={0}
+				durationMinutes={10}
+				isBusy={false}
+				isDiagnostic={false}
+				onContinueLearning={onContinueLearning}
+				onPrimary={onPrimary}
+				phase="theory"
+			/>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Theorie abschließen" }),
+		).toBeEnabled();
+		expect(screen.queryByText("Noch 10 Min. weiterlernen")).toBeNull();
+		expect(
+			screen.getByText(
+				"Du hast alle Themen dieser Theorieeinheit geschafft. Gehe jetzt zum nächsten Schritt.",
+			),
+		).toBeTruthy();
+
+		fireEvent.press(
+			screen.getByRole("button", { name: "Theorie abschließen" }),
+		);
+		expect(onPrimary).toHaveBeenCalledTimes(1);
+		expect(onContinueLearning).not.toHaveBeenCalled();
+	});
+
 	test("opens Analyse directly without offering another practice block", async () => {
 		const onPrimary = jest.fn();
 		const onContinueLearning = jest.fn();


### PR DESCRIPTION
## Summary
- remove the secondary “Noch 10 Min. weiterlernen” button from theory completion
- update the completion copy so it no longer suggests repeating the lesson
- add a UI regression test for the single-action theory completion state

## Validation
- `pnpm exec jest --runInBand src/features/learning-plans/learning-session-completion.ui.test.tsx`
- `pnpm exec biome format src/features/learning-plans/learning-session-completion.tsx src/features/learning-plans/learning-session-completion.ui.test.tsx`
- `pnpm exec biome lint src/features/learning-plans/learning-session-completion.tsx src/features/learning-plans/learning-session-completion.ui.test.tsx`
- `pnpm exec eslint src/features/learning-plans/learning-session-completion.tsx src/features/learning-plans/learning-session-completion.ui.test.tsx`
- `pnpm typecheck`