### PR TITLE
Open next learning session from analytics

### DIFF
--- a/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
+++ b/src/app/learning-plans/[planId]/sessions/[sessionId]/index.tsx
@@ -23,9 +23,10 @@ import { Textarea } from "~/components/ui/textarea";
 import { ThemedStatusBar } from "~/components/ui/themed-status-bar";
 import { useAuthSession } from "~/context/AuthContext";
 import { LearningSessionCompletion } from "~/features/learning-plans/learning-session-completion";
-import { FeedbackView } from "~/features/learning-plans/session-feedback";
 import { getLearningSessionAnalysisDestination } from "~/features/learning-plans/session-analysis-navigation";
 import { learningSessionAnalyticsProperties } from "~/features/learning-plans/session-analytics";
+import { FeedbackView } from "~/features/learning-plans/session-feedback";
+import { getLearningSessionBackTarget } from "~/features/learning-plans/session-navigation";
 import {
 	CONTINUE_LEARNING_MINUTES,
 	getLearningSessionCompletionPhase,
@@ -222,6 +223,7 @@ export default function LearningSessionContentScreen() {
 	const insets = useSafeAreaInsets();
 	const params = useLocalSearchParams<{
 		planId?: string;
+		returnTo?: string;
 		sessionId?: string;
 	}>();
 	const planId = params.planId as Id<"learningPlans"> | undefined;
@@ -345,15 +347,12 @@ export default function LearningSessionContentScreen() {
 	const currentRunCorrectCount = currentRunAttempts.filter(
 		(attempt) => attempt.rating === "correct",
 	).length;
+	const backTarget = getLearningSessionBackTarget(planId, params.returnTo);
 
 	const goBack = useCallback(() => {
-		if (planId) {
-			dismissToOrReplace(router, `/learning-plans/${planId}` as const);
-			return true;
-		}
-		dismissToOrReplace(router, "/learning-plans");
+		dismissToOrReplace(router, backTarget);
 		return true;
-	}, [planId, router]);
+	}, [backTarget, router]);
 
 	useBackIntent(Boolean(planId), goBack);
 
@@ -842,7 +841,6 @@ export default function LearningSessionContentScreen() {
 						},
 						headerLeft: () => (
 							<BackButton
-								accessibilityHint="Kehrt zum Lernplan zurück."
 								onPress={goBack}
 								className="h-11 min-h-11 w-11 min-w-11"
 							/>
@@ -905,7 +903,6 @@ export default function LearningSessionContentScreen() {
 								},
 								headerLeft: () => (
 									<BackButton
-										accessibilityHint="Kehrt zum Lernplan zurück."
 										onPress={goBack}
 										className="h-11 min-h-11 w-11 min-w-11"
 									/>

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -1298,10 +1298,13 @@ export function AnalyticsScreen({
 							analysis={analysis}
 							onOpenNextStep={() => {
 								if (selectedPlanIdForRoute) {
-									router.push({
-										pathname: ROUTES.analyticsNextStep,
-										params: { planId: selectedPlanIdForRoute },
-									});
+									if (analysis.recommendation) {
+										router.push(
+											`/learning-plans/${selectedPlanIdForRoute}/sessions/${analysis.recommendation.sessionId}`,
+										);
+										return;
+									}
+									router.push(`/learning-plans/${selectedPlanIdForRoute}`);
 								}
 							}}
 							onOpenTopic={(topicId) => {

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -42,7 +42,7 @@ import { useAuthSession } from "~/context/AuthContext";
 import { getDayKey, useCurrentLocalDay } from "~/lib/day-key";
 import { DAYOVA_DESIGN_SYSTEM } from "~/lib/design-system";
 import { formatGermanUiText } from "~/lib/german-ui-text";
-import { ROUTES } from "~/lib/routes";
+import { ROUTES, withReturnTo } from "~/lib/routes";
 import { useDayovaTheme } from "~/lib/theme";
 import { cn } from "~/lib/utils";
 
@@ -1300,7 +1300,10 @@ export function AnalyticsScreen({
 								if (selectedPlanIdForRoute) {
 									if (analysis.recommendation) {
 										router.push(
-											`/learning-plans/${selectedPlanIdForRoute}/sessions/${analysis.recommendation.sessionId}`,
+											withReturnTo(
+												`/learning-plans/${selectedPlanIdForRoute}/sessions/${analysis.recommendation.sessionId}`,
+												ROUTES.analytics,
+											),
 										);
 										return;
 									}

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -504,7 +504,7 @@ describe("AnalyticsScreen", () => {
 			}),
 		);
 		expect(mockPush).toHaveBeenCalledWith(
-			"/learning-plans/plan_1/sessions/session_1",
+			"/learning-plans/plan_1/sessions/session_1?returnTo=%2Fanalyse",
 		);
 
 		await fireEvent.press(

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -503,10 +503,9 @@ describe("AnalyticsScreen", () => {
 				name: "Nächster Schritt: Steigung vollständig erklären",
 			}),
 		);
-		expect(mockPush).toHaveBeenCalledWith({
-			pathname: "/analyse/naechster-schritt",
-			params: { planId: "plan_1" },
-		});
+		expect(mockPush).toHaveBeenCalledWith(
+			"/learning-plans/plan_1/sessions/session_1",
+		);
 
 		await fireEvent.press(
 			screen.getByRole("button", {
@@ -517,6 +516,18 @@ describe("AnalyticsScreen", () => {
 			pathname: "/analyse/wissensstand",
 			params: { planId: "plan_1", topicId: "steigung" },
 		});
+	});
+
+	test("opens the related learning plan when the next step has no session", async () => {
+		mockUseQuery.mockReturnValue({ ...examAnalysis, recommendation: null });
+		const screen = await render(<AnalyticsScreen />);
+
+		await fireEvent.press(
+			screen.getByRole("button", {
+				name: "Nächster Schritt: Lernplan prüfen",
+			}),
+		);
+		expect(mockPush).toHaveBeenCalledWith("/learning-plans/plan_1");
 	});
 
 	test("does not show an aggregate knowledge card with existing evidence", async () => {

--- a/src/features/learning-plans/session-navigation.test.ts
+++ b/src/features/learning-plans/session-navigation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import type { Id } from "#convex/_generated/dataModel";
+import { ROUTES } from "~/lib/routes";
+import { getLearningSessionBackTarget } from "./session-navigation";
+
+describe("getLearningSessionBackTarget", () => {
+	const planId = "plan_1" as Id<"learningPlans">;
+
+	test("returns to the screen that opened the learning session", () => {
+		expect(getLearningSessionBackTarget(planId, ROUTES.analytics)).toBe(
+			ROUTES.analytics,
+		);
+	});
+
+	test("falls back to the related learning plan", () => {
+		expect(getLearningSessionBackTarget(planId)).toBe("/learning-plans/plan_1");
+	});
+
+	test("rejects an external return destination", () => {
+		expect(getLearningSessionBackTarget(planId, "https://example.com")).toBe(
+			"/learning-plans/plan_1",
+		);
+	});
+
+	test("falls back to the learning-plan list without route context", () => {
+		expect(getLearningSessionBackTarget()).toBe(ROUTES.learningPlans);
+	});
+});

--- a/src/features/learning-plans/session-navigation.ts
+++ b/src/features/learning-plans/session-navigation.ts
@@ -1,0 +1,12 @@
+import type { Id } from "#convex/_generated/dataModel";
+import { getSafeReturnTo, ROUTES } from "~/lib/routes";
+
+export const getLearningSessionBackTarget = (
+	planId?: Id<"learningPlans">,
+	returnTo?: string,
+) => {
+	const safeReturnTo = getSafeReturnTo(returnTo);
+	if (safeReturnTo) return safeReturnTo;
+
+	return planId ? `/learning-plans/${planId}` : ROUTES.learningPlans;
+};


### PR DESCRIPTION
## Summary
- open the recommended learning session directly from the analytics next-step card
- preserve Analytics as the session return destination so button, gesture, and system back navigation return correctly
- fall back to the related learning plan when no recommended session or explicit return destination exists
- validate return destinations before using them
- cover the direct route and back-target behavior with regression tests

## Validation
- `pnpm jest --runInBand src/features/analytics/analytics-screen.ui.test.tsx`
- `pnpm vitest run src/features/learning-plans/session-navigation.test.ts`
- `pnpm typecheck`
- `pnpm biome check` on changed files
- `pnpm eslint` on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter back navigation for learning sessions, including returning to the screen users came from.
  * Analytics recommendations now open directly to the suggested session with a return path to analytics.
  * When no session is recommended, analytics now opens the related learning plan.

* **Bug Fixes**
  * Improved navigation fallback behavior and blocked invalid external return destinations.

* **Tests**
  * Added coverage for session back navigation and analytics navigation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->