### PR TITLE
Fix exam flow back navigation

### DIFF
--- a/src/app/(creation)/entry/new.tsx
+++ b/src/app/(creation)/entry/new.tsx
@@ -740,14 +740,14 @@ export default function NewEntryScreen() {
 		return true;
 	}, [goToStep, isHomework, pickerTarget, router, selectTarget, step]);
 
-	useBackIntent(
+	const runBackIntent = useBackIntent(
 		Boolean(selectTarget || pickerTarget || !isHomework || step !== "basics"),
 		handleBack,
 	);
 	useLearningPlanCreationProgress({
 		active: !isHomework,
 		currentStep: getExamEntryCreationProgress(step),
-		onBack: handleBack,
+		onBack: runBackIntent,
 		title: "Prüfung eintragen",
 	});
 
@@ -853,7 +853,7 @@ export default function NewEntryScreen() {
 				{isHomework ? (
 					step === "basics" ? (
 						<>
-							<HomeworkScreenHeader title="Abgabe" onBack={handleBack} />
+							<HomeworkScreenHeader title="Abgabe" onBack={runBackIntent} />
 							<View className="mb-7">
 								<Text className="font-poppins font-semibold text-body-3 text-text">
 									Hausaufgabe eintragen
@@ -916,7 +916,7 @@ export default function NewEntryScreen() {
 						</>
 					) : (
 						<>
-							<HomeworkScreenHeader title="Erledigen" onBack={handleBack} />
+							<HomeworkScreenHeader title="Erledigen" onBack={runBackIntent} />
 							<View className="mb-5">
 								<Text className="font-poppins font-semibold text-body-3 text-text">
 									Hausaufgabe eintragen

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -35,7 +35,23 @@ export const useBackIntent = (enabled: boolean, onBack: () => boolean) => {
 	const navigation = useNavigation();
 	const isHandlingNativeBackRef = useRef(false);
 
-	useAndroidBackHandler(enabled, onBack);
+	const runBackIntent = useCallback(() => {
+		if (isHandlingNativeBackRef.current) return true;
+
+		isHandlingNativeBackRef.current = true;
+		const handled = onBack();
+		if (!handled) {
+			isHandlingNativeBackRef.current = false;
+			return false;
+		}
+
+		requestAnimationFrame(() => {
+			isHandlingNativeBackRef.current = false;
+		});
+		return true;
+	}, [onBack]);
+
+	useAndroidBackHandler(enabled, runBackIntent);
 
 	useFocusEffect(
 		useCallback(() => {
@@ -44,22 +60,19 @@ export const useBackIntent = (enabled: boolean, onBack: () => boolean) => {
 			const unsubscribe = navigation.addListener("beforeRemove", (event) => {
 				if (!isBackRemovalAction(event)) return;
 
-				if (isHandlingNativeBackRef.current) {
-					event.preventDefault();
-					return;
-				}
+				// A route removal started by runBackIntent is the intended result of
+				// the custom back control. Let that nested navigation action through.
+				if (isHandlingNativeBackRef.current) return;
 
-				const handled = onBack();
+				const handled = runBackIntent();
 				if (!handled) return;
 
-				isHandlingNativeBackRef.current = true;
 				event.preventDefault();
-				requestAnimationFrame(() => {
-					isHandlingNativeBackRef.current = false;
-				});
 			});
 
 			return unsubscribe;
-		}, [enabled, navigation, onBack]),
+		}, [enabled, navigation, runBackIntent]),
 	);
+
+	return runBackIntent;
 };

--- a/src/lib/navigation.ui.test.tsx
+++ b/src/lib/navigation.ui.test.tsx
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react-native";
+import { useBackIntent } from "./navigation";
+
+type BeforeRemoveEvent = {
+	data: { action: { type: string } };
+	preventDefault: jest.Mock;
+};
+
+type BeforeRemoveListener = (event: BeforeRemoveEvent) => void;
+
+let mockBeforeRemoveListener: BeforeRemoveListener | undefined;
+const mockAddListener = jest.fn(
+	(_eventName: string, listener: BeforeRemoveListener) => {
+		mockBeforeRemoveListener = listener;
+		return jest.fn();
+	},
+);
+
+jest.mock("expo-router/react-navigation", () => ({
+	useFocusEffect: (effect: () => undefined | (() => void)) => effect(),
+	useNavigation: () => ({ addListener: mockAddListener }),
+}));
+
+const createBeforeRemoveEvent = (): BeforeRemoveEvent => ({
+	data: { action: { type: "GO_BACK" } },
+	preventDefault: jest.fn(),
+});
+
+describe("useBackIntent", () => {
+	beforeEach(() => {
+		mockBeforeRemoveListener = undefined;
+		mockAddListener.mockClear();
+		global.requestAnimationFrame = jest.fn(() => 1);
+	});
+
+	test("allows a back action started by the custom back control to remove the route", async () => {
+		const removalEvent = createBeforeRemoveEvent();
+		const onBack = jest.fn(() => {
+			mockBeforeRemoveListener?.(removalEvent);
+			return true;
+		});
+		const hook = await renderHook(() => useBackIntent(true, onBack));
+
+		await act(async () => {
+			hook.result.current();
+		});
+
+		expect(onBack).toHaveBeenCalledTimes(1);
+		expect(removalEvent.preventDefault).not.toHaveBeenCalled();
+	});
+
+	test("handles a native back action once while allowing its replacement navigation", async () => {
+		const replacementRemovalEvent = createBeforeRemoveEvent();
+		const onBack = jest.fn(() => {
+			mockBeforeRemoveListener?.(replacementRemovalEvent);
+			return true;
+		});
+		await renderHook(() => useBackIntent(true, onBack));
+		const nativeRemovalEvent = createBeforeRemoveEvent();
+
+		await act(async () => {
+			mockBeforeRemoveListener?.(nativeRemovalEvent);
+		});
+
+		expect(onBack).toHaveBeenCalledTimes(1);
+		expect(nativeRemovalEvent.preventDefault).toHaveBeenCalledTimes(1);
+		expect(replacementRemovalEvent.preventDefault).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What changed

- Return a guarded custom-back runner from `useBackIntent`.
- Allow route removals initiated by that runner to pass through the native `beforeRemove` interceptor.
- Wire the exam-entry header controls to the guarded runner.
- Add rendered hook regression tests for custom and native back actions.

## Why

At the first exam-entry step, the visible back button called `router.back()`. The screen's `beforeRemove` listener intercepted that same programmatic action, invoked the handler again, and prevented the route removal, leaving the learner trapped in the flow.

## Impact

The back button still moves between internal exam steps, and it can now leave the creation flow from the first step. Native and Android back handling remain routed through the same intent logic without duplicate handling.

## Validation

- `pnpm check`
- `pnpm test` (652 unit/support tests and 127 rendered mobile tests)
- Isolated branch regression: `jest src/lib/navigation.ui.test.tsx --runInBand`