### PR TITLE
Make theory sections collapsible

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
 		"expo-notifications": "~57.0.7",
 		"expo-router": "^57.0.8",
 		"expo-secure-store": "~57.0.1",
-		"expo-speech": "~57.0.1",
 		"expo-splash-screen": "~57.0.5",
 		"expo-status-bar": "~57.0.1",
 		"expo-system-ui": "~57.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,9 +115,6 @@ importers:
       expo-secure-store:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.8)
-      expo-speech:
-        specifier: ~57.0.1
-        version: 57.0.1(expo@57.0.8)
       expo-splash-screen:
         specifier: ~57.0.5
         version: 57.0.5(expo@57.0.8)(supports-color@8.1.1)(typescript@6.0.3)
@@ -4334,11 +4331,6 @@ packages:
   expo-server@57.0.1:
     resolution: {integrity: sha512-sBfVDH6dmKVHZxqUxbfkzS00PZELMZt1IpnHKxcOTMZtR/t7CtRAFrbXcisG+EyzeqHSVDacZT+1tbYfZt5D8w==}
     engines: {node: '>=20.16.0'}
-
-  expo-speech@57.0.1:
-    resolution: {integrity: sha512-xRI5FyAju4rK10xcVE+3SjdrF1ni24+Sj8ujSrylBsbrwFrrLO19H5DkG6EzXXVQ6lWdn+dC0JCr8OLaM7HI+Q==}
-    peerDependencies:
-      expo: '*'
 
   expo-splash-screen@57.0.5:
     resolution: {integrity: sha512-ZN0LDXlhHRNFjXTYZDojXk8IfaoUIu7qa3hhoBTXgyj1UB/iewGlH6+M3Nvhun2lY2d/+xhwqMhv0hIRoBo09Q==}
