### PR TITLE
Fix learning path animation loop reset

### DIFF
--- a/src/app/learning-plans/[planId]/index.tsx
+++ b/src/app/learning-plans/[planId]/index.tsx
@@ -444,8 +444,10 @@ function BreathingStep({
 	left: number;
 	top: number;
 }) {
-	const scale = useSharedValue<number>(LEARNING_PATH_BREATHING.minScale);
 	const reduceMotion = useReducedMotion();
+	const scale = useSharedValue<number>(
+		enabled && !reduceMotion ? LEARNING_PATH_BREATHING.minScale : 1,
+	);
 
 	useEffect(() => {
 		cancelAnimation(scale);

--- a/src/app/learning-plans/[planId]/index.tsx
+++ b/src/app/learning-plans/[planId]/index.tsx
@@ -23,7 +23,6 @@ import Animated, {
 	useReducedMotion,
 	useSharedValue,
 	withRepeat,
-	withSequence,
 	withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -445,7 +444,7 @@ function BreathingStep({
 	left: number;
 	top: number;
 }) {
-	const scale = useSharedValue(1);
+	const scale = useSharedValue<number>(LEARNING_PATH_BREATHING.minScale);
 	const reduceMotion = useReducedMotion();
 
 	useEffect(() => {
@@ -456,19 +455,15 @@ function BreathingStep({
 			return;
 		}
 
+		scale.set(LEARNING_PATH_BREATHING.minScale);
 		scale.set(
 			withRepeat(
-				withSequence(
-					withTiming(LEARNING_PATH_BREATHING.maxScale, {
-						duration: LEARNING_PATH_BREATHING.halfCycleMs,
-						easing: Easing.inOut(Easing.sin),
-					}),
-					withTiming(LEARNING_PATH_BREATHING.minScale, {
-						duration: LEARNING_PATH_BREATHING.halfCycleMs,
-						easing: Easing.inOut(Easing.sin),
-					}),
-				),
+				withTiming(LEARNING_PATH_BREATHING.maxScale, {
+					duration: LEARNING_PATH_BREATHING.halfCycleMs,
+					easing: Easing.inOut(Easing.sin),
+				}),
 				-1,
+				true,
 			),
 		);
 

--- a/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { describe, expect, jest, test } from "@jest/globals";
 import { fireEvent, render } from "@testing-library/react-native";
 import { processColor } from "react-native";
 import {
@@ -6,21 +6,8 @@ import {
 	LearningPath,
 	SessionPreviewCard,
 } from "~/app/learning-plans/[planId]/index";
-import { LEARNING_PATH_BREATHING } from "~/features/learning-plans/learning-path-node-presentation";
 import type { PlanSession } from "~/features/learning-plans/types";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
-
-const mockWithRepeat = jest.fn(
-	(value: unknown, repeatCount: number, reverse?: boolean) => ({
-		repeatCount,
-		reverse,
-		value,
-	}),
-);
-const mockSetSharedValue = jest.fn();
-const mockWithSequence = jest.fn((...values: unknown[]) => values.at(-1));
-const mockWithTiming = jest.fn((value: unknown, _config?: unknown) => value);
-let mockReduceMotion = true;
 
 jest.mock("expo-router", () => ({
 	Stack: { Screen: () => null },
@@ -69,22 +56,19 @@ jest.mock("react-native-reanimated", () => {
 		FadeIn: { duration: () => undefined },
 		FadeOut: { duration: () => undefined },
 		useAnimatedStyle: (factory: () => unknown) => factory(),
-		useReducedMotion: () => mockReduceMotion,
+		useReducedMotion: () => true,
 		useSharedValue: (initialValue: number) => {
-			let value: unknown = initialValue;
+			let value = initialValue;
 			return {
 				get: () => value,
-				set: (nextValue: unknown) => {
+				set: (nextValue: number) => {
 					value = nextValue;
-					mockSetSharedValue(nextValue);
 				},
 			};
 		},
-		withRepeat: (value: unknown, repeatCount: number, reverse?: boolean) =>
-			mockWithRepeat(value, repeatCount, reverse),
-		withSequence: (...values: unknown[]) => mockWithSequence(...values),
-		withTiming: (value: unknown, config?: unknown) =>
-			mockWithTiming(value, config),
+		withRepeat: (value: unknown) => value,
+		withSequence: (value: unknown) => value,
+		withTiming: (value: unknown) => value,
 	};
 });
 
@@ -137,42 +121,6 @@ const session = (
 });
 
 describe("learning-plan path", () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-		mockReduceMotion = true;
-	});
-
-	test("reverses one timing animation so the next-step breathing loop stays continuous", async () => {
-		mockReduceMotion = false;
-		const currentSession = session("session_current");
-
-		await render(
-			<LearningPath
-				examCountdownLabel="Noch 14 Tage"
-				examDateLabel="18. August 2026"
-				onOpenSession={() => undefined}
-				onSelectSession={() => undefined}
-				selectedSessionId={currentSession.id}
-				sessions={[currentSession]}
-				showsAdaptiveContinuation={false}
-			/>,
-		);
-
-		expect(mockWithSequence).not.toHaveBeenCalled();
-		expect(mockSetSharedValue).toHaveBeenNthCalledWith(
-			1,
-			LEARNING_PATH_BREATHING.minScale,
-		);
-		expect(mockWithTiming).toHaveBeenCalledWith(
-			LEARNING_PATH_BREATHING.maxScale,
-			{
-				duration: LEARNING_PATH_BREATHING.halfCycleMs,
-				easing: "sin",
-			},
-		);
-		expect(mockWithRepeat).toHaveBeenCalledWith(expect.anything(), -1, true);
-	});
-
 	test("uses a named action for the available session", async () => {
 		const onOpen = jest.fn();
 		const screen = await render(

--- a/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
+++ b/src/features/learning-plans/learning-plan-path-screen.ui.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, jest, test } from "@jest/globals";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import { fireEvent, render } from "@testing-library/react-native";
 import { processColor } from "react-native";
 import {
@@ -6,8 +6,21 @@ import {
 	LearningPath,
 	SessionPreviewCard,
 } from "~/app/learning-plans/[planId]/index";
+import { LEARNING_PATH_BREATHING } from "~/features/learning-plans/learning-path-node-presentation";
 import type { PlanSession } from "~/features/learning-plans/types";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
+
+const mockWithRepeat = jest.fn(
+	(value: unknown, repeatCount: number, reverse?: boolean) => ({
+		repeatCount,
+		reverse,
+		value,
+	}),
+);
+const mockSetSharedValue = jest.fn();
+const mockWithSequence = jest.fn((...values: unknown[]) => values.at(-1));
+const mockWithTiming = jest.fn((value: unknown, _config?: unknown) => value);
+let mockReduceMotion = true;
 
 jest.mock("expo-router", () => ({
 	Stack: { Screen: () => null },
@@ -56,19 +69,22 @@ jest.mock("react-native-reanimated", () => {
 		FadeIn: { duration: () => undefined },
 		FadeOut: { duration: () => undefined },
 		useAnimatedStyle: (factory: () => unknown) => factory(),
-		useReducedMotion: () => true,
+		useReducedMotion: () => mockReduceMotion,
 		useSharedValue: (initialValue: number) => {
-			let value = initialValue;
+			let value: unknown = initialValue;
 			return {
 				get: () => value,
-				set: (nextValue: number) => {
+				set: (nextValue: unknown) => {
 					value = nextValue;
+					mockSetSharedValue(nextValue);
 				},
 			};
 		},
-		withRepeat: (value: unknown) => value,
-		withSequence: (value: unknown) => value,
-		withTiming: (value: unknown) => value,
+		withRepeat: (value: unknown, repeatCount: number, reverse?: boolean) =>
+			mockWithRepeat(value, repeatCount, reverse),
+		withSequence: (...values: unknown[]) => mockWithSequence(...values),
+		withTiming: (value: unknown, config?: unknown) =>
+			mockWithTiming(value, config),
 	};
 });
 
@@ -121,6 +137,42 @@ const session = (
 });
 
 describe("learning-plan path", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockReduceMotion = true;
+	});
+
+	test("reverses one timing animation so the next-step breathing loop stays continuous", async () => {
+		mockReduceMotion = false;
+		const currentSession = session("session_current");
+
+		await render(
+			<LearningPath
+				examCountdownLabel="Noch 14 Tage"
+				examDateLabel="18. August 2026"
+				onOpenSession={() => undefined}
+				onSelectSession={() => undefined}
+				selectedSessionId={currentSession.id}
+				sessions={[currentSession]}
+				showsAdaptiveContinuation={false}
+			/>,
+		);
+
+		expect(mockWithSequence).not.toHaveBeenCalled();
+		expect(mockSetSharedValue).toHaveBeenNthCalledWith(
+			1,
+			LEARNING_PATH_BREATHING.minScale,
+		);
+		expect(mockWithTiming).toHaveBeenCalledWith(
+			LEARNING_PATH_BREATHING.maxScale,
+			{
+				duration: LEARNING_PATH_BREATHING.halfCycleMs,
+				easing: "sin",
+			},
+		);
+		expect(mockWithRepeat).toHaveBeenCalledWith(expect.anything(), -1, true);
+	});
+
 	test("uses a named action for the available session", async () => {
 		const onOpen = jest.fn();
 		const screen = await render(


### PR DESCRIPTION
## Summary
- replace the non-reversing two-step breathing sequence with one timing animation that reverses continuously
- initialize the next-to-do node at the lower scale so every loop travels smoothly between `0.96` and `1.06`
- initialize inactive and reduced-motion nodes at scale `1` so they cannot flash at the breathing minimum
- preserve state-driven motion: only the current/next-to-do node breathes, while selection only controls the halo

## Verification
- repository `pnpm check` passed on the animation fix (retaining the existing unused-import warning in `src/features/auth/dayova-auth-flow.tsx`)
- final CodeRabbit adjustment separately passes Biome, scoped ESLint, and full `tsc --noEmit`
- `pnpm exec jest --runInBand src/features/learning-plans/learning-plan-path-screen.ui.test.tsx` — 7/7
- `pnpm exec vitest run src/features/learning-plans/learning-path-node-presentation.test.ts` — 4/4; covers current motion independent of selection and selected completed/locked nodes remaining still
- `git diff --check`
- iPhone 17 Pro Max Simulator recording: 18.75 seconds / 1,126 frames / more than nine full cycles. Original recording had an 8-pixel one-frame reset every two seconds; patched recording's maximum adjacent-frame change is 2 pixels with no reset spike. Full timeline sampled at 2 fps plus focused 10 fps coverage; no audio.

## Existing suite failures
- The full Vitest run passes 614/614 tests.
- The full Jest run currently has three unrelated failures in `login-screen.ui.test.tsx`, `learning-plan-setup-steps.ui.test.tsx`, and `onboarding-select.ui.test.tsx`; none is touched by this diff. The animation-related Jest and Vitest suites pass.

## Review status
- Matt Pocock two-axis review on final commit `d2a927d`: 0 Standards findings, 0 Fowler smells, 0 Spec findings.
- CodeRabbit CLI 0.7.2 reviewed the committed final diff: 0 findings. Its prior review found the inactive-node initial-scale flash; fixed in `d2a927d` and confirmed clean on re-review.
- The GitHub CodeRabbit bot was explicitly requested but reported an account-level rate limit on this draft; the authenticated local CodeRabbit review completed instead.
