### PR TITLE
Keep learning plans active until mastery

### DIFF
--- a/convex/adaptiveLearningPlan.ts
+++ b/convex/adaptiveLearningPlan.ts
@@ -421,13 +421,12 @@ export const advanceRollingLearningPlan = async (
 		),
 		...diagnosticReadiness,
 	];
-	const committedTarget =
-		selectNextAdaptiveLearningTarget({
-			topics,
-			initialReadiness: effectiveTopicReadiness,
-			evidence,
-			history,
-		}) ?? selectAdaptiveMaintenanceTarget({ topics, history });
+	const committedTarget = selectNextAdaptiveLearningTarget({
+		topics,
+		initialReadiness: effectiveTopicReadiness,
+		evidence,
+		history,
+	});
 	const provisionalSessions = sessions.filter(
 		(session) =>
 			session.planningStatus === "provisional" &&
@@ -443,6 +442,9 @@ export const advanceRollingLearningPlan = async (
 		if (provisional) await removeRollingSession(ctx, provisional);
 		await ctx.db.patch("learningPlans", plan._id, {
 			adaptationRevision,
+			masteryStatus: "mastered",
+			topicReadiness: effectiveTopicReadiness,
+			contentGenerationStage: "ready",
 			updatedAt: Date.now(),
 		});
 		return { committedSessionId: null, provisionalSessionId: null };
@@ -533,7 +535,16 @@ export const advanceRollingLearningPlan = async (
 			}
 		}
 	}