@@ -11922,10 +11914,6 @@ snapshots:
       expo: 57.0.8(@babel/core@7.29.0(supports-color@8.1.1))(@expo/metro-runtime@57.0.7)(expo-router@57.0.8)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.0(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.0(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.0(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.0(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.0(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
 
   expo-server@57.0.1: {}
-
-  expo-speech@57.0.1(expo@57.0.8):
-    dependencies:
-      expo: 57.0.8(@babel/core@7.29.0(supports-color@8.1.1))(@expo/metro-runtime@57.0.7)(expo-router@57.0.8)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.0(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.0(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.0(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.0(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.0(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
 
   expo-splash-screen@57.0.5(expo@57.0.8)(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:

--- a/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
+++ b/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
@@ -1,6 +1,5 @@
 import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import * as Speech from "expo-speech";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	ActivityIndicator,
@@ -455,7 +454,6 @@ export default function LearningSessionContentScreen() {
 	).length;
 
 	const goBack = useCallback(() => {
-		void Speech.stop().catch(() => undefined);
 		if (planId) {
 			dismissToOrReplace(router, `/learning-plans/${planId}` as const);
 			return true;

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -54,7 +54,6 @@ import {
 	SparklesIcon,
 	SquareLock02Icon,
 	SquareRootSquareIcon,
-	StopIcon,
 	Sun01Icon,
 	Task01Icon,
 	TaskEdit01Icon,
@@ -65,7 +64,6 @@ import {
 	UserCircleIcon,
 	ViewIcon,
 	ViewOffIcon,
-	VolumeHighIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon, type HugeiconsProps } from "@hugeicons/react-native";
 
@@ -132,7 +130,6 @@ export const Repeat = createIcon(RepeatIcon);
 export const Route2 = createIcon(Route02Icon);
 export const ScanImage = createIcon(ScanImageIcon);
 export const Settings = createIcon(Settings01Icon);
-export const Stop = createIcon(StopIcon);
 export const SquareLock = createIcon(SquareLock02Icon);
 export const SquareRootSquare = createIcon(SquareRootSquareIcon);
 export const Sparkles = createIcon(SparklesIcon);
@@ -143,5 +140,4 @@ export const TimeManagement = createIcon(TimeManagementCircleIcon);
 export const Timer = createIcon(Clock03Icon);
 export const Trash2 = createIcon(Delete02Icon);
 export const UserRound = createIcon(UserCircleIcon);
-export const VolumeHigh = createIcon(VolumeHighIcon);
 export const X = createIcon(Cancel01Icon);

--- a/src/features/learning-plans/theory-topic-page.tsx
+++ b/src/features/learning-plans/theory-topic-page.tsx
@@ -1,6 +1,4 @@
-import { useFocusEffect } from "expo-router";
-import * as Speech from "expo-speech";
-import { useCallback, useRef, useState } from "react";
+import { useState } from "react";
 import {
 	ActivityIndicator,
 	ScrollView,
@@ -17,26 +15,21 @@ import { FlowProgressBar } from "~/components/ui/flow-progress-bar";
 import {
 	BookOpen,
 	Bulb,
+	ChevronDown,
 	CircleAlert,
 	Pencil,
-	Stop,
-	VolumeHigh,
 } from "~/components/ui/icon";
 import { Text } from "~/components/ui/text";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 import { useDayovaTheme } from "~/lib/theme";
+import { cn } from "~/lib/utils";
 import {
 	adaptTheoryTopic,
-	buildTheorySpeechText,
 	getTheoryPagePresentation,
 	getTheoryTopicNavigation,
-	splitTheorySpeechText,
 	type TheoryTopic,
 } from "./theory-topic";
 import type { SessionContentItem } from "./types";
-
-const SPEECH_ERROR_MESSAGE =
-	"Vorlesen ist gerade nicht verfügbar. Lies das Thema selbst weiter oder versuche es erneut.";
 
 type TheoryTopicPageProps = {
 	item: SessionContentItem;
@@ -89,58 +82,62 @@ function TheoryTopicProgress({
 	);
 }
 
-function TheoryTopicIntroduction({
-	topic,
-	accessory,
-}: {
-	topic: TheoryTopic;
-	accessory?: React.ReactNode;
-}) {
+function TheoryTopicIntroduction({ topic }: { topic: TheoryTopic }) {
 	return (
-		<View className="gap-4">
-			<View className="flex-row items-start gap-4">
-				<Text
-					selectable
-					accessibilityRole="header"
-					className="flex-1 font-poppins font-semibold text-heading-2 text-text"
-				>
-					{topic.conceptTitle}
-				</Text>
-				{accessory}
-			</View>
-			<View className="rounded-[24px] bg-system-subtle px-5 py-5">
-				<Text className="font-poppins font-semibold text-body-4 text-primary">
-					Leitfrage
-				</Text>
-				<Text
-					selectable
-					className="mt-2 font-poppins font-semibold text-body-1 text-text"
-				>
-					{topic.question}
-				</Text>
-			</View>
-		</View>
+		<Text
+			selectable
+			accessibilityRole="header"
+			className="font-poppins font-semibold text-heading-2 text-text"
+		>
+			{topic.question}
+		</Text>
 	);
 }
 
-function TopicSectionTitle({
-	icon,
+function CollapsibleTheorySection({
 	children,
+	className,
+	icon,
+	title,
 }: {
+	children: React.ReactNode;
+	className?: string;
 	icon: React.ReactNode;
-	children: string;
+	title: string;
 }) {
+	const [isExpanded, setIsExpanded] = useState(true);
+	const { colors } = useDayovaTheme();
+
 	return (
-		<View className="flex-row items-center gap-3">
-			<View className="h-10 w-10 items-center justify-center rounded-full bg-system-subtle">
-				{icon}
-			</View>
-			<Text
-				selectable
-				className="flex-1 font-poppins font-semibold text-body-2 text-text"
+		<View className={cn("gap-4", className)}>
+			<TouchableOpacity
+				accessibilityHint={
+					isExpanded
+						? "Blendet den Inhalt dieses Abschnitts aus."
+						: "Blendet den Inhalt dieses Abschnitts ein."
+				}
+				accessibilityLabel={`${title} ${isExpanded ? "einklappen" : "ausklappen"}`}
+				accessibilityRole="button"
+				accessibilityState={{ expanded: isExpanded }}
+				activeOpacity={0.72}
+				className="min-h-12 flex-row items-center gap-3"
+				onPress={() => setIsExpanded((value) => !value)}
 			>
-				{children}
-			</Text>
+				<View className="h-10 w-10 items-center justify-center rounded-full bg-system-subtle">
+					{icon}
+				</View>
+				<Text className="flex-1 font-poppins font-semibold text-body-2 text-text">
+					{title}
+				</Text>
+				<View className={cn(isExpanded && "rotate-180")}>
+					<ChevronDown
+						size={20}
+						color={colors.secondaryText}
+						strokeWidth={2.1}
+					/>
+				</View>
+			</TouchableOpacity>
+			{isExpanded ? children : null}
 		</View>
 	);
 }
@@ -159,77 +156,6 @@ export function TheoryTopicPage({
 	const topic = adaptTheoryTopic(item, currentIndex);
 	const presentation = getTheoryPagePresentation(item.questionAngle);
 	const navigation = getTheoryTopicNavigation(currentIndex, total);
-	const [isSpeaking, setIsSpeaking] = useState(false);
-	const [speechError, setSpeechError] = useState<string | null>(null);
-	const speechRunRef = useRef(0);
-
-	const stopSpeaking = useCallback(() => {
-		speechRunRef.current += 1;
-		setIsSpeaking(false);
-		void Speech.stop().catch(() => undefined);
-	}, []);
-
-	useFocusEffect(useCallback(() => () => stopSpeaking(), [stopSpeaking]));
-
-	const toggleSpeech = useCallback(() => {
-		if (isSpeaking) {
-			stopSpeaking();
-			return;
-		}
-
-		const nextRun = speechRunRef.current + 1;
-		speechRunRef.current = nextRun;
-		setSpeechError(null);
-		void Speech.stop()
-			.then(() => {
-				if (speechRunRef.current !== nextRun) return;
-
-				const speechChunks = splitTheorySpeechText(
-					buildTheorySpeechText(topic, item.questionAngle),
-					Speech.maxSpeechInputLength,
-				);
-				const speakChunk = (chunkIndex: number) => {
-					const chunk = speechChunks[chunkIndex];
-					if (!chunk || speechRunRef.current !== nextRun) return;
-
-					Speech.speak(chunk, {
-						language: "de-DE",
-						rate: 0.92,
-						useApplicationAudioSession: false,
-						onStart: () => {
-							if (speechRunRef.current === nextRun) setIsSpeaking(true);
-						},
-						onDone: () => {
-							if (speechRunRef.current !== nextRun) return;
-							if (chunkIndex < speechChunks.length - 1) {
-								speakChunk(chunkIndex + 1);
-								return;
-							}
-							setIsSpeaking(false);
-						},
-						onStopped: () => {
-							if (speechRunRef.current === nextRun) setIsSpeaking(false);
-						},
-						onError: () => {
-							if (speechRunRef.current !== nextRun) return;
-							setIsSpeaking(false);
-							setSpeechError(SPEECH_ERROR_MESSAGE);
-						},
-					});
-				};
-				speakChunk(0);
-			})
-			.catch(() => {
-				if (speechRunRef.current !== nextRun) return;
-				setIsSpeaking(false);
-				setSpeechError(SPEECH_ERROR_MESSAGE);
-			});
-	}, [isSpeaking, item.questionAngle, stopSpeaking, topic]);
-
-	const stopAndRun = (action: () => void) => {
-		stopSpeaking();
-		action();
-	};
 
 	return (
 		<View className="flex-1 bg-background">
@@ -249,58 +175,18 @@ export function TheoryTopicPage({
 					entering={reduceMotion ? undefined : FadeInDown.duration(220)}
 					className="gap-7"
 				>
-					<TheoryTopicIntroduction
-						topic={topic}
-						accessory={
-							<TouchableOpacity
-								accessibilityLabel={
-									isSpeaking ? "Vorlesen stoppen" : "Thema vorlesen"
-								}
-								accessibilityRole="button"
-								accessibilityState={{ selected: isSpeaking }}
-								activeOpacity={0.8}
-								hitSlop={8}
-								onPress={toggleSpeech}
-								className="h-12 w-12 items-center justify-center rounded-full bg-system-subtle"
-							>
-								{isSpeaking ? (
-									<Stop
-										size={21}
-										color={DAYOVA_DESIGN_SYSTEM.colors.primary}
-										strokeWidth={2.2}
-									/>
-								) : (
-									<VolumeHigh
-										size={22}
-										color={DAYOVA_DESIGN_SYSTEM.colors.primary}
-										strokeWidth={2.2}
-									/>
-								)}
-							</TouchableOpacity>
-						}
-					/>
-					{speechError ? (
-						<Text
-							selectable
-							accessibilityLiveRegion="polite"
-							className="font-poppins text-body-4 text-wrong"
-						>
-							{speechError}
-						</Text>
-					) : null}
+					<TheoryTopicIntroduction topic={topic} />
 
-					<View className="gap-4">
-						<TopicSectionTitle
-							icon={
-								<BookOpen
-									size={20}
-									color={DAYOVA_DESIGN_SYSTEM.colors.primary}
-									strokeWidth={2.1}
-								/>
-							}
-						>
-							{presentation.sectionTitle}
-						</TopicSectionTitle>
+					<CollapsibleTheorySection
+						title={presentation.sectionTitle}
+						icon={
+							<BookOpen
+								size={20}
+								color={DAYOVA_DESIGN_SYSTEM.colors.primary}
+								strokeWidth={2.1}
+							/>
+						}
+					>
 						<Text
 							selectable
 							className="font-poppins text-body-2 text-secondary-text"
@@ -322,63 +208,60 @@ export function TheoryTopicPage({
 								))}
 							</View>
 						) : null}
-					</View>
+					</CollapsibleTheorySection>
 
 					{presentation.showExample && topic.example ? (
-						<View className="gap-4 rounded-[32px] border border-primary/20 bg-system-subtle px-5 py-5">
-							<TopicSectionTitle
-								icon={
-									<Pencil
-										size={19}
-										color={DAYOVA_DESIGN_SYSTEM.colors.primary}
-										strokeWidth={2.1}
-									/>
-								}
-							>
-								Beispiel
-							</TopicSectionTitle>
+						<CollapsibleTheorySection
+							className="rounded-[32px] border border-primary/20 bg-system-subtle px-5 py-5"
+							title="Beispiel"
+							icon={
+								<Pencil
+									size={19}
+									color={DAYOVA_DESIGN_SYSTEM.colors.primary}
+									strokeWidth={2.1}
+								/>
+							}
+						>
 							<Text selectable className="font-poppins text-body-2 text-text">
 								{topic.example}
 							</Text>
-						</View>
+						</CollapsibleTheorySection>
 					) : null}
 
 					{presentation.showMemoryCue && topic.memoryCue ? (
-						<View className="gap-4 rounded-[32px] bg-theorie-subtle px-5 py-5">
-							<TopicSectionTitle
-								icon={
-									<Bulb
-										size={20}
-										color={DAYOVA_DESIGN_SYSTEM.colors.theorie}
-										strokeWidth={2.1}
-									/>
-								}
-							>
-								Merksatz
-							</TopicSectionTitle>
+						<CollapsibleTheorySection
+							className="rounded-[32px] bg-theorie-subtle px-5 py-5"
+							title="Merksatz"
+							icon={
+								<Bulb
+									size={20}
+									color={DAYOVA_DESIGN_SYSTEM.colors.theorie}
+									strokeWidth={2.1}
+								/>
+							}
+						>
 							<Text selectable className="font-poppins text-body-2 text-text">
 								{topic.memoryCue}
 							</Text>
-						</View>
+						</CollapsibleTheorySection>
 					) : null}
 
 					{presentation.showCommonMistake && topic.commonMistake ? (
-						<View className="gap-4 rounded-[32px] bg-wrong-subtle px-5 py-5">
-							<TopicSectionTitle
-								icon={
-									<CircleAlert
-										size={20}
-										color={DAYOVA_DESIGN_SYSTEM.colors.wrong}
-										strokeWidth={2.1}
-									/>
-								}
-							>
-								Typischer Fehler
-							</TopicSectionTitle>
+						<CollapsibleTheorySection
+							className="rounded-[32px] bg-wrong-subtle px-5 py-5"
+							title="Typischer Fehler"
+							icon={
+								<CircleAlert
+									size={20}
+									color={DAYOVA_DESIGN_SYSTEM.colors.wrong}
+									strokeWidth={2.1}
+								/>
+							}
+						>
 							<Text selectable className="font-poppins text-body-2 text-text">
 								{topic.commonMistake}
 							</Text>
-						</View>
+						</CollapsibleTheorySection>
 					) : null}
 				</Animated.View>
 			</ScrollView>
@@ -391,7 +274,7 @@ export function TheoryTopicPage({
 				<Button
 					className="flex-1 px-4"
 					disabled={!navigation.canGoPrevious || isCompleting}
-					onPress={() => stopAndRun(onPrevious)}
+					onPress={onPrevious}
 					variant="neutral"
 				>
 					<Text>Zurück</Text>
@@ -399,7 +282,7 @@ export function TheoryTopicPage({
 				<Button
 					className="flex-[1.35] px-4"
 					disabled={isCompleting}
-					onPress={() => stopAndRun(onNext)}
+					onPress={onNext}
 				>
 					{isCompleting ? (
 						<ActivityIndicator color={colors.light1} />

--- a/src/features/learning-plans/theory-topic-page.tsx
+++ b/src/features/learning-plans/theory-topic-page.tsx
@@ -95,18 +95,19 @@ function TheoryTopicIntroduction({ topic }: { topic: TheoryTopic }) {
 }
 
 function CollapsibleTheorySection({
+	chevronColor,
 	children,
 	className,
 	icon,
 	title,
 }: {
+	chevronColor: string;
 	children: React.ReactNode;
 	className?: string;
 	icon: React.ReactNode;
 	title: string;
 }) {
 	const [isExpanded, setIsExpanded] = useState(false);
-	const { colors } = useDayovaTheme();
 
 	return (
 		<View className={cn("gap-4", className)}>
@@ -130,11 +131,7 @@ function CollapsibleTheorySection({
 					{title}
 				</Text>
 				<View className={cn(isExpanded && "rotate-180")}>
-					<ChevronDown
-						size={20}
-						color={colors.secondaryText}
-						strokeWidth={2.1}
-					/>
+					<ChevronDown size={20} color={chevronColor} strokeWidth={2.1} />
 				</View>
 			</TouchableOpacity>
 			{isExpanded ? children : null}
@@ -178,6 +175,7 @@ export function TheoryTopicPage({
 					<TheoryTopicIntroduction topic={topic} />
 
 					<CollapsibleTheorySection
+						chevronColor={colors.secondaryText}
 						title={presentation.sectionTitle}
 						icon={
 							<BookOpen
@@ -212,6 +210,7 @@ export function TheoryTopicPage({
 
 					{presentation.showExample && topic.example ? (
 						<CollapsibleTheorySection
+							chevronColor={colors.secondaryText}
 							className="rounded-[32px] border border-primary/20 bg-system-subtle px-5 py-5"
 							title="Beispiel"
 							icon={
@@ -230,6 +229,7 @@ export function TheoryTopicPage({
 
 					{presentation.showMemoryCue && topic.memoryCue ? (
 						<CollapsibleTheorySection
+							chevronColor={colors.secondaryText}
 							className="rounded-[32px] bg-theorie-subtle px-5 py-5"
 							title="Merksatz"
 							icon={
@@ -248,6 +248,7 @@ export function TheoryTopicPage({
 
 					{presentation.showCommonMistake && topic.commonMistake ? (
 						<CollapsibleTheorySection
+							chevronColor={colors.secondaryText}
 							className="rounded-[32px] bg-wrong-subtle px-5 py-5"
 							title="Typischer Fehler"
 							icon={

--- a/src/features/learning-plans/theory-topic-page.tsx
+++ b/src/features/learning-plans/theory-topic-page.tsx
@@ -105,7 +105,7 @@ function CollapsibleTheorySection({
 	icon: React.ReactNode;
 	title: string;
 }) {
-	const [isExpanded, setIsExpanded] = useState(true);
+	const [isExpanded, setIsExpanded] = useState(false);
 	const { colors } = useDayovaTheme();
 
 	return (

--- a/src/features/learning-plans/theory-topic-page.ui.test.tsx
+++ b/src/features/learning-plans/theory-topic-page.ui.test.tsx
@@ -1,0 +1,167 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import type { SessionContentItem } from "./types";
+import { TheoryTopicPage } from "./theory-topic-page";
+
+jest.mock("react-native-reanimated", () => {
+	const Native =
+		jest.requireActual<typeof import("react-native")>("react-native");
+	return {
+		__esModule: true,
+		default: { View: Native.View },
+		FadeInDown: { duration: () => undefined },
+		LinearTransition: { duration: () => undefined },
+		useReducedMotion: () => true,
+	};
+});
+
+jest.mock("react-native-safe-area-context", () => ({
+	useSafeAreaInsets: () => ({ bottom: 0, left: 0, right: 0, top: 0 }),
+}));
+
+jest.mock("~/components/ui/icon", () => {
+	const React = jest.requireActual<typeof import("react")>("react");
+	const Native =
+		jest.requireActual<typeof import("react-native")>("react-native");
+	const Icon = (props: Record<string, unknown>) =>
+		React.createElement(Native.View, props);
+
+	return new Proxy(
+		{ __esModule: true },
+		{
+			get: (target, property) =>
+				property in target ? target[property as keyof typeof target] : Icon,
+		},
+	);
+});
+
+jest.mock("~/lib/theme", () => ({
+	useDayovaTheme: () => ({
+		colors: {
+			light1: "#FFFFFF",
+			secondaryText: "#697586",
+		},
+	}),
+}));
+
+const item: SessionContentItem = {
+	id: "content-item" as SessionContentItem["id"],
+	sessionId: "session" as SessionContentItem["sessionId"],
+	phase: "theory",
+	kind: "learnCard",
+	title: "IT-Schadensszenarien",
+	prompt: "Was könnte schlimmstenfalls passieren?",
+	front: "Was könnte schlimmstenfalls passieren?",
+	back: "Ein Ausfall kann den Betrieb unterbrechen.",
+	explanation: "Ein Ausfall kann den Betrieb unterbrechen.",
+	idealAnswer: "Schütze zuerst die geschäftskritischen Systeme.",
+	choices: [],
+	learningBlockIndex: 0,
+	topicId: "it-schadensszenarien",
+	questionAngle: "overview",
+	coverageKey: "it-schadensszenarien:overview:0",
+	estimatedSeconds: 40,
+	sortOrder: 0,
+	theoryContent: {
+		conceptTitle: "IT-Schadensszenarien",
+		question:
+			"Was könnte schlimmstenfalls passieren, wenn ein Firmenserver plötzlich ausfällt?",
+		explanation: "Der Betrieb kann vollständig zum Stillstand kommen.",
+		keyPoints: [
+			"Mitarbeitende können nicht mehr auf wichtige Daten zugreifen.",
+		],
+		example: "Ein Onlineshop kann keine Bestellungen mehr verarbeiten.",
+		memoryCue: "Kritische Systeme brauchen einen Wiederanlaufplan.",
+		commonMistake: "Nur den technischen Schaden zu betrachten.",
+	},
+};
+
+describe("TheoryTopicPage", () => {
+	test("uses the question as the plain page heading without a read control", async () => {
+		const screen = await render(
+			<TheoryTopicPage
+				currentIndex={0}
+				isCompleting={false}
+				item={item}
+				onNext={() => undefined}
+				onPrevious={() => undefined}
+				total={1}
+			/>,
+		);
+
+		const heading = screen.getByRole("header");
+		expect(heading).toHaveTextContent(item.theoryContent?.question ?? "");
+		expect(heading.props.className).not.toContain("bg-");
+		expect(screen.queryByText("IT-Schadensszenarien")).toBeNull();
+		expect(screen.queryByText("Leitfrage")).toBeNull();
+		expect(screen.queryByRole("button", { name: /vorlesen/i })).toBeNull();
+	});
+
+	test("lets every theory section collapse and expand independently", async () => {
+		const screen = await render(
+			<TheoryTopicPage
+				currentIndex={0}
+				isCompleting={false}
+				item={item}
+				onNext={() => undefined}
+				onPrevious={() => undefined}
+				total={1}
+			/>,
+		);
+
+		const sections = [
+			["Das solltest du wissen", item.theoryContent?.explanation],
+			["Beispiel", item.theoryContent?.example],
+			["Merksatz", item.theoryContent?.memoryCue],
+			["Typischer Fehler", item.theoryContent?.commonMistake],
+		] as const;
+
+		for (const [title, content] of sections) {
+			expect(content).toBeDefined();
+			expect(screen.getByText(content ?? "")).toBeOnTheScreen();
+
+			fireEvent.press(
+				screen.getByRole("button", { name: `${title} einklappen` }),
+			);
+			await waitFor(() => expect(screen.queryByText(content ?? "")).toBeNull());
+			expect(
+				screen.getByRole("button", { name: `${title} ausklappen` }).props
+					.accessibilityState,
+			).toEqual({ expanded: false });
+
+			fireEvent.press(
+				screen.getByRole("button", { name: `${title} ausklappen` }),
+			);
+			await waitFor(() =>
+				expect(screen.getByText(content ?? "")).toBeOnTheScreen(),
+			);
+		}
+	});
+
+	test("also makes the focused Kernidee section collapsible", async () => {
+		const focusedItem = { ...item, questionAngle: "recall" };
+		const screen = await render(
+			<TheoryTopicPage
+				currentIndex={0}
+				isCompleting={false}
+				item={focusedItem}
+				onNext={() => undefined}
+				onPrevious={() => undefined}
+				total={1}
+			/>,
+		);
+
+		fireEvent.press(
+			screen.getByRole("button", { name: "Kernidee einklappen" }),
+		);
+		await waitFor(() =>
+			expect(
+				screen.queryByText(item.theoryContent?.explanation ?? ""),
+			).toBeNull(),
+		);
+		expect(
+			screen.getByRole("button", { name: "Kernidee ausklappen" }).props
+				.accessibilityState,
+		).toEqual({ expanded: false });
+	});
+});

--- a/src/features/learning-plans/theory-topic-page.ui.test.tsx
+++ b/src/features/learning-plans/theory-topic-page.ui.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, jest, test } from "@jest/globals";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import type { SessionContentItem } from "./types";
 import { TheoryTopicPage } from "./theory-topic-page";
@@ -36,13 +36,17 @@ jest.mock("~/components/ui/icon", () => {
 });
 
 jest.mock("~/lib/theme", () => ({
-	useDayovaTheme: () => ({
+	useDayovaTheme: jest.fn(() => ({
 		colors: {
 			light1: "#FFFFFF",
 			secondaryText: "#697586",
 		},
-	}),
+	})),
 }));
+
+const mockUseDayovaTheme = jest.requireMock<{
+	useDayovaTheme: jest.Mock;
+}>("~/lib/theme").useDayovaTheme;
 
 const item: SessionContentItem = {
 	id: "content-item" as SessionContentItem["id"],
@@ -77,6 +81,10 @@ const item: SessionContentItem = {
 };
 
 describe("TheoryTopicPage", () => {
+	beforeEach(() => {
+		mockUseDayovaTheme.mockClear();
+	});
+
 	test("uses the question as the plain page heading without a read control", async () => {
 		const screen = await render(
 			<TheoryTopicPage
@@ -95,6 +103,7 @@ describe("TheoryTopicPage", () => {
 		expect(screen.queryByText("IT-Schadensszenarien")).toBeNull();
 		expect(screen.queryByText("Leitfrage")).toBeNull();
 		expect(screen.queryByRole("button", { name: /vorlesen/i })).toBeNull();
+		expect(mockUseDayovaTheme).toHaveBeenCalledTimes(1);
 	});
 
 	test("starts every theory section collapsed and toggles independently", async () => {

--- a/src/features/learning-plans/theory-topic-page.ui.test.tsx
+++ b/src/features/learning-plans/theory-topic-page.ui.test.tsx
@@ -97,7 +97,7 @@ describe("TheoryTopicPage", () => {
 		expect(screen.queryByRole("button", { name: /vorlesen/i })).toBeNull();
 	});
 
-	test("lets every theory section collapse and expand independently", async () => {
+	test("starts every theory section collapsed and toggles independently", async () => {
 		const screen = await render(
 			<TheoryTopicPage
 				currentIndex={0}
@@ -118,12 +118,7 @@ describe("TheoryTopicPage", () => {
 
 		for (const [title, content] of sections) {
 			expect(content).toBeDefined();
-			expect(screen.getByText(content ?? "")).toBeOnTheScreen();
-
-			fireEvent.press(
-				screen.getByRole("button", { name: `${title} einklappen` }),
-			);
-			await waitFor(() => expect(screen.queryByText(content ?? "")).toBeNull());
+			expect(screen.queryByText(content ?? "")).toBeNull();
 			expect(
 				screen.getByRole("button", { name: `${title} ausklappen` }).props
 					.accessibilityState,
@@ -135,10 +130,19 @@ describe("TheoryTopicPage", () => {
 			await waitFor(() =>
 				expect(screen.getByText(content ?? "")).toBeOnTheScreen(),
 			);
+			expect(
+				screen.getByRole("button", { name: `${title} einklappen` }).props
+					.accessibilityState,
+			).toEqual({ expanded: true });
+
+			fireEvent.press(
+				screen.getByRole("button", { name: `${title} einklappen` }),
+			);
+			await waitFor(() => expect(screen.queryByText(content ?? "")).toBeNull());
 		}
 	});
 
-	test("also makes the focused Kernidee section collapsible", async () => {
+	test("also starts the focused Kernidee section collapsed", async () => {
 		const focusedItem = { ...item, questionAngle: "recall" };
 		const screen = await render(
 			<TheoryTopicPage
@@ -151,17 +155,21 @@ describe("TheoryTopicPage", () => {
 			/>,
 		);
 
-		fireEvent.press(
-			screen.getByRole("button", { name: "Kernidee einklappen" }),
-		);
-		await waitFor(() =>
-			expect(
-				screen.queryByText(item.theoryContent?.explanation ?? ""),
-			).toBeNull(),
-		);
+		expect(
+			screen.queryByText(item.theoryContent?.explanation ?? ""),
+		).toBeNull();
 		expect(
 			screen.getByRole("button", { name: "Kernidee ausklappen" }).props
 				.accessibilityState,
 		).toEqual({ expanded: false });
+
+		fireEvent.press(
+			screen.getByRole("button", { name: "Kernidee ausklappen" }),
+		);
+		await waitFor(() =>
+			expect(
+				screen.getByText(item.theoryContent?.explanation ?? ""),
+			).toBeOnTheScreen(),
+		);
 	});
 });

--- a/src/features/learning-plans/theory-topic.test.ts
+++ b/src/features/learning-plans/theory-topic.test.ts
@@ -2,11 +2,9 @@ import { describe, expect, test } from "vitest";
 import type { SessionContentItem } from "./types";
 import {
 	adaptTheoryTopic,
-	buildTheorySpeechText,
 	getTheoryPagePresentation,
 	getTheoryTopicNavigation,
 	runTheoryTopicPrimaryAction,
-	splitTheorySpeechText,
 } from "./theory-topic";
 
 const baseItem: SessionContentItem = {
@@ -87,22 +85,6 @@ describe("theory topic adaptation", () => {
 	});
 });
 
-test("speech text includes every visible topic section in reading order", () => {
-	const speechText = buildTheorySpeechText({
-		conceptTitle: "Äquivalenzumformungen",
-		question: "Warum bleibt die Lösungsmenge gleich?",
-		explanation: "Auf beiden Seiten wird dieselbe Operation ausgeführt.",
-		keyPoints: ["Arbeite schrittweise.", "Mache eine Probe."],
-		example: "x plus 3 ist 7, also ist x gleich 4.",
-		memoryCue: "Links und rechts gehören zusammen.",
-		commonMistake: "Nur eine Seite verändern.",
-	});
-
-	expect(speechText).toBe(
-		"Äquivalenzumformungen. Leitfrage: Warum bleibt die Lösungsmenge gleich? Erklärung: Auf beiden Seiten wird dieselbe Operation ausgeführt. Wichtig: Arbeite schrittweise. Mache eine Probe. Beispiel: x plus 3 ist 7, also ist x gleich 4. Merksatz: Links und rechts gehören zusammen. Typischer Fehler: Nur eine Seite verändern.",
-	);
-});
-
 test("focused theory pages only expose the sections needed for their role", () => {
 	expect(getTheoryPagePresentation("recall")).toMatchObject({
 		sectionTitle: "Kernidee",
@@ -120,36 +102,6 @@ test("focused theory pages only expose the sections needed for their role", () =
 		sectionTitle: "Darauf musst du achten",
 		showCommonMistake: true,
 	});
-});
-
-test("speech follows the focused page presentation", () => {
-	const speechText = buildTheorySpeechText(
-		{
-			conceptTitle: "Äquivalenzumformungen",
-			question: "Wie bleibt die Gleichung im Gleichgewicht?",
-			explanation: "Beide Seiten werden gleich behandelt.",
-			keyPoints: ["Führe dieselbe Operation aus."],
-			example: "Aus x plus 3 gleich 7 wird x gleich 4.",
-			memoryCue: "Links und rechts gehören zusammen.",
-			commonMistake: "Nur eine Seite verändern.",
-		},
-		"apply",
-	);
-
-	expect(speechText).toContain("Beispiel:");
-	expect(speechText).toContain("Merksatz:");
-	expect(speechText).not.toContain("Wichtig:");
-	expect(speechText).not.toContain("Typischer Fehler:");
-});
-
-test("speech chunks preserve the complete topic within the platform limit", () => {
-	const speechText =
-		"Äquivalenzumformungen. Leitfrage: Warum bleibt die Lösungsmenge gleich? Erklärung: Beide Seiten werden gleich behandelt.";
-	const chunks = splitTheorySpeechText(speechText, 48);
-
-	expect(chunks.length).toBeGreaterThan(1);
-	expect(chunks.every((chunk) => chunk.length <= 48)).toBe(true);
-	expect(chunks.join(" ")).toBe(speechText);
 });
 
 describe("theory topic navigation", () => {

--- a/src/features/learning-plans/theory-topic.ts
+++ b/src/features/learning-plans/theory-topic.ts
@@ -87,52 +87,6 @@ export const adaptTheoryTopic = (
 	};
 };
 
-export const buildTheorySpeechText = (
-	topic: TheoryTopic,
-	questionAngle?: string,
-) => {
-	const presentation = getTheoryPagePresentation(questionAngle);
-	return [
-		topic.conceptTitle,
-		`Leitfrage: ${topic.question}`,
-		`Erklärung: ${topic.explanation}`,
-		presentation.showKeyPoints && topic.keyPoints.length > 0
-			? `Wichtig: ${topic.keyPoints.join(" ")}`
-			: undefined,
-		presentation.showExample && topic.example
-			? `Beispiel: ${topic.example}`
-			: undefined,
-		presentation.showMemoryCue && topic.memoryCue
-			? `Merksatz: ${topic.memoryCue}`
-			: undefined,
-		presentation.showCommonMistake && topic.commonMistake
-			? `Typischer Fehler: ${topic.commonMistake}`
-			: undefined,
-	]
-		.filter((section): section is string => Boolean(section))
-		.map((section) => (/[.!?]$/.test(section) ? section : `${section}.`))
-		.join(" ");
-};
-
-export const splitTheorySpeechText = (text: string, maximumLength: number) => {
-	const remainingText = text.trim();
-	const safeMaximumLength = Math.max(1, Math.floor(maximumLength));
-	if (remainingText.length <= safeMaximumLength) return [remainingText];
-
-	const chunks: string[] = [];
-	let remaining = remainingText;
-	while (remaining.length > safeMaximumLength) {
-		const candidate = remaining.slice(0, safeMaximumLength + 1);
-		const lastWhitespace = candidate.lastIndexOf(" ");
-		const splitIndex = lastWhitespace > 0 ? lastWhitespace : safeMaximumLength;
-		chunks.push(remaining.slice(0, splitIndex).trimEnd());
-		remaining = remaining.slice(splitIndex).trimStart();
-	}
-
-	if (remaining) chunks.push(remaining);
-	return chunks;
-};
-
 export const getTheoryTopicNavigation = (
 	currentIndex: number,
 	total: number,


### PR DESCRIPTION
## Summary
- use the theory question as the plain page heading and remove the duplicate concept title/card treatment
- remove the read-aloud control and the now-unused expo-speech dependency
- start every theory content section collapsed and let each section expand independently with accessible state and action labels
- resolve theme state once at the page boundary so repeated disclosures stay navigation-agnostic and do not trigger the reported missing NavigationContainer context
- add focused UI coverage for the heading, collapsed initial state, disclosure behavior, and single theme-context read

## Validation
- pnpm check (passes; one pre-existing unused-import warning in src/features/auth/dayova-auth-flow.tsx)
- pnpm typecheck
- targeted theory UI tests: 3 passed
- targeted theory unit tests: 6 passed
- full unit suite: 101 files / 627 tests passed
- full UI suite: 111 passed, 3 pre-existing unrelated failures in onboarding/setup tests
- fresh cache-cleared iOS bundle starts without the reported navigation-context error
- disclosure layout and expanded/collapsed states inspected on iPhone 17 / iOS 26.5
- remaining simulator console error is an unrelated Convex notifications:recordDeliveredNotification failure
- Android not inspected because no emulator was connected