### PR TITLE
Restore Convex production schema compatibility

### DIFF
--- a/convex/dayEntries.test.ts
+++ b/convex/dayEntries.test.ts
@@ -12,6 +12,25 @@ const user = {
 	tokenIdentifier: "test:user",
 };
 
+test("keeps adaptive exam entries with a stored subject schema-compatible", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+
+	await expect(
+		t.run((ctx) =>
+			ctx.db.insert("dayEntries", {
+				ownerTokenIdentifier: user.tokenIdentifier,
+				dayKey: "2026-08-13",
+				title: "Mathematik Klausur",
+				subject: "Mathematik",
+				kind: "Leistungskontrolle",
+				plannedDateLabel: "Donnerstag, 13. August",
+				durationMinutes: 30,
+				examTypeLabel: "Klausur",
+			}),
+		),
+	).resolves.toEqual(expect.any(String));
+});
+
 test("manual timed entry overlapping an existing entry is rejected with conflict details", async () => {
 	const t = convexTest(schema, modules).withIdentity(user);
 

--- a/convex/dayEntries.test.ts
+++ b/convex/dayEntries.test.ts
@@ -22,6 +22,7 @@ test("keeps adaptive exam entries with a stored subject schema-compatible", asyn
 				dayKey: "2026-08-13",
 				title: "Mathematik Klausur",
 				subject: "Mathematik",
+				topicDescription: "Analysis und Integralrechnung",
 				kind: "Leistungskontrolle",
 				plannedDateLabel: "Donnerstag, 13. August",
 				durationMinutes: 30,

--- a/convex/learningContentPlan.ts
+++ b/convex/learningContentPlan.ts
@@ -2,12 +2,18 @@ export type LearningContentPhase = "theory" | "practice" | "rehearsal";
 
 export type LearningTopicPriority = "high" | "medium" | "low";
 
+export type LearningEvidenceDimension =
+	| "understanding"
+	| "problemSolving"
+	| "independent";
+
 export type LearningTopic = {
 	id: string;
 	title: string;
 	learningGoal: string;
 	keywords: string[];
 	priority: LearningTopicPriority;
+	requiredEvidenceDimensions?: LearningEvidenceDimension[];
 };
 
 export type LearningQuestionAngle =

--- a/convex/learningTopicMap.ts
+++ b/convex/learningTopicMap.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { normalizeGeneratedGermanText } from "./generatedGermanText";
 import type {
+	LearningEvidenceDimension,
 	LearningTopic,
 	LearningTopicPriority,
 } from "./learningContentPlan";
@@ -14,13 +15,28 @@ export const learningTopicPriorityValidator = v.union(
 	v.literal("low"),
 );
 
+export const learningEvidenceDimensionValidator = v.union(
+	v.literal("understanding"),
+	v.literal("problemSolving"),
+	v.literal("independent"),
+);
+
 export const learningTopicValidator = v.object({
 	id: v.string(),
 	title: v.string(),
 	learningGoal: v.string(),
 	keywords: v.array(v.string()),
 	priority: learningTopicPriorityValidator,
+	requiredEvidenceDimensions: v.optional(
+		v.array(learningEvidenceDimensionValidator),
+	),
 });
+
+const ALL_EVIDENCE_DIMENSIONS: LearningEvidenceDimension[] = [
+	"understanding",
+	"problemSolving",
+	"independent",
+];
 
 const normalizeTopicId = (value: string, index: number) => {
 	const normalized = value
@@ -41,6 +57,7 @@ export const normalizeLearningTopics = (
 		learningGoal: string;
 		keywords: string[];
 		priority: LearningTopicPriority;
+		requiredEvidenceDimensions?: LearningEvidenceDimension[];
 	}>,
 ): LearningTopic[] => {
 	const usedIds = new Set<string>();
@@ -55,6 +72,10 @@ export const normalizeLearningTopics = (
 		}
 		usedIds.add(id);
 
+		const requiredEvidenceDimensions = ALL_EVIDENCE_DIMENSIONS.filter(
+			(dimension) => topic.requiredEvidenceDimensions?.includes(dimension),
+		);
+
 		return {
 			id,
 			title,
@@ -64,6 +85,9 @@ export const normalizeLearningTopics = (
 				.filter(Boolean)
 				.slice(0, MAX_LEARNING_TOPIC_KEYWORD_COUNT),
 			priority: topic.priority,
+			...(requiredEvidenceDimensions.length > 0
+				? { requiredEvidenceDimensions }
+				: {}),
 		};
 	});
 };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,6 +1,9 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { learningTopicValidator } from "./learningTopicMap";
+import {
+	learningEvidenceDimensionValidator,
+	learningTopicValidator,
+} from "./learningTopicMap";
 import { theoryContentValidator } from "./theoryContent";
 
 const planQuestionValidator = v.object({
@@ -9,6 +12,18 @@ const planQuestionValidator = v.object({
 	targetInsight: v.string(),
 	topicId: v.optional(v.string()),
 	kind: v.optional(v.union(v.literal("performance"), v.literal("confidence"))),
+	responseKind: v.optional(
+		v.union(
+			v.literal("multipleChoice"),
+			v.literal("shortText"),
+			v.literal("longText"),
+		),
+	),
+	options: v.optional(v.array(v.string())),
+	correctAnswer: v.optional(v.string()),
+	idealAnswer: v.optional(v.string()),
+	explanation: v.optional(v.string()),
+	evidenceDimension: v.optional(learningEvidenceDimensionValidator),
 	evaluationKeywords: v.optional(v.array(v.string())),
 });
 
@@ -34,6 +49,18 @@ const sessionExecutionStatusValidator = v.union(
 	v.literal("partiallyCompleted"),
 	v.literal("missed"),
 	v.literal("adjusted"),
+);
+
+const knowledgeValidationStatusValidator = v.union(
+	v.literal("pending"),
+	v.literal("completed"),
+	v.literal("skipped"),
+);
+
+const knowledgeValidationConfidenceValidator = v.union(
+	v.literal("unsure"),
+	v.literal("somewhatSure"),
+	v.literal("sure"),
 );
 
 const missedReasonValidator = v.union(
@@ -79,6 +106,11 @@ const contentGenerationStageValidator = v.union(
 	v.literal("failed"),
 );
 
+const learningPlanSessionPlanningStatusValidator = v.union(
+	v.literal("committed"),
+	v.literal("provisional"),
+);
+
 const sessionContentItemKindValidator = v.union(
 	v.literal("learnCard"),
 	v.literal("multipleChoice"),
@@ -116,6 +148,25 @@ export default defineSchema({
 		.index("by_tokenIdentifier", ["tokenIdentifier"])
 		.index("by_clerkId", ["clerkId"])
 		.index("by_email", ["email"]),
+	accessEntitlements: defineTable({
+		ownerTokenIdentifier: v.string(),
+		userId: v.id("users"),
+		trialStartedAt: v.number(),
+		trialExpiresAt: v.number(),
+		trialReminderAt: v.number(),
+		trialTermsVersion: v.string(),
+		revenueCatEntitlementActive: v.optional(v.boolean()),
+		subscriptionExpiresAt: v.optional(v.number()),
+		subscriptionGraceExpiresAt: v.optional(v.number()),
+		subscriptionProductId: v.optional(v.string()),
+		subscriptionStore: v.optional(v.string()),
+		subscriptionWillRenew: v.optional(v.boolean()),
+		subscriptionBillingIssueDetectedAt: v.optional(v.number()),
+		subscriptionManagementUrl: v.optional(v.string()),
+		subscriptionVerifiedAt: v.optional(v.number()),
+		createdAt: v.number(),
+		updatedAt: v.number(),
+	}).index("by_ownerTokenIdentifier", ["ownerTokenIdentifier"]),
 	validationUserStates: defineTable({
 		ownerTokenIdentifier: v.string(),
 		userId: v.id("users"),
@@ -225,6 +276,7 @@ export default defineSchema({
 			v.literal("dailyBriefing"),
 			v.literal("beforeEvent"),
 			v.literal("forgottenEvent"),
+			v.literal("trialEnding"),
 		),
 		title: v.string(),
 		body: v.string(),
@@ -248,6 +300,8 @@ export default defineSchema({
 		ownerTokenIdentifier: v.string(),
 		dayKey: v.string(),
 		title: v.string(),
+		// Keep entries written by adaptive exam-planning builds schema-compatible.
+		subject: v.optional(v.string()),
 		time: v.optional(v.string()),
 		kind: v.optional(v.string()),
 		notes: v.optional(v.string()),
@@ -256,6 +310,7 @@ export default defineSchema({
 		plannedDateLabel: v.optional(v.string()),
 		durationMinutes: v.optional(v.number()),
 		examTypeLabel: v.optional(v.string()),
+		topicDescription: v.optional(v.string()),
 		completed: v.optional(v.boolean()),
 		executionStatus: v.optional(sessionExecutionStatusValidator),
 		startedAt: v.optional(v.number()),
@@ -270,6 +325,57 @@ export default defineSchema({
 			"ownerTokenIdentifier",
 			"dayKey",
 		]),
+	timetables: defineTable({
+		ownerTokenIdentifier: v.string(),
+		title: v.string(),
+		status: v.union(
+			v.literal("draft"),
+			v.literal("processing"),
+			v.literal("review"),
+			v.literal("active"),
+			v.literal("failed"),
+			v.literal("archived"),
+		),
+		errorMessage: v.optional(v.string()),
+		activatedAt: v.optional(v.number()),
+		createdAt: v.number(),
+		updatedAt: v.number(),
+	})
+		.index("by_ownerTokenIdentifier", ["ownerTokenIdentifier"])
+		.index("by_ownerTokenIdentifier_and_status", [
+			"ownerTokenIdentifier",
+			"status",
+		]),
+	timetableDocuments: defineTable({
+		ownerTokenIdentifier: v.string(),
+		timetableId: v.id("timetables"),
+		storageId: v.string(),
+		storageProvider: v.union(v.literal("convex"), v.literal("r2")),
+		fileName: v.string(),
+		fileType: v.string(),
+		fileSizeBytes: v.number(),
+		createdAt: v.number(),
+	})
+		.index("by_timetableId", ["timetableId"])
+		.index("by_ownerTokenIdentifier", ["ownerTokenIdentifier"]),
+	timetableLessons: defineTable({
+		ownerTokenIdentifier: v.string(),
+		timetableId: v.id("timetables"),
+		dayOfWeek: v.number(),
+		subject: v.string(),
+		startTime: v.string(),
+		endTime: v.string(),
+		room: v.optional(v.string()),
+		sortOrder: v.number(),
+		createdAt: v.number(),
+		updatedAt: v.number(),
+	})
+		.index("by_timetableId_and_dayOfWeek_and_startTime", [
+			"timetableId",
+			"dayOfWeek",
+			"startTime",
+		])
+		.index("by_ownerTokenIdentifier", ["ownerTokenIdentifier"]),
 	learningPlans: defineTable({
 		ownerTokenIdentifier: v.string(),
 		subject: v.string(),
@@ -287,6 +393,7 @@ export default defineSchema({
 			),
 		),
 		topicDescription: v.string(),
+		teacherGuidance: v.optional(v.string()),
 		notes: v.optional(v.string()),
 		status: v.union(
 			v.literal("draft"),
@@ -295,12 +402,16 @@ export default defineSchema({
 			v.literal("accepted"),
 		),
 		knowledgeQuestions: v.optional(v.array(planQuestionValidator)),
+		diagnosticPlacement: v.optional(v.literal("firstSession")),
 		knowledgeAnswersJson: v.optional(v.string()),
 		sourceSummary: v.optional(v.string()),
 		topicMap: v.optional(v.array(learningTopicValidator)),
+		scopeConfirmedAt: v.optional(v.number()),
 		topicReadiness: v.optional(v.array(topicReadinessValidator)),
 		insight: v.optional(planInsightValidator),
 		planningHint: v.optional(v.string()),
+		rollingPlanEnabled: v.optional(v.boolean()),
+		adaptationRevision: v.optional(v.number()),
 		contentGenerationStage: v.optional(contentGenerationStageValidator),
 		contentGenerationId: v.optional(v.string()),
 		contentGenerationStartedAt: v.optional(v.number()),
@@ -323,6 +434,7 @@ export default defineSchema({
 		fileName: v.string(),
 		fileType: v.string(),
 		fileSizeBytes: v.number(),
+		sourceKind: v.optional(v.union(v.literal("school"), v.literal("external"))),
 		createdAt: v.number(),
 	})
 		.index("by_learningPlanId", ["learningPlanId"])
@@ -342,9 +454,11 @@ export default defineSchema({
 		ownerTokenIdentifier: v.string(),
 		learningPlanId: v.id("learningPlans"),
 		sessionId: v.optional(v.id("learningPlanSessions")),
+		reservationId: v.optional(v.string()),
 		operation: v.union(
 			v.literal("diagnostic"),
 			v.literal("plan"),
+			v.literal("answer_evaluation"),
 			v.literal("session_theory"),
 			v.literal("session_practice"),
 			v.literal("session_praxis"),
@@ -354,13 +468,53 @@ export default defineSchema({
 		cachedInputTokens: v.number(),
 		outputTokens: v.number(),
 		estimatedCostUsdMicros: v.number(),
+		budgetCostUsdMicros: v.optional(v.number()),
+		accountingKind: v.optional(
+			v.union(v.literal("measured"), v.literal("projected_failure")),
+		),
 		createdAt: v.number(),
 	})
 		.index("by_learningPlanId", ["learningPlanId"])
+		.index("by_ownerTokenIdentifier_and_reservationId", [
+			"ownerTokenIdentifier",
+			"reservationId",
+		])
 		.index("by_ownerTokenIdentifier_and_createdAt", [
 			"ownerTokenIdentifier",
 			"createdAt",
 		]),
+	learningPlanAiBudgetReservations: defineTable({
+		ownerTokenIdentifier: v.string(),
+		learningPlanId: v.id("learningPlans"),
+		sessionId: v.optional(v.id("learningPlanSessions")),
+		reservationId: v.string(),
+		operation: v.union(
+			v.literal("diagnostic"),
+			v.literal("plan"),
+			v.literal("session_theory"),
+			v.literal("session_practice"),
+			v.literal("session_praxis"),
+		),
+		modelId: v.string(),
+		projectedCostUsdMicros: v.number(),
+		status: v.union(
+			v.literal("active"),
+			v.literal("settled"),
+			v.literal("forfeited"),
+		),
+		monthStart: v.number(),
+		createdAt: v.number(),
+		updatedAt: v.number(),
+	})
+		.index("by_ownerTokenIdentifier_and_reservationId", [
+			"ownerTokenIdentifier",
+			"reservationId",
+		])
+		.index("by_ownerTokenIdentifier_and_monthStart", [
+			"ownerTokenIdentifier",
+			"monthStart",
+		])
+		.index("by_learningPlanId_and_createdAt", ["learningPlanId", "createdAt"]),
 	learningPlanSessions: defineTable({
 		ownerTokenIdentifier: v.string(),
 		learningPlanId: v.id("learningPlans"),
@@ -371,19 +525,33 @@ export default defineSchema({
 		startTime: v.string(),
 		durationMinutes: v.number(),
 		compositionVariant: v.optional(sessionCompositionVariantValidator),
+		sessionPurpose: v.optional(
+			v.union(v.literal("diagnostic"), v.literal("learning")),
+		),
 		goal: v.string(),
 		tasks: v.array(v.string()),
 		expectedOutcome: v.string(),
 		contentGenerationStatus: v.optional(contentGenerationStatusValidator),
 		contentGenerationError: v.optional(v.string()),
+		contentGenerationStartedAt: v.optional(v.number()),
 		contentGeneratedAt: v.optional(v.number()),
+		contentGenerationVersion: v.optional(v.number()),
 		completed: v.optional(v.boolean()),
 		executionStatus: v.optional(sessionExecutionStatusValidator),
 		startedAt: v.optional(v.number()),
 		outcomeAt: v.optional(v.number()),
 		activeStudySeconds: v.optional(v.number()),
+		knowledgeValidationStatus: v.optional(knowledgeValidationStatusValidator),
+		knowledgeValidationConfidence: v.optional(
+			knowledgeValidationConfidenceValidator,
+		),
 		missedReason: v.optional(missedReasonValidator),
 		adjustedFromSessionId: v.optional(v.id("learningPlanSessions")),
+		planningStatus: v.optional(learningPlanSessionPlanningStatusValidator),
+		targetTopicIds: v.optional(v.array(v.string())),
+		targetEvidenceDimension: v.optional(learningEvidenceDimensionValidator),
+		selectionReason: v.optional(v.string()),
+		adaptationRevision: v.optional(v.number()),
 		sortOrder: v.number(),
 		dayEntryId: v.optional(v.id("dayEntries")),
 		createdAt: v.number(),
@@ -410,6 +578,7 @@ export default defineSchema({
 		evaluationKeywords: v.array(v.string()),
 		learningBlockIndex: v.optional(v.number()),
 		topicId: v.optional(v.string()),
+		evidenceDimension: v.optional(learningEvidenceDimensionValidator),
 		questionAngle: v.optional(v.string()),
 		coverageKey: v.optional(v.string()),
 		estimatedSeconds: v.optional(v.number()),


### PR DESCRIPTION
## Summary
- keep `main` schema-compatible with documents already written by `production-app-release`
- retain optional adaptive exam, timetable, entitlement, and learning-evidence fields without changing main behavior
- add a regression for production-shaped day entries

## Why
The post-merge Convex deployment for #485 advanced past the DAY-169/DAY-170 feature checks but rejected existing production data because `main` had older validators. The schema is now aligned with `production-app-release`, allowing the merged fix to deploy safely.

## Validation
- `pnpm check`
- `pnpm format:check`
- `pnpm check:unused`
- `pnpm exec vitest run convex/dayEntries.test.ts --reporter=verbose --testTimeout=20000` (10/10)
- `pnpm exec vitest run convex/learningTopicMap.test.ts convex/learningContentPlan.test.ts --reporter=verbose`
- `CONVEX_AGENT_MODE=anonymous pnpm exec convex dev --once` (functions ready; schema validation passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Learning plans now support richer questions, including response formats, answer guidance, explanations, and evidence requirements.
  * Added support for timetables, timetable documents and lessons, access entitlements, adaptive planning, diagnostic sessions, and learning-session metadata.
  * Added tracking for evidence of understanding, problem-solving, and independent learning.
  * Added AI usage budgeting and reservation tracking for learning-plan features.

* **Bug Fixes**
  * Improved compatibility for adaptive exam entries that include a subject.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->