### PR TITLE
Fix HTML entities in session feedback

### DIFF
--- a/convex/generatedGermanText.test.ts
+++ b/convex/generatedGermanText.test.ts
@@ -22,6 +22,14 @@ describe("normalizeGeneratedGermanText", () => {
 		);
 	});
 
+	test("decodes HTML entities in generated German display text", () => {
+		expect(
+			normalizeGeneratedGermanText(
+				"Sch&auml;den k&ouml;nnen durch Bu&szlig;gelder entstehen. &#220;berpr&uuml;fe auch x &lt; 5.",
+			),
+		).toBe("Schäden können durch Bußgelder entstehen. Überprüfe auch x < 5.");
+	});
+
 	test("repairs common technical learning prompt transliterations", () => {
 		expect(
 			normalizeGeneratedGermanText(

--- a/convex/generatedGermanText.ts
+++ b/convex/generatedGermanText.ts
@@ -95,6 +95,47 @@ const GERMAN_UI_REPLACEMENTS: ReadonlyArray<readonly [RegExp, string]> = [
 	[/\bueben\b/g, "üben"],
 ];
 
+const HTML_ENTITY_REPLACEMENTS: Readonly<Record<string, string>> = {
+	amp: "&",
+	apos: "'",
+	gt: ">",
+	lt: "<",
+	nbsp: " ",
+	quot: '"',
+	Auml: "Ä",
+	auml: "ä",
+	Ouml: "Ö",
+	ouml: "ö",
+	Uuml: "Ü",
+	uuml: "ü",
+	szlig: "ß",
+};
+
+const htmlEntityPattern =
+	/&(#(?:[xX][\dA-Fa-f]{1,6}|\d{1,7})|[A-Za-z][A-Za-z\d]+);/g;
+
+const isValidUnicodeCodePoint = (value: number) =>
+	Number.isInteger(value) &&
+	value >= 0 &&
+	value <= 0x10ffff &&
+	(value < 0xd800 || value > 0xdfff);
+
+export const decodeGeneratedTextHtmlEntities = (value: string) =>
+	value.replace(htmlEntityPattern, (match, entity: string) => {
+		if (!entity.startsWith("#")) {
+			return HTML_ENTITY_REPLACEMENTS[entity] ?? match;
+		}
+
+		const isHex = entity[1]?.toLowerCase() === "x";
+		const codePoint = Number.parseInt(
+			entity.slice(isHex ? 2 : 1),
+			isHex ? 16 : 10,
+		);
+		return isValidUnicodeCodePoint(codePoint)
+			? String.fromCodePoint(codePoint)
+			: match;
+	});
+
 const unsafeControlCharacterPattern = new RegExp(
 	["[\\u0000-\\u0008", "\\u000B\\u000C", "\\u000E-\\u001F", "\\u007F]"].join(
 		"",
@@ -117,7 +158,7 @@ export const normalizeGeneratedGermanText = (value: string) => {
 	const formatted = GERMAN_UI_REPLACEMENTS.reduce(
 		(formatted, [pattern, replacement]) =>
 			formatted.replace(pattern, replacement),
-		value,
+		decodeGeneratedTextHtmlEntities(value),
 	);
 
 	if (unsafeControlCharacterPattern.test(formatted)) {

--- a/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
+++ b/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
@@ -17,19 +17,13 @@ import { QuestionProgressBar } from "~/components/question-progress-bar";
 import { ScreenHeader } from "~/components/screen-header";
 import { BackButton, Button } from "~/components/ui/button";
 import { ErrorMessage } from "~/components/ui/error-message";
-import {
-	Check,
-	CircleAlert,
-	ClipboardEdit,
-	Pencil,
-	Timer,
-} from "~/components/ui/icon";
-import { Surface } from "~/components/ui/surface";
+import { Check, Timer } from "~/components/ui/icon";
 import { Text } from "~/components/ui/text";
 import { Textarea } from "~/components/ui/textarea";
 import { ThemedStatusBar } from "~/components/ui/themed-status-bar";
 import { useAuthSession } from "~/context/AuthContext";
 import { LearningSessionCompletion } from "~/features/learning-plans/learning-session-completion";
+import { FeedbackView } from "~/features/learning-plans/session-feedback";
 import { getLearningSessionAnalysisDestination } from "~/features/learning-plans/session-analysis-navigation";
 import { learningSessionAnalyticsProperties } from "~/features/learning-plans/session-analytics";
 import {
@@ -45,7 +39,6 @@ import { TheoryTopicPage } from "~/features/learning-plans/theory-topic-page";
 import type {
 	LearningSessionContentSnapshot,
 	SessionAnswerAttempt,
-	SessionAnswerRating,
 	SessionContentItem,
 } from "~/features/learning-plans/types";
 import { usePrepareSessionContent } from "~/features/learning-plans/use-prepare-session-content";
@@ -57,35 +50,6 @@ import { triggerSuccessHaptic } from "~/lib/safe-haptics";
 import { useDayovaTheme } from "~/lib/theme";
 import { useValidationAnalytics } from "~/lib/use-validation-analytics";
 import { cn } from "~/lib/utils";
-
-const ratingCopy: Record<
-	SessionAnswerRating,
-	{
-		title: string;
-		color: string;
-		subtleClassName: string;
-		textClassName: string;
-	}
-> = {
-	notCorrect: {
-		title: "Noch nicht gewusst",
-		color: DAYOVA_DESIGN_SYSTEM.colors.wrong,
-		subtleClassName: "bg-wrong-subtle",
-		textClassName: "text-wrong",
-	},
-	partiallyCorrect: {
-		title: "Teilweise richtig",
-		color: DAYOVA_DESIGN_SYSTEM.colors.info,
-		subtleClassName: "bg-info-subtle",
-		textClassName: "text-info",
-	},
-	correct: {
-		title: "Richtige Antwort",
-		color: DAYOVA_DESIGN_SYSTEM.colors.success,
-		subtleClassName: "bg-success-subtle",
-		textClassName: "text-success",
-	},
-};
 
 const phaseTitle = (
 	phase: LearningSessionContentSnapshot["session"]["phase"],
@@ -101,34 +65,6 @@ const formatRemainingTime = (seconds: number) => {
 		.toString()
 		.padStart(2, "0")}`;
 };
-
-function TagPill({
-	label,
-	icon,
-}: {
-	label: string;
-	icon: "answer" | "evaluation" | "question";
-}) {
-	const Icon =
-		icon === "answer"
-			? Pencil
-			: icon === "evaluation"
-				? ClipboardEdit
-				: CircleAlert;
-
-	return (
-		<View className="flex-row items-center gap-2 self-start rounded-full bg-system-subtle px-3 py-2">
-			<Icon
-				size={16}
-				color={DAYOVA_DESIGN_SYSTEM.colors.primary}
-				strokeWidth={2.1}
-			/>
-			<Text className="font-poppins font-semibold text-body-4 text-primary">
-				{label}
-			</Text>
-		</View>
-	);
-}
 
 function ActionRow({
 	secondaryLabel,
@@ -173,49 +109,6 @@ function ActionRow({
 					<Text>{primaryLabel}</Text>
 				)}
 			</Button>
-		</View>
-	);
-}
-
-function FeedbackView({ attempt }: { attempt: SessionAnswerAttempt }) {
-	const copy = ratingCopy[attempt.rating];
-	const StatusIcon = attempt.rating === "correct" ? Check : CircleAlert;
-	return (
-		<View className="flex-1 justify-between">
-			<View className="items-center pt-6">
-				<View
-					className={cn(
-						"h-20 w-20 items-center justify-center rounded-full",
-						copy.subtleClassName,
-					)}
-				>
-					<StatusIcon size={34} color={copy.color} strokeWidth={2.4} />
-				</View>
-				<Text
-					className={cn(
-						"mt-3 font-poppins font-semibold text-body-3",
-						copy.textClassName,
-					)}
-				>
-					{copy.title}
-				</Text>
-			</View>
-
-			<View className="mt-9">
-				<Surface className="rounded-[32px] px-5 py-6" variant="flat">
-					<TagPill label="Auswertung" icon="evaluation" />
-					<Text className="mt-8 font-poppins text-body-2 text-secondary-text">
-						{attempt.feedback}
-					</Text>
-				</Surface>
-				<View className="mx-8 my-8 h-px bg-border" />
-				<Surface className="rounded-[32px] px-5 py-6" variant="flat">
-					<TagPill label="Ideale Antwort" icon="answer" />
-					<Text className="mt-8 font-poppins text-body-2 text-secondary-text">
-						{attempt.perfectAnswer}
-					</Text>
-				</Surface>
-			</View>
 		</View>
 	);
 }

--- a/src/features/learning-plans/session-feedback.tsx
+++ b/src/features/learning-plans/session-feedback.tsx
@@ -1,0 +1,113 @@
+import { View } from "react-native";
+import { decodeGeneratedTextHtmlEntities } from "#convex/generatedGermanText";
+import {
+	Check,
+	CircleAlert,
+	ClipboardEdit,
+	Pencil,
+} from "~/components/ui/icon";
+import { Surface } from "~/components/ui/surface";
+import { Text } from "~/components/ui/text";
+import type {
+	SessionAnswerAttempt,
+	SessionAnswerRating,
+} from "~/features/learning-plans/types";
+import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
+import { cn } from "~/lib/utils";
+
+const ratingCopy: Record<
+	SessionAnswerRating,
+	{
+		title: string;
+		color: string;
+		subtleClassName: string;
+		textClassName: string;
+	}
+> = {
+	notCorrect: {
+		title: "Noch nicht gewusst",
+		color: DAYOVA_DESIGN_SYSTEM.colors.wrong,
+		subtleClassName: "bg-wrong-subtle",
+		textClassName: "text-wrong",
+	},
+	partiallyCorrect: {
+		title: "Teilweise richtig",
+		color: DAYOVA_DESIGN_SYSTEM.colors.info,
+		subtleClassName: "bg-info-subtle",
+		textClassName: "text-info",
+	},
+	correct: {
+		title: "Richtige Antwort",
+		color: DAYOVA_DESIGN_SYSTEM.colors.success,
+		subtleClassName: "bg-success-subtle",
+		textClassName: "text-success",
+	},
+};
+
+function TagPill({
+	label,
+	icon,
+}: {
+	label: string;
+	icon: "answer" | "evaluation";
+}) {
+	const Icon = icon === "answer" ? Pencil : ClipboardEdit;
+
+	return (
+		<View className="flex-row items-center gap-2 self-start rounded-full bg-system-subtle px-3 py-2">
+			<Icon
+				size={16}
+				color={DAYOVA_DESIGN_SYSTEM.colors.primary}
+				strokeWidth={2.1}
+			/>
+			<Text className="font-poppins font-semibold text-body-4 text-primary">
+				{label}
+			</Text>
+		</View>
+	);
+}
+
+export function FeedbackView({ attempt }: { attempt: SessionAnswerAttempt }) {
+	const copy = ratingCopy[attempt.rating];
+	const StatusIcon = attempt.rating === "correct" ? Check : CircleAlert;
+	const feedback = decodeGeneratedTextHtmlEntities(attempt.feedback);
+	const perfectAnswer = decodeGeneratedTextHtmlEntities(attempt.perfectAnswer);
+	return (
+		<View className="flex-1 justify-between">
+			<View className="items-center pt-6">
+				<View
+					className={cn(
+						"h-20 w-20 items-center justify-center rounded-full",
+						copy.subtleClassName,
+					)}
+				>
+					<StatusIcon size={34} color={copy.color} strokeWidth={2.4} />
+				</View>
+				<Text
+					className={cn(
+						"mt-3 font-poppins font-semibold text-body-3",
+						copy.textClassName,
+					)}
+				>
+					{copy.title}
+				</Text>
+			</View>
+
+			<View className="mt-9">
+				<Surface className="rounded-[32px] px-5 py-6" variant="flat">
+					<TagPill label="Auswertung" icon="evaluation" />
+					<Text className="mt-8 font-poppins text-body-2 text-secondary-text">
+						{feedback}
+					</Text>
+				</Surface>
+				<View className="mx-8 my-8 h-px bg-border" />
+				<Surface className="rounded-[32px] px-5 py-6" variant="flat">
+					<TagPill label="Ideale Antwort" icon="answer" />
+					<Text className="mt-8 font-poppins text-body-2 text-secondary-text">
+						{perfectAnswer}
+					</Text>
+				</Surface>
+			</View>
+		</View>
+	);
+}

--- a/src/features/learning-plans/session-feedback.ui.test.tsx
+++ b/src/features/learning-plans/session-feedback.ui.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "@jest/globals";
+import { render } from "@testing-library/react-native";
+import { FeedbackView } from "~/features/learning-plans/session-feedback";
+import type { SessionAnswerAttempt } from "~/features/learning-plans/types";
+
+describe("session feedback", () => {
+	test("renders escaped German evaluation text as readable characters", async () => {
+		const attempt = {
+			id: "attempt_1",
+			itemId: "item_1",
+			sessionId: "session_1",
+			rating: "correct",
+			feedback:
+				"Du hast die finanziellen Sch&auml;den korrekt benannt. Diese k&ouml;nnen durch Bu&szlig;gelder entstehen.",
+			perfectAnswer:
+				"Finanzielle Sch&auml;den k&ouml;nnen durch Bu&szlig;gelder entstehen.",
+			createdAt: 1,
+		} as SessionAnswerAttempt;
+
+		const screen = await render(<FeedbackView attempt={attempt} />);
+
+		expect(
+			screen.getByText(
+				"Du hast die finanziellen Schäden korrekt benannt. Diese können durch Bußgelder entstehen.",
+			),
+		).toBeOnTheScreen();
+		expect(
+			screen.getByText("Finanzielle Schäden können durch Bußgelder entstehen."),
+		).toBeOnTheScreen();
+		expect(screen.queryByText(/&(?:auml|ouml|szlig);/)).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary
- decode common named and numeric HTML entities in generated German text before persistence
- decode existing stored feedback at the rendered session-feedback boundary
- add unit and rendered regression coverage for umlauts and ß

## Root cause
The AI provider can return German evaluation copy using HTML entities. The generated-text normalizer did not decode them, and React Native renders strings literally instead of interpreting HTML entities.

## Validation
- `pnpm check`
- `pnpm test` (630 unit tests, 115 UI tests)
- `pnpm format:check`
- `CONVEX_AGENT_MODE=anonymous pnpm exec convex dev --once`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - German text now correctly displays umlauts, ß, and other encoded characters in generated content.
  - Feedback and ideal answers in learning sessions now render readable text instead of HTML entity codes.
  - Invalid or unsupported encoded characters remain safely handled without disrupting text display.

- **Improvements**
  - Session feedback now uses a consistent presentation for ratings, feedback details, answer tags, and ideal answers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->