-	if (!committed) return null;
+	if (!committed) {
+		await ctx.db.patch("learningPlans", plan._id, {
+			adaptationRevision,
+			masteryStatus: "learning",
+			topicReadiness: effectiveTopicReadiness,
+			contentGenerationStage: "ready",
+			updatedAt: Date.now(),
+		});
+		return null;
+	}
 	const projectedHistory = [
 		...history,
 		{
@@ -601,6 +612,7 @@ export const advanceRollingLearningPlan = async (
 	}
 	await ctx.db.patch("learningPlans", plan._id, {
 		adaptationRevision,
+		masteryStatus: "learning",
 		topicReadiness: effectiveTopicReadiness,
 		contentGenerationStage: "ready",
 		updatedAt: Date.now(),

--- a/convex/firstSessionDiagnostic.test.ts
+++ b/convex/firstSessionDiagnostic.test.ts
@@ -526,6 +526,10 @@ test("does not invent a rolling slot when no learning time is saved", async () =
 		rollingWindow: true,
 		sessions: generatedSlots,
 	});
+	await t.mutation(internal.learningPlans.finalizeContentGeneration, {
+		learningPlanId,
+	});
+	await t.mutation(api.learningPlans.acceptPlan, { learningPlanId });
 	const initial = await t.query(api.learningPlans.getSnapshot, {
 		id: learningPlanId,
 	});
@@ -549,6 +553,42 @@ test("does not invent a rolling slot when no learning time is saved", async () =
 			(session) => session.planningStatus === "provisional",
 		),
 	).toBe(false);
+
+	const repeatSessionId = openSessions?.[0]?.id;
+	if (!repeatSessionId) throw new Error("Expected a committed repeat session.");
+	await t.mutation(api.learningPlans.setSessionCompleted, {
+		sessionId: repeatSessionId,
+		completed: true,
+	});
+	const [overview] = await t.query(api.learningPlans.listOverview, {});
+	expect(overview).toMatchObject({
+		id: learningPlanId,
+		completedCount: 2,
+		sessionCount: 2,
+		upcomingSessionCount: 0,
+		masteryStatus: "learning",
+	});
+
+	await t.mutation(api.learningTimes.upsertMine, {
+		dayOfWeek: 3,
+		startTime: "17:00",
+		endTime: "18:00",
+	});
+	await expect(
+		t.mutation(api.learningPlans.ensureNextRepeat, { learningPlanId }),
+	).resolves.toMatchObject({ status: "scheduled" });
+	const resumed = await t.query(api.learningPlans.getSnapshot, {
+		id: learningPlanId,
+	});
+	expect(
+		resumed?.sessions.find(
+			(session) => session.planningStatus === "committed" && !session.completed,
+		),
+	).toMatchObject({
+		dateKey: "2026-06-03",
+		startTime: "17:00",
+		targetEvidenceDimension: "understanding",
+	});
 });
 
 test("requires every diagnostic answer before the rolling plan can advance", async () => {

--- a/convex/learningPlans.ts
+++ b/convex/learningPlans.ts
@@ -1212,6 +1212,9 @@ export const getSnapshot = query({
 					hasLearningTimes: learningTimes.length > 0,
 				}),
 				rollingPlanEnabled: plan.rollingPlanEnabled,
+				masteryStatus:
+					plan.masteryStatus ??
+					(plan.rollingPlanEnabled ? ("learning" as const) : undefined),
 				adaptationRevision: plan.adaptationRevision,
 				sessionCompositionVariant: plan.sessionCompositionVariant,
 				contentGeneration: plan.contentGenerationStage
@@ -1286,6 +1289,9 @@ export const listOverview = query({
 			).length;
 			const hasOpenRollingWindow =
 				plan.rollingPlanEnabled === true && upcomingSessionCount > 0;
+			const masteryStatus =
+				plan.masteryStatus ??
+				(plan.rollingPlanEnabled ? ("learning" as const) : undefined);
 			const currentSession =
 				sessions.find(
 					(session) =>
@@ -1317,9 +1323,9 @@ export const listOverview = query({
 						)
 					: 0;
 			const progressPercent = plan.rollingPlanEnabled
-				? hasOpenRollingWindow
-					? Math.min(99, rollingProgressPercent)
-					: rollingProgressPercent
+				? masteryStatus === "mastered"
+					? 100
+					: Math.min(99, rollingProgressPercent)
 				: sessions.length > 0
 					? Math.round((completedCount / sessions.length) * 100)
 					: 0;
@@ -1336,6 +1342,7 @@ export const listOverview = query({
 				sessionCount: sessions.length,
 				upcomingSessionCount,
 				rollingPlanEnabled: plan.rollingPlanEnabled === true,
+				masteryStatus,
 				hasOpenRollingWindow,
 				examDateKey: plan.examDateKey,
 				examDateLabel: plan.examDateLabel,
@@ -2159,6 +2166,7 @@ export const replaceGeneratedSessions = internalMutation({
 			sourceSummary: normalizedSourceSummary,
 			insight: normalizedInsight,
 			rollingPlanEnabled: rollingWindow,
+			masteryStatus: rollingWindow ? "learning" : undefined,
 			adaptationRevision,
 			sessionCompositionVariant: args.sessionCompositionVariant ?? "split",
 			status: args.deferReadyUntilContent ? "questionsReady" : "generated",
@@ -2563,6 +2571,69 @@ const advanceOwnedRollingLearningPlan = (
 		clearSession: clearSessionDayEntry,
 		syncSession: syncSessionDayEntry,
 	});
+
+export const ensureNextRepeat = mutation({
+	args: {
+		learningPlanId: v.id("learningPlans"),
+	},
+	returns: v.object({
+		status: v.union(
+			v.literal("notAdaptive"),
+			v.literal("scheduled"),
+			v.literal("mastered"),
+			v.literal("needsLearningTime"),
+		),
+		sessionId: v.union(v.id("learningPlanSessions"), v.null()),
+	}),
+	handler: async (ctx, args) => {
+		const ownerTokenIdentifier =
+			await requireOwnerTokenIdentifierForMutation(ctx);
+		const plan = await ctx.db.get("learningPlans", args.learningPlanId);
+		if (!plan || plan.ownerTokenIdentifier !== ownerTokenIdentifier) {
+			throwUserFacingError("Lernplan nicht gefunden.");
+		}
+		if (!plan.rollingPlanEnabled || plan.status !== "accepted") {
+			return { status: "notAdaptive" as const, sessionId: null };
+		}
+
+		const sessions = await ctx.db
+			.query("learningPlanSessions")
+			.withIndex("by_learningPlanId_and_sortOrder", (q) =>
+				q.eq("learningPlanId", args.learningPlanId),
+			)
+			.order("asc")
+			.take(50);
+		const openCommittedSession = sessions.find(
+			(session) =>
+				session.planningStatus !== "provisional" &&
+				["notStarted", "started"].includes(getSessionExecutionStatus(session)),
+		);
+		if (openCommittedSession) {
+			return {
+				status: "scheduled" as const,
+				sessionId: openCommittedSession._id,
+			};
+		}
+
+		const update = await advanceOwnedRollingLearningPlan(ctx, plan);
+		if (update?.committedSessionId) {
+			return {
+				status: "scheduled" as const,
+				sessionId: update.committedSessionId,
+			};
+		}
+
+		const updatedPlan = await ctx.db.get("learningPlans", args.learningPlanId);
+		return {
+			status:
+				updatedPlan?.masteryStatus === "mastered"
+					? ("mastered" as const)
+					: ("needsLearningTime" as const),
+			sessionId: null,
+		};
+	},
+});
+
 export const startSession = mutation({
 	args: {
 		sessionId: v.id("learningPlanSessions"),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -111,6 +111,11 @@ const learningPlanSessionPlanningStatusValidator = v.union(
 	v.literal("provisional"),
 );
 
+const learningPlanMasteryStatusValidator = v.union(
+	v.literal("learning"),
+	v.literal("mastered"),
+);
+
 const sessionContentItemKindValidator = v.union(
 	v.literal("learnCard"),
 	v.literal("multipleChoice"),
@@ -411,6 +416,7 @@ export default defineSchema({
 		insight: v.optional(planInsightValidator),
 		planningHint: v.optional(v.string()),
 		rollingPlanEnabled: v.optional(v.boolean()),
+		masteryStatus: v.optional(learningPlanMasteryStatusValidator),
 		adaptationRevision: v.optional(v.number()),
 		contentGenerationStage: v.optional(contentGenerationStageValidator),
 		contentGenerationId: v.optional(v.string()),

--- a/src/app/(app)/learning-plans.tsx
+++ b/src/app/(app)/learning-plans.tsx
@@ -38,6 +38,7 @@ import { ThemedStatusBar } from "~/components/ui/themed-status-bar";
 import { useAuthSession } from "~/context/AuthContext";
 import { learningPlanResumePath } from "~/features/learning-plans/creation-routes";
 import { LearningPlanCardFooter } from "~/features/learning-plans/learning-plan-card-footer";
+import { getLearningPlanStatus } from "~/features/learning-plans/learning-plan-status";
 import { MaterialRequiredSheet } from "~/features/learning-plans/material-required-sheet";
 import { getRollingLearningWindowLabel } from "~/features/learning-plans/rolling-learning-window";
 import { createAsyncActionGate } from "~/lib/async-action-gate";
@@ -72,6 +73,8 @@ type LearningPlanOverview = {
 	completedCount?: number;
 	sessionCount?: number;
 	upcomingSessionCount?: number;
+	rollingPlanEnabled?: boolean;
+	masteryStatus?: "learning" | "mastered";
 	examDateKey?: string;
 	examDateLabel?: string;
 	currentSession?: {
@@ -156,52 +159,6 @@ const getHomeworkStatus = (
 		};
 	}
 	if (remainingDays === 1) {
-		return {
-			label: "Morgen",
-			background: STATUS_NEUTRAL_BACKGROUND,
-			foreground: DAYOVA_DESIGN_SYSTEM.colors.primary,
-		};
-	}
-	return {
-		label: "Geplant",
-		background: STATUS_NEUTRAL_BACKGROUND,
-		foreground: DAYOVA_DESIGN_SYSTEM.colors.primary,
-	};
-};
-
-const getStatus = (
-	plan: LearningPlanOverview,
-	todayKey: string,
-): { label: string; background: string; foreground: string } => {
-	const sessionCount = plan.sessionCount ?? 0;
-	const completedCount = plan.completedCount ?? 0;
-	if (sessionCount > 0 && completedCount >= sessionCount) {
-		return {
-			label: "Fertig",
-			background: DAYOVA_DESIGN_SYSTEM.colors.successSubtle,
-			foreground: DAYOVA_DESIGN_SYSTEM.colors.success,
-		};
-	}
-
-	const sessionKey = plan.currentSession?.dateKey;
-	const daysUntilSession = sessionKey
-		? differenceInCalendarDays(sessionKey, todayKey)
-		: null;
-	if (daysUntilSession !== null && daysUntilSession < 0) {
-		return {
-			label: "Fällig",
-			background: STATUS_DUE_BACKGROUND,
-			foreground: STATUS_DUE_FOREGROUND,
-		};
-	}
-	if (daysUntilSession === 0) {
-		return {
-			label: "Heute",
-			background: STATUS_NEUTRAL_BACKGROUND,
-			foreground: DAYOVA_DESIGN_SYSTEM.colors.primary,
-		};
-	}
-	if (daysUntilSession === 1) {
 		return {
 			label: "Morgen",
 			background: STATUS_NEUTRAL_BACKGROUND,
@@ -437,7 +394,7 @@ function LearningPlanCard({
 				background: STATUS_NEUTRAL_BACKGROUND,
 				foreground: DAYOVA_DESIGN_SYSTEM.colors.primary,
 			}
-		: getStatus(plan, todayKey);
+		: getLearningPlanStatus(plan, todayKey);
 	const remainingDays = Math.max(
 		0,
 		plan.examDateKey

--- a/src/app/learning-plans/[planId]/index.tsx
+++ b/src/app/learning-plans/[planId]/index.tsx
@@ -1,4 +1,4 @@
-import { useAction, useConvexAuth, useQuery } from "convex/react";
+import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import {
 	type ReactNode,
@@ -69,6 +69,7 @@ import { parseDayKey, useCurrentLocalDay } from "~/lib/day-key";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 import { formatGermanUiText } from "~/lib/german-ui-text";
 import { dismissToOrReplace } from "~/lib/navigation";
+import { ROUTES, withReturnTo } from "~/lib/routes";
 import { useDayovaTheme } from "~/lib/theme";
 
 const PHASE_LABEL: Record<PlanSession["phase"], string> = {
@@ -688,6 +689,7 @@ function PathNode({
 export function LearningPath({
 	examCountdownLabel,
 	examDateLabel,
+	onAddLearningTime,
 	onOpenSession,
 	onSelectSession,
 	selectedSessionId,
@@ -696,6 +698,7 @@ export function LearningPath({
 }: {
 	examCountdownLabel: string | null;
 	examDateLabel: string;
+	onAddLearningTime?: () => void;
 	onOpenSession: (session: PlanSession) => void;
 	onSelectSession: (session: PlanSession) => void;
 	selectedSessionId: Id<"learningPlanSessions"> | null;
@@ -711,8 +714,16 @@ export function LearningPath({
 	);
 	const continuationTop = continuationEndpoint.y + 16;
 	const basePathHeight = getFigmaPathHeight(sessions.length);
+	const hasScheduledContinuation = sessions.some(
+		(session) => !isLearningPlanSessionHistory(session),
+	);
+	const needsLearningTime =
+		showsAdaptiveContinuation && !hasScheduledContinuation;
 	const pathHeight = showsAdaptiveContinuation
-		? Math.max(basePathHeight, continuationTop + 220)
+		? Math.max(
+				basePathHeight,
+				continuationTop + (needsLearningTime ? 280 : 220),
+			)
 		: basePathHeight;
 	const segments = sessions.slice(1).map((_, index) => ({
 		d: getFigmaSegmentPath(index),
@@ -807,8 +818,12 @@ export function LearningPath({
 
 			{showsAdaptiveContinuation ? (
 				<View
-					accessible
-					accessibilityLabel={`Dayova plant mit dir weiter. Nach deinem Abschluss passt Dayova die Vorschau an und plant den nächsten Termin. Prüfung am ${examDateLabel}${examCountdownLabel ? `, ${examCountdownLabel}` : ""}.`}
+					accessible={!needsLearningTime}
+					accessibilityLabel={
+						needsLearningTime
+							? undefined
+							: `Dayova plant mit dir weiter. Nach deinem Abschluss passt Dayova die Vorschau an und plant den nächsten Termin. Prüfung am ${examDateLabel}${examCountdownLabel ? `, ${examCountdownLabel}` : ""}.`
+					}
 					className="absolute right-2 left-2 gap-4 overflow-hidden rounded-card border border-primary/20 bg-system-subtle px-4 py-4"
 					// The card is positioned against the generated path geometry; the
 					// continuous curve has no NativeWind utility.
@@ -825,12 +840,25 @@ export function LearningPath({
 						</View>
 						<View className="min-w-0 flex-1">
 							<Text className="font-poppins font-semibold text-body-3 text-text">
-								Dayova plant mit dir weiter
+								{needsLearningTime
+									? "Wiederholung offen"
+									: "Dayova plant mit dir weiter"}
 							</Text>
 							<Text className="mt-1 font-poppins text-body-4 text-secondary-text">
-								Nach deinem Abschluss passt Dayova die Vorschau an und plant den
-								nächsten Termin.
+								{needsLearningTime
+									? "Dein Wissen ist noch nicht sicher. Ergänze eine Lernzeit vor der Prüfung, damit Dayova die nächste Wiederholung planen kann."
+									: "Nach deinem Abschluss passt Dayova die Vorschau an und plant den nächsten Termin."}
 							</Text>
+							{needsLearningTime && onAddLearningTime ? (
+								<Button
+									accessibilityLabel="Lernzeit für die nächste Wiederholung ergänzen"
+									className="mt-3 self-start"
+									size="sm"
+									onPress={onAddLearningTime}
+								>
+									<Text>Lernzeit ergänzen</Text>
+								</Button>
+							) : null}
 						</View>
 					</View>
 
@@ -880,7 +908,11 @@ export default function LearningPlanSessionsScreen() {
 	const ensureSessionContent = useAction(
 		api.learningPlanAi.ensureSessionContent,
 	);
+	const ensureNextRepeat = useMutation(api.learningPlans.ensureNextRepeat);
 	const preparingSessionIdRef = useRef<Id<"learningPlanSessions"> | null>(null);
+	const repeatPlanningAttemptedForPlanRef = useRef<Id<"learningPlans"> | null>(
+		null,
+	);
 	const snapshot = (useQuery(
 		api.learningPlans.getSnapshot,
 		user && isConvexAuthenticated && planId ? { id: planId } : "skip",
@@ -921,6 +953,13 @@ export default function LearningPlanSessionsScreen() {
 		!selectedSessionNeedsTheoryUpgrade &&
 		(selectedSession?.contentGenerationStatus === undefined ||
 			selectedSession.contentGenerationStatus === "ready");
+	const needsRepeatScheduling = Boolean(
+		snapshot?.plan.rollingPlanEnabled === true &&
+			snapshot.plan.masteryStatus !== "mastered" &&
+			!snapshot.sessions.some(
+				(session) => !isLearningPlanSessionHistory(session),
+			),
+	);
 	const preparationState =
 		selectedSession?.contentGenerationStatus === "failed"
 			? ("failed" as const)
@@ -946,6 +985,20 @@ export default function LearningPlanSessionsScreen() {
 		},
 		[ensureSessionContent],
 	);
+
+	useEffect(() => {
+		if (
+			!planId ||
+			!needsRepeatScheduling ||
+			repeatPlanningAttemptedForPlanRef.current === planId
+		) {
+			return;
+		}
+		repeatPlanningAttemptedForPlanRef.current = planId;
+		void ensureNextRepeat({ learningPlanId: planId }).catch(() => {
+			// The reactive plan state keeps the repeat affordance available for retry.
+		});
+	}, [ensureNextRepeat, needsRepeatScheduling, planId]);
 
 	useEffect(() => {
 		const needsTheoryUpgrade = Boolean(
@@ -1045,7 +1098,16 @@ export default function LearningPlanSessionsScreen() {
 						selectedSessionId={selectedSession.id}
 						sessions={snapshot.sessions}
 						showsAdaptiveContinuation={
-							snapshot.plan.rollingPlanEnabled === true
+							snapshot.plan.rollingPlanEnabled === true &&
+							snapshot.plan.masteryStatus !== "mastered"
+						}
+						onAddLearningTime={() =>
+							router.push(
+								withReturnTo(
+									ROUTES.learningTimes,
+									`/learning-plans/${snapshot.plan.id}`,
+								),
+							)
 						}
 						onOpenSession={(session) => {
 							if (

--- a/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
@@ -18,13 +18,17 @@ jest.mock("expo-router", () => ({
 jest.mock("convex/react", () => ({
 	useAction: () => jest.fn(),
 	useConvexAuth: () => ({ isAuthenticated: true }),
+	useMutation: () => jest.fn(),
 	useQuery: () => null,
 }));
 
 jest.mock("#convex/_generated/api", () => ({
 	api: {
 		learningPlanAi: { ensureSessionContent: "ensureSessionContent" },
-		learningPlans: { getSnapshot: "getSnapshot" },
+		learningPlans: {
+			ensureNextRepeat: "ensureNextRepeat",
+			getSnapshot: "getSnapshot",
+		},
 	},
 }));
 
@@ -285,6 +289,37 @@ describe("learning-plan path", () => {
 		);
 		expect(onOpenSession).toHaveBeenCalledTimes(1);
 		expect(onSelectSession).toHaveBeenCalledWith(sessions[2]);
+	});
+
+	test("asks for learning time instead of claiming an exhausted plan is finished", async () => {
+		const onAddLearningTime = jest.fn();
+		const sessions = [
+			session("session_done", {
+				completed: true,
+				executionStatus: "completed",
+			}),
+		];
+		const screen = await render(
+			<LearningPath
+				examCountdownLabel="Noch 1 Tag"
+				examDateLabel="15. August 2026"
+				onAddLearningTime={onAddLearningTime}
+				onOpenSession={() => undefined}
+				onSelectSession={() => undefined}
+				selectedSessionId={sessions[0]?.id ?? null}
+				sessions={sessions}
+				showsAdaptiveContinuation
+			/>,
+		);
+
+		expect(screen.getByText("Wiederholung offen")).toBeOnTheScreen();
+		expect(screen.queryByText("Dayova plant mit dir weiter")).toBeNull();
+		await fireEvent.press(
+			screen.getByRole("button", {
+				name: "Lernzeit für die nächste Wiederholung ergänzen",
+			}),
+		);
+		expect(onAddLearningTime).toHaveBeenCalledTimes(1);
 	});
 
 	test("formats the exam countdown for today and future dates", () => {

--- a/src/features/learning-plans/learning-plan-status.test.ts
+++ b/src/features/learning-plans/learning-plan-status.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import {
+	getLearningPlanStatus,
+	type LearningPlanStatusInput,
+} from "./learning-plan-status";
+
+const plan = (
+	overrides: Partial<LearningPlanStatusInput> = {},
+): LearningPlanStatusInput => ({
+	completedCount: 2,
+	sessionCount: 2,
+	...overrides,
+});
+
+describe("adaptive learning plan status", () => {
+	test("does not call an exhausted adaptive plan finished while mastery is still developing", () => {
+		expect(
+			getLearningPlanStatus(
+				plan({ rollingPlanEnabled: true, masteryStatus: "learning" }),
+				"2026-08-14",
+			),
+		).toMatchObject({ label: "Wiederholen" });
+	});
+
+	test("calls an adaptive plan finished only after mastery is verified", () => {
+		expect(
+			getLearningPlanStatus(
+				plan({ rollingPlanEnabled: true, masteryStatus: "mastered" }),
+				"2026-08-14",
+			),
+		).toMatchObject({ label: "Fertig" });
+	});
+});

--- a/src/features/learning-plans/learning-plan-status.ts
+++ b/src/features/learning-plans/learning-plan-status.ts
@@ -1,0 +1,78 @@
+import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
+import { parseDayKey } from "~/lib/day-key";
+
+export type LearningPlanStatusInput = {
+	completedCount?: number;
+	sessionCount?: number;
+	rollingPlanEnabled?: boolean;
+	masteryStatus?: "learning" | "mastered";
+	currentSession?: { dateKey: string } | null;
+};
+
+const differenceInCalendarDays = (laterKey: string, earlierKey: string) => {
+	const later = parseDayKey(laterKey);
+	const earlier = parseDayKey(earlierKey);
+	if (!later || !earlier) return null;
+	return Math.ceil((later.getTime() - earlier.getTime()) / 86_400_000);
+};
+
+export const getLearningPlanStatus = (
+	plan: LearningPlanStatusInput,
+	todayKey: string,
+): { label: string; background: string; foreground: string } => {
+	const sessionCount = plan.sessionCount ?? 0;
+	const completedCount = plan.completedCount ?? 0;
+	const isFinished = plan.rollingPlanEnabled
+		? plan.masteryStatus === "mastered"
+		: sessionCount > 0 && completedCount >= sessionCount;
+	if (isFinished) {
+		return {
+			label: "Fertig",
+			background: DAYOVA_DESIGN_SYSTEM.colors.successSubtle,
+			foreground: DAYOVA_DESIGN_SYSTEM.colors.success,
+		};
+	}
+	if (
+		plan.rollingPlanEnabled &&
+		plan.masteryStatus === "learning" &&
+		sessionCount > 0 &&
+		completedCount >= sessionCount
+	) {
+		return {
+			label: "Wiederholen",
+			background: DAYOVA_DESIGN_SYSTEM.colors.systemSubtle,
+			foreground: DAYOVA_DESIGN_SYSTEM.colors.primary,
+		};
+	}
+
+	const sessionKey = plan.currentSession?.dateKey;
+	const daysUntilSession = sessionKey
+		? differenceInCalendarDays(sessionKey, todayKey)
+		: null;
+	if (daysUntilSession !== null && daysUntilSession < 0) {
+		return {
+			label: "Fällig",
+			background: DAYOVA_DESIGN_SYSTEM.colors.wrongSubtle,
+			foreground: DAYOVA_DESIGN_SYSTEM.colors.wrong,
+		};
+	}
+	if (daysUntilSession === 0) {
+		return {
+			label: "Heute",
+			background: DAYOVA_DESIGN_SYSTEM.colors.systemSubtle,
+			foreground: DAYOVA_DESIGN_SYSTEM.colors.primary,
+		};
+	}
+	if (daysUntilSession === 1) {
+		return {
+			label: "Morgen",
+			background: DAYOVA_DESIGN_SYSTEM.colors.systemSubtle,
+			foreground: DAYOVA_DESIGN_SYSTEM.colors.primary,
+		};
+	}
+	return {
+		label: "Geplant",
+		background: DAYOVA_DESIGN_SYSTEM.colors.systemSubtle,
+		foreground: DAYOVA_DESIGN_SYSTEM.colors.primary,
+	};
+};

--- a/src/features/learning-plans/types.ts
+++ b/src/features/learning-plans/types.ts
@@ -215,6 +215,7 @@ export type LearningPlanSnapshot = {
 		planningHint?: string;
 		diagnosticPlacement?: "firstSession";
 		rollingPlanEnabled?: boolean;
+		masteryStatus?: "learning" | "mastered";
 		adaptationRevision?: number;
 		sessionCompositionVariant?: "control" | "split";
 		contentGeneration?: {


### PR DESCRIPTION
## Summary

- persist mastery separately from scheduled-session counts for rolling learning plans
- keep weak topics active and materialize repeat sessions when learning time becomes available
- show Wiederholen / Wiederholung offen instead of Fertig when the rolling window is exhausted before mastery
- stop adaptive continuation only after every required evidence dimension is mastered

## Root cause

The overview treated completedCount >= sessionCount as completion, even for adaptive plans. When no saved learning slot remained, the adaptive backend could identify the next weak target but did not persist that the plan was still learning or provide a retry path after availability changed.

## Validation

- pnpm vitest run convex/adaptiveLearningPlanPolicy.test.ts convex/firstSessionDiagnostic.test.ts convex/learningPlans.test.ts src/features/learning-plans/learning-plan-status.test.ts (62 passed)
- pnpm jest src/features/learning-plans/learning-plan-path-screen.ui.test.tsx --runInBand (8 passed)
- pnpm test:unit:vitest (616 passed)
- pnpm typecheck
- pnpm lint (one pre-existing unused-variable warning in auth flow)
- CONVEX_AGENT_MODE=anonymous npx convex dev --once

## Validation limitations

- Full UI suite has three unrelated existing accessibility/callback expectation failures outside these files; the affected learning-plan path suite passes.
- Live iOS inspection is blocked by the installed development client missing the already-declared ExpoSpeech native module.
- Local Node is 25.9.0 while the repository declares >=24.3 <25; validation commands still completed successfully.