### PR TITLE
Improve Analyse progress overview

### DIFF
--- a/convex/userAnalytics.test.ts
+++ b/convex/userAnalytics.test.ts
@@ -254,6 +254,11 @@ test("returns a selected exam analysis grounded in topics, answers, and schedule
 			uncertain: 1,
 			unknown: 0,
 		},
+		answerAccuracy: {
+			answeredQuestions: 1,
+			correctAnswers: 0,
+			percent: 0,
+		},
 		abilities: [
 			{
 				statement: "Du erkennst lineare Zusammenhänge.",
@@ -395,6 +400,51 @@ test("returns a selected exam analysis grounded in topics, answers, and schedule
 		}),
 	).resolves.toMatchObject({
 		selectedPlan: { id: learningPlanId },
+	});
+});
+
+test("calculates answer correctness across all latest question answers", async () => {
+	const { t, learningPlanId, firstSessionId } = await seedAnalyticsData();
+	await t.run(async (ctx) => {
+		for (let index = 0; index < 9; index += 1) {
+			const itemId = await ctx.db.insert("learningSessionContentItems", {
+				ownerTokenIdentifier: identity.tokenIdentifier,
+				learningPlanId,
+				sessionId: firstSessionId,
+				phase: "practice",
+				kind: "written",
+				title: `Richtige Antwort ${index + 1}`,
+				prompt: `Beantworte Frage ${index + 1}.`,
+				explanation: "Die Antwort ist richtig.",
+				idealAnswer: "Richtig",
+				evaluationKeywords: ["Richtig"],
+				sortOrder: index,
+				createdAt: Date.UTC(2026, 6, 27, 10, index),
+				updatedAt: Date.UTC(2026, 6, 27, 10, index),
+			});
+			await ctx.db.insert("learningSessionAnswerAttempts", {
+				ownerTokenIdentifier: identity.tokenIdentifier,
+				learningPlanId,
+				sessionId: firstSessionId,
+				itemId,
+				answerText: "Richtig",
+				rating: "correct",
+				feedback: "Richtig.",
+				perfectAnswer: "Richtig",
+				createdAt: Date.UTC(2026, 6, 27, 10, index, 30),
+			});
+		}
+	});
+
+	const analysis = await t.query(api.userAnalytics.getExamAnalysis, {
+		learningPlanId,
+		todayKey: "2026-07-28",
+	});
+
+	expect(analysis.answerAccuracy).toEqual({
+		answeredQuestions: 10,
+		correctAnswers: 9,
+		percent: 90,
 	});
 });
 

--- a/convex/userAnalytics.ts
+++ b/convex/userAnalytics.ts
@@ -166,6 +166,11 @@ const examAnalysisValidator = v.object({
 		uncertain: v.number(),
 		unknown: v.number(),
 	}),
+	answerAccuracy: v.object({
+		answeredQuestions: v.number(),
+		correctAnswers: v.number(),
+		percent: v.union(v.number(), v.null()),
+	}),
 	abilities: v.array(
 		v.object({
 			statement: v.string(),
@@ -979,6 +984,11 @@ export const getExamAnalysis = query({
 				plans: planOptions,
 				selectedPlan: null,
 				readiness: { secure: 0, developing: 0, uncertain: 0, unknown: 0 },
+				answerAccuracy: {
+					answeredQuestions: 0,
+					correctAnswers: 0,
+					percent: null,
+				},
 				abilities: [],
 				improvements: [],
 				latestKnowledgeChange: null,
@@ -1050,6 +1060,22 @@ export const getExamAnalysis = query({
 			}
 		}
 		const latestAttempts = [...latestAttemptByItem.values()];
+		const scoredAttempts = latestAttempts.filter((attempt) => {
+			const item = itemById.get(attempt.itemId);
+			return item !== undefined && item.kind !== "learnCard";
+		});
+		const answeredQuestions = scoredAttempts.length;
+		const correctAnswers = scoredAttempts.filter(
+			(attempt) => attempt.rating === "correct",
+		).length;
+		const answerAccuracy = {
+			answeredQuestions,
+			correctAnswers,
+			percent:
+				answeredQuestions > 0
+					? Math.round((correctAnswers / answeredQuestions) * 100)
+					: null,
+		};
 
 		const analyses = (
 			await ctx.db
@@ -1502,6 +1528,7 @@ export const getExamAnalysis = query({
 				daysRemaining: remainingDays,
 			},
 			readiness,
+			answerAccuracy,
 			abilities,
 			improvements,
 			latestKnowledgeChange,

--- a/src/app/(app)/settings.tsx
+++ b/src/app/(app)/settings.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
 import { type ReactNode, useRef, useState } from "react";
-import { Pressable, View } from "react-native";
+import { Pressable, useWindowDimensions, View } from "react-native";
 import { ErrorMessage } from "~/components/ui/error-message";
 import {
 	ArrowRight,
@@ -27,6 +27,9 @@ import { useDayovaTheme } from "~/lib/theme";
 import { THEME_OPTIONS, type ThemePreference } from "~/lib/theme-preference";
 import { cn } from "~/lib/utils";
 
+const SETTINGS_CONTENT_MAX_WIDTH = 640;
+const SETTINGS_EXPANDED_LAYOUT_MIN_WIDTH = 700;
+
 const themeIconByPreference = {
 	light: Sun,
 	system: Computer,
@@ -48,6 +51,7 @@ function SettingsRow({
 	disabled = false,
 	busy = false,
 	showDisclosure = true,
+	expanded = false,
 }: {
 	icon: (props: {
 		size?: number;
@@ -60,25 +64,37 @@ function SettingsRow({
 	disabled?: boolean;
 	busy?: boolean;
 	showDisclosure?: boolean;
+	expanded?: boolean;
 }) {
 	const Icon = icon;
 	const { colors } = useDayovaTheme();
 
 	return (
 		<ListRow
-			icon={<Icon size={22} color={colors.text} strokeWidth={2} />}
+			icon={
+				<Icon size={expanded ? 26 : 22} color={colors.text} strokeWidth={2} />
+			}
+			iconContainerClassName={expanded ? "h-14 w-14 mr-4" : undefined}
 			label={label}
+			labelClassName={expanded ? "text-body-1" : undefined}
 			onPress={onPress}
 			disabled={disabled}
 			accessibilityState={{
 				busy,
 				disabled,
 			}}
-			className="rounded-3xl bg-transparent px-3 shadow-none"
+			className={cn(
+				"rounded-3xl bg-transparent px-3 shadow-none",
+				expanded && "min-h-20 px-5 py-4",
+			)}
 			trailing={
 				trailing ??
 				(onPress && showDisclosure ? (
-					<ArrowRight size={18} color={colors.secondaryText} strokeWidth={2} />
+					<ArrowRight
+						size={expanded ? 20 : 18}
+						color={colors.secondaryText}
+						strokeWidth={2}
+					/>
 				) : undefined)
 			}
 			variant="flat"
@@ -92,20 +108,27 @@ function SettingsDivider() {
 
 function SettingsSection({
 	children,
+	expanded = false,
 	title,
 }: {
 	children: ReactNode;
+	expanded?: boolean;
 	title: string;
 }) {
 	return (
-		<View className="gap-2">
+		<View className={expanded ? "gap-3" : "gap-2"}>
 			<Text
 				accessibilityRole="header"
-				className="px-4 font-poppins font-semibold text-body-4 text-secondary-text"
+				className={cn(
+					"px-4 font-poppins font-semibold text-body-4 text-secondary-text",
+					expanded && "px-5 text-body-3",
+				)}
 			>
 				{title}
 			</Text>
-			<Surface className="overflow-hidden p-2">{children}</Surface>
+			<Surface className={cn("overflow-hidden p-2", expanded && "p-3")}>
+				{children}
+			</Surface>
 		</View>
 	);
 }
@@ -113,9 +136,11 @@ function SettingsSection({
 function ThemePreferenceToggle({
 	preference,
 	setPreference,
+	expanded = false,
 }: {
 	preference: ThemePreference;
 	setPreference: (preference: ThemePreference) => Promise<void>;
+	expanded?: boolean;
 }) {
 	const { colors } = useDayovaTheme();
 
@@ -132,7 +157,8 @@ function ThemePreferenceToggle({
 						accessibilityRole="radio"
 						accessibilityState={{ checked: isActive }}
 						className={cn(
-							"h-11 w-11 items-center justify-center rounded-full",
+							"items-center justify-center rounded-full",
+							expanded ? "h-12 w-12" : "h-11 w-11",
 							isActive ? "bg-primary" : "bg-transparent",
 						)}
 						onPress={() => {
@@ -142,7 +168,7 @@ function ThemePreferenceToggle({
 						}}
 					>
 						<Icon
-							size={20}
+							size={expanded ? 22 : 20}
 							color={isActive ? "#FFFFFF" : colors.secondaryText}
 							strokeWidth={2}
 						/>
@@ -155,10 +181,12 @@ function ThemePreferenceToggle({
 
 export default function SettingsScreen() {
 	const router = useRouter();
+	const { width } = useWindowDimensions();
 	const { logout } = useAccountActions();
 	const { preference, setPreference } = useDayovaTheme();
 	const [logoutError, setLogoutError] = useState<string | null>(null);
 	const [isLoggingOut, setIsLoggingOut] = useState(false);
+	const expanded = width >= SETTINGS_EXPANDED_LAYOUT_MIN_WIDTH;
 	const logoutGateRef = useRef(createAsyncActionGate());
 	const handleLogout = () => {
 		void logoutGateRef.current.run(async () => {
@@ -183,34 +211,45 @@ export default function SettingsScreen() {
 	return (
 		<Screen>
 			<ThemedStatusBar />
-			<ScreenScroll topPadding={104} bottomPadding={120} horizontalPadding={24}>
-				<View className="gap-7">
-					<SettingsSection title="Lernen">
+			<ScreenScroll
+				contentMaxWidth={SETTINGS_CONTENT_MAX_WIDTH}
+				testID="settings-scroll"
+				topPadding={104}
+				bottomPadding={120}
+				horizontalPadding={24}
+			>
+				<View className={expanded ? "gap-9" : "gap-7"}>
+					<SettingsSection expanded={expanded} title="Lernen">
 						<SettingsRow
+							expanded={expanded}
 							icon={Timer}
 							label="Lernzeiten"
 							onPress={() => router.push("/learning-times")}
 						/>
 						<SettingsDivider />
 						<SettingsRow
+							expanded={expanded}
 							icon={CalendarDays}
 							label="Stundenplan"
 							onPress={() => router.push("/timetable")}
 						/>
 					</SettingsSection>
 
-					<SettingsSection title="App">
+					<SettingsSection expanded={expanded} title="App">
 						<SettingsRow
+							expanded={expanded}
 							icon={Bell}
 							label="Mitteilungen"
 							onPress={() => router.push("/notification-settings")}
 						/>
 						<SettingsDivider />
 						<SettingsRow
+							expanded={expanded}
 							icon={Palette}
 							label="Design"
 							trailing={
 								<ThemePreferenceToggle
+									expanded={expanded}
 									preference={preference}
 									setPreference={setPreference}
 								/>
@@ -219,20 +258,23 @@ export default function SettingsScreen() {
 					</SettingsSection>
 
 					<View className="gap-3">
-						<SettingsSection title="Konto">
+						<SettingsSection expanded={expanded} title="Konto">
 							<SettingsRow
+								expanded={expanded}
 								icon={Settings}
 								label="Profil"
 								onPress={() => router.push("/profile")}
 							/>
 							<SettingsDivider />
 							<SettingsRow
+								expanded={expanded}
 								icon={SquareLock}
 								label="Passwort ändern"
 								onPress={() => router.push("/change-password")}
 							/>
 							<SettingsDivider />
 							<SettingsRow
+								expanded={expanded}
 								icon={Logout}
 								label="Abmelden"
 								onPress={handleLogout}

--- a/src/components/ui/list-row.tsx
+++ b/src/components/ui/list-row.tsx
@@ -7,7 +7,9 @@ import { cn } from "~/lib/utils";
 
 type ListRowProps = React.ComponentProps<typeof ActionSurface> & {
 	icon?: ReactNode;
+	iconContainerClassName?: string;
 	label: string;
+	labelClassName?: string;
 	description?: string;
 	trailing?: ReactNode;
 };
@@ -16,7 +18,9 @@ function ListRow({
 	className,
 	description,
 	icon,
+	iconContainerClassName,
 	label,
+	labelClassName,
 	trailing,
 	...props
 }: ListRowProps) {
@@ -54,6 +58,7 @@ function ListRow({
 						className={cn(
 							"h-11 w-11 shrink-0 items-center justify-center rounded-full bg-muted",
 							shouldStackInlineContent ? "mb-3" : "mr-3",
+							iconContainerClassName,
 						)}
 					>
 						{icon}
@@ -61,7 +66,10 @@ function ListRow({
 				) : null}
 				<View className="min-w-0 flex-1">
 					<Text
-						className="font-poppins font-semibold text-body-2 text-text"
+						className={cn(
+							"font-poppins font-semibold text-body-2 text-text",
+							labelClassName,
+						)}
 						numberOfLines={shouldStackInlineContent ? undefined : 1}
 					>
 						{label}

--- a/src/features/analytics/analytics-progress-card.tsx
+++ b/src/features/analytics/analytics-progress-card.tsx
@@ -1,6 +1,5 @@
 import { View } from "react-native";
 import Svg, { Circle } from "react-native-svg";
-import { Sparkles } from "~/components/ui/icon";
 import { useContentSizeLayout } from "~/components/ui/portrait-content";
 import { Surface } from "~/components/ui/surface";
 import { Text } from "~/components/ui/text";
@@ -66,43 +65,26 @@ function getProgressHeadline({
 	return "Dein Lernstand wird jetzt sichtbar";
 }
 
-function getProgressDescription({
-	secureTopics,
-	totalTopics,
-}: AnalyticsProgress) {
-	if (totalTopics === 0) return "Noch keine Prüfungsthemen bewertet.";
-	if (secureTopics === 1 && totalTopics === 1) {
-		return "Dein Prüfungsthema ist sicher belegt.";
-	}
-	if (secureTopics === 1) {
-		return `1 von ${totalTopics} Prüfungsthemen ist sicher belegt.`;
-	}
-	return `${secureTopics} von ${totalTopics} Prüfungsthemen sind sicher belegt.`;
-}
-
-function getProgressInsight({
-	latestKnowledgeChange,
-	progress,
-}: {
-	latestKnowledgeChange: string | null;
-	progress: AnalyticsProgress;
-}) {
-	if (latestKnowledgeChange) return latestKnowledgeChange;
+function getProgressMotivation(
+	progress: AnalyticsProgress,
+	ringProgress: RingProgress,
+) {
 	if (progress.totalTopics === 0) {
-		return "Öffne deinen Lernplan und ergänze zuerst die Prüfungsthemen.";
+		return "Ergänze deine Prüfungsthemen, damit dein Fortschritt sichtbar wird.";
 	}
-
-	const remainingTopics = Math.max(
-		progress.totalTopics - progress.secureTopics,
-		0,
-	);
-	if (remainingTopics === 0) {
-		return "Alle Themen sind sicher belegt. Wiederhole sie bis zur Prüfung.";
+	if (ringProgress.progressPercent === null) {
+		return "Beantworte deine ersten Fragen – dann wird dein Fortschritt sichtbar.";
 	}
-	if (remainingTopics === 1) {
-		return "Noch 1 Thema braucht weitere sichere Belege.";
+	if (ringProgress.progressPercent === 100) {
+		return "Alles sitzt – halte dein Wissen bis zur Prüfung frisch.";
 	}
-	return `Noch ${remainingTopics} Themen brauchen weitere sichere Belege.`;
+	if (ringProgress.completed === 0) {
+		return "Dein Lernstand ist jetzt sichtbar – mit jeder Aufgabe baust du darauf auf.";
+	}
+	if (ringProgress.completed === 1) {
+		return "Ein Lernkriterium sitzt bereits sicher – baue jetzt darauf auf.";
+	}
+	return `${ringProgress.completed} von ${ringProgress.total} ${ringProgress.unit} sitzen sicher – du bist auf einem guten Weg.`;
 }
 
 function TopicProgressRing({
@@ -190,28 +172,25 @@ function TopicProgressRing({
 }
 
 export function AnalyticsProgressCard({
-	latestKnowledgeChange,
 	preliminary,
 	progress,
 }: {
-	latestKnowledgeChange: string | null;
 	preliminary: boolean;
 	progress: AnalyticsProgress;
 }) {
-	const { colors } = useDayovaTheme();
 	const { shouldStackInlineContent } = useContentSizeLayout();
 	const ringProgress = getRingProgress(progress);
 
 	return (
 		<Surface
-			className="gap-3 border border-border p-2"
+			className="border border-border p-5"
 			style={continuousCardStyle}
 			testID="analysis-progress-card"
 			variant="flat"
 		>
 			<View
 				className={cn(
-					"gap-5 px-3 pt-3",
+					"gap-5",
 					shouldStackInlineContent ? "items-start" : "flex-row items-center",
 				)}
 			>
@@ -232,7 +211,7 @@ export function AnalyticsProgressCard({
 						selectable
 						className="font-poppins text-body-4 text-secondary-text"
 					>
-						{getProgressDescription(progress)}
+						{getProgressMotivation(progress, ringProgress)}
 					</Text>
 				</View>
 
@@ -242,16 +221,6 @@ export function AnalyticsProgressCard({
 						progress={ringProgress}
 					/>
 				</View>
-			</View>
-
-			<View className="flex-row items-start gap-3 rounded-lg bg-system-subtle p-4">
-				<Sparkles size={19} color={colors.primaryStrong} strokeWidth={2.2} />
-				<Text
-					selectable
-					className="min-w-0 flex-1 font-poppins text-body-4 text-text"
-				>
-					{getProgressInsight({ latestKnowledgeChange, progress })}
-				</Text>
 			</View>
 		</Surface>
 	);

--- a/src/features/analytics/analytics-progress-card.tsx
+++ b/src/features/analytics/analytics-progress-card.tsx
@@ -13,40 +13,29 @@ const PROGRESS_RING_STROKE_WIDTH = 9;
 // borderCurve is native geometry and has no NativeWind utility.
 const continuousCardStyle = { borderCurve: "continuous" } as const;
 
-export type AnalyticsProgress = {
-	assessedCriteria: number;
-	secureCriteria: number;
-	secureTopics: number;
-	totalCriteria: number;
-	totalTopics: number;
+export type AnalyticsAnswerAccuracy = {
+	answeredQuestions: number;
+	correctAnswers: number;
+	percent: number | null;
 };
 
 type RingProgress = {
-	completed: number;
+	answered: number;
+	correct: number;
 	progressPercent: number | null;
-	total: number;
-	unit: "Lernkriterien" | "Prüfungsthemen";
 };
 
-function getRingProgress(progress: AnalyticsProgress): RingProgress {
-	const usesCriteria = progress.totalCriteria > 0;
-	const safeTotal = Math.max(
-		0,
-		usesCriteria ? progress.totalCriteria : progress.totalTopics,
-	);
-	const safeCompleted = Math.min(
-		Math.max(0, usesCriteria ? progress.secureCriteria : progress.secureTopics),
-		safeTotal,
-	);
+function getRingProgress(accuracy: AnalyticsAnswerAccuracy): RingProgress {
+	const answered = Math.max(0, accuracy.answeredQuestions);
+	const correct = Math.min(Math.max(0, accuracy.correctAnswers), answered);
 
 	return {
-		completed: safeCompleted,
+		answered,
+		correct,
 		progressPercent:
-			progress.assessedCriteria > 0 && safeTotal > 0
-				? Math.round((safeCompleted / safeTotal) * 100)
+			answered > 0 && accuracy.percent !== null
+				? Math.min(Math.max(Math.round(accuracy.percent), 0), 100)
 				: null,
-		total: safeTotal,
-		unit: usesCriteria ? "Lernkriterien" : "Prüfungsthemen",
 	};
 }
 
@@ -58,36 +47,32 @@ function getProgressHeadline({
 	progressPercent: number | null;
 }) {
 	if (preliminary) return "Dein Startpunkt ist sichtbar";
-	if (progressPercent === null) return "Noch kein Lernstand belegt";
-	if (progressPercent === 100) return "Stark – du hast alles sicher belegt";
-	if (progressPercent >= 50) return "Guter Fortschritt – bleib dran";
-	if (progressPercent > 0) return "Dein Fortschritt nimmt Form an";
-	return "Dein Lernstand wird jetzt sichtbar";
+	if (progressPercent === null) return "Noch keine Antworten bewertet";
+	if (progressPercent === 100) return "Stark – alle Antworten sind richtig";
+	if (progressPercent >= 80) return "Stark – du bist auf dem richtigen Weg";
+	if (progressPercent >= 50) return "Guter Anfang – bleib dran";
+	if (progressPercent > 0) return "Jede richtige Antwort zählt";
+	return "Jetzt kannst du gezielt besser werden";
 }
 
-function getProgressMotivation(
-	progress: AnalyticsProgress,
-	ringProgress: RingProgress,
-) {
-	if (progress.totalTopics === 0) {
-		return "Ergänze deine Prüfungsthemen, damit dein Fortschritt sichtbar wird.";
-	}
+function getProgressMotivation(ringProgress: RingProgress) {
 	if (ringProgress.progressPercent === null) {
-		return "Beantworte deine ersten Fragen – dann wird dein Fortschritt sichtbar.";
+		return "Beantworte deine erste Frage – dann wird dein Fortschritt sichtbar.";
 	}
+	const questionLabel = ringProgress.answered === 1 ? "Frage" : "Fragen";
 	if (ringProgress.progressPercent === 100) {
-		return "Alles sitzt – halte dein Wissen bis zur Prüfung frisch.";
+		return `${ringProgress.correct} von ${ringProgress.answered} ${questionLabel} richtig – stark, halte dieses Niveau.`;
 	}
-	if (ringProgress.completed === 0) {
-		return "Dein Lernstand ist jetzt sichtbar – mit jeder Aufgabe baust du darauf auf.";
+	if (ringProgress.progressPercent >= 80) {
+		return `${ringProgress.correct} von ${ringProgress.answered} ${questionLabel} richtig – das ist ein starker Stand.`;
 	}
-	if (ringProgress.completed === 1) {
-		return "Ein Lernkriterium sitzt bereits sicher – baue jetzt darauf auf.";
+	if (ringProgress.progressPercent >= 50) {
+		return `${ringProgress.correct} von ${ringProgress.answered} ${questionLabel} richtig – du bist auf einem guten Weg.`;
 	}
-	return `${ringProgress.completed} von ${ringProgress.total} ${ringProgress.unit} sitzen sicher – du bist auf einem guten Weg.`;
+	return `${ringProgress.correct} von ${ringProgress.answered} ${questionLabel} richtig – jede weitere bringt dich voran.`;
 }
 
-function TopicProgressRing({
+function AnswerAccuracyRing({
 	large,
 	progress,
 }: {
@@ -102,12 +87,12 @@ function TopicProgressRing({
 		ringCircumference * (1 - (progress.progressPercent ?? 0) / 100);
 	const accessibilityValue =
 		progress.progressPercent === null
-			? { text: `Noch keine ${progress.unit} bewertet` }
+			? { text: "Noch keine Antworten bewertet" }
 			: {
 					min: 0,
 					max: 100,
 					now: progress.progressPercent,
-					text: `${progress.progressPercent} Prozent der ${progress.unit} sicher belegt`,
+					text: `${progress.progressPercent} Prozent der Antworten richtig`,
 				};
 
 	return (
@@ -115,8 +100,8 @@ function TopicProgressRing({
 			accessible
 			accessibilityLabel={
 				progress.progressPercent === null
-					? `Noch keine ${progress.unit} bewertet`
-					: `${progress.completed} von ${progress.total} ${progress.unit} sicher belegt`
+					? "Noch keine Antworten bewertet"
+					: `${progress.correct} von ${progress.answered} Antworten richtig`
 			}
 			accessibilityRole="progressbar"
 			accessibilityValue={accessibilityValue}
@@ -165,21 +150,21 @@ function TopicProgressRing({
 					: `${progress.progressPercent}%`}
 			</Text>
 			<Text className="font-poppins text-body-5 text-secondary-text">
-				{progress.progressPercent === null ? "noch offen" : "Kriterien sicher"}
+				{progress.progressPercent === null ? "noch offen" : "Antworten richtig"}
 			</Text>
 		</View>
 	);
 }
 
 export function AnalyticsProgressCard({
+	accuracy,
 	preliminary,
-	progress,
 }: {
+	accuracy: AnalyticsAnswerAccuracy;
 	preliminary: boolean;
-	progress: AnalyticsProgress;
 }) {
 	const { shouldStackInlineContent } = useContentSizeLayout();
-	const ringProgress = getRingProgress(progress);
+	const ringProgress = getRingProgress(accuracy);
 
 	return (
 		<Surface
@@ -211,12 +196,12 @@ export function AnalyticsProgressCard({
 						selectable
 						className="font-poppins text-body-4 text-secondary-text"
 					>
-						{getProgressMotivation(progress, ringProgress)}
+						{getProgressMotivation(ringProgress)}
 					</Text>
 				</View>
 
 				<View className={shouldStackInlineContent ? "self-center" : undefined}>
-					<TopicProgressRing
+					<AnswerAccuracyRing
 						large={shouldStackInlineContent}
 						progress={ringProgress}
 					/>

--- a/src/features/analytics/analytics-progress-card.tsx
+++ b/src/features/analytics/analytics-progress-card.tsx
@@ -1,0 +1,258 @@
+import { View } from "react-native";
+import Svg, { Circle } from "react-native-svg";
+import { Sparkles } from "~/components/ui/icon";
+import { useContentSizeLayout } from "~/components/ui/portrait-content";
+import { Surface } from "~/components/ui/surface";
+import { Text } from "~/components/ui/text";
+import { useDayovaTheme } from "~/lib/theme";
+import { cn } from "~/lib/utils";
+
+const PROGRESS_RING_SIZE = 108;
+const LARGE_PROGRESS_RING_SIZE = 156;
+const PROGRESS_RING_STROKE_WIDTH = 9;
+
+// borderCurve is native geometry and has no NativeWind utility.
+const continuousCardStyle = { borderCurve: "continuous" } as const;
+
+export type AnalyticsProgress = {
+	assessedCriteria: number;
+	secureCriteria: number;
+	secureTopics: number;
+	totalCriteria: number;
+	totalTopics: number;
+};
+
+type RingProgress = {
+	completed: number;
+	progressPercent: number | null;
+	total: number;
+	unit: "Lernkriterien" | "Prüfungsthemen";
+};
+
+function getRingProgress(progress: AnalyticsProgress): RingProgress {
+	const usesCriteria = progress.totalCriteria > 0;
+	const safeTotal = Math.max(
+		0,
+		usesCriteria ? progress.totalCriteria : progress.totalTopics,
+	);
+	const safeCompleted = Math.min(
+		Math.max(0, usesCriteria ? progress.secureCriteria : progress.secureTopics),
+		safeTotal,
+	);
+
+	return {
+		completed: safeCompleted,
+		progressPercent:
+			progress.assessedCriteria > 0 && safeTotal > 0
+				? Math.round((safeCompleted / safeTotal) * 100)
+				: null,
+		total: safeTotal,
+		unit: usesCriteria ? "Lernkriterien" : "Prüfungsthemen",
+	};
+}
+
+function getProgressHeadline({
+	preliminary,
+	progressPercent,
+}: {
+	preliminary: boolean;
+	progressPercent: number | null;
+}) {
+	if (preliminary) return "Dein Startpunkt ist sichtbar";
+	if (progressPercent === null) return "Noch kein Lernstand belegt";
+	if (progressPercent === 100) return "Stark – du hast alles sicher belegt";
+	if (progressPercent >= 50) return "Guter Fortschritt – bleib dran";
+	if (progressPercent > 0) return "Dein Fortschritt nimmt Form an";
+	return "Dein Lernstand wird jetzt sichtbar";
+}
+
+function getProgressDescription({
+	secureTopics,
+	totalTopics,
+}: AnalyticsProgress) {
+	if (totalTopics === 0) return "Noch keine Prüfungsthemen bewertet.";
+	if (secureTopics === 1 && totalTopics === 1) {
+		return "Dein Prüfungsthema ist sicher belegt.";
+	}
+	if (secureTopics === 1) {
+		return `1 von ${totalTopics} Prüfungsthemen ist sicher belegt.`;
+	}
+	return `${secureTopics} von ${totalTopics} Prüfungsthemen sind sicher belegt.`;
+}
+
+function getProgressInsight({
+	latestKnowledgeChange,
+	progress,
+}: {
+	latestKnowledgeChange: string | null;
+	progress: AnalyticsProgress;
+}) {
+	if (latestKnowledgeChange) return latestKnowledgeChange;
+	if (progress.totalTopics === 0) {
+		return "Öffne deinen Lernplan und ergänze zuerst die Prüfungsthemen.";
+	}
+
+	const remainingTopics = Math.max(
+		progress.totalTopics - progress.secureTopics,
+		0,
+	);
+	if (remainingTopics === 0) {
+		return "Alle Themen sind sicher belegt. Wiederhole sie bis zur Prüfung.";
+	}
+	if (remainingTopics === 1) {
+		return "Noch 1 Thema braucht weitere sichere Belege.";
+	}
+	return `Noch ${remainingTopics} Themen brauchen weitere sichere Belege.`;
+}
+
+function TopicProgressRing({
+	large,
+	progress,
+}: {
+	large: boolean;
+	progress: RingProgress;
+}) {
+	const { colors } = useDayovaTheme();
+	const ringSize = large ? LARGE_PROGRESS_RING_SIZE : PROGRESS_RING_SIZE;
+	const ringRadius = (ringSize - PROGRESS_RING_STROKE_WIDTH) / 2;
+	const ringCircumference = 2 * Math.PI * ringRadius;
+	const progressOffset =
+		ringCircumference * (1 - (progress.progressPercent ?? 0) / 100);
+	const accessibilityValue =
+		progress.progressPercent === null
+			? { text: `Noch keine ${progress.unit} bewertet` }
+			: {
+					min: 0,
+					max: 100,
+					now: progress.progressPercent,
+					text: `${progress.progressPercent} Prozent der ${progress.unit} sicher belegt`,
+				};
+
+	return (
+		<View
+			accessible
+			accessibilityLabel={
+				progress.progressPercent === null
+					? `Noch keine ${progress.unit} bewertet`
+					: `${progress.completed} von ${progress.total} ${progress.unit} sicher belegt`
+			}
+			accessibilityRole="progressbar"
+			accessibilityValue={accessibilityValue}
+			className="items-center justify-center"
+			// Ring geometry expands at accessibility text sizes.
+			style={{ width: ringSize, height: ringSize }}
+			testID="analysis-progress-ring"
+		>
+			<View className="absolute inset-0">
+				<Svg
+					accessibilityElementsHidden
+					importantForAccessibility="no-hide-descendants"
+					width={ringSize}
+					height={ringSize}
+					viewBox={`0 0 ${ringSize} ${ringSize}`}
+				>
+					<Circle
+						cx={ringSize / 2}
+						cy={ringSize / 2}
+						r={ringRadius}
+						fill="none"
+						stroke={colors.path1}
+						strokeWidth={PROGRESS_RING_STROKE_WIDTH}
+					/>
+					<Circle
+						cx={ringSize / 2}
+						cy={ringSize / 2}
+						r={ringRadius}
+						fill="none"
+						stroke={colors.success}
+						strokeDasharray={`${ringCircumference} ${ringCircumference}`}
+						strokeDashoffset={progressOffset}
+						strokeLinecap="round"
+						strokeWidth={PROGRESS_RING_STROKE_WIDTH}
+						transform={`rotate(-90 ${ringSize / 2} ${ringSize / 2})`}
+					/>
+				</Svg>
+			</View>
+			<Text
+				selectable
+				className="font-poppins font-semibold text-heading-2 text-success"
+				style={{ fontVariant: ["tabular-nums"] }}
+			>
+				{progress.progressPercent === null
+					? "–"
+					: `${progress.progressPercent}%`}
+			</Text>
+			<Text className="font-poppins text-body-5 text-secondary-text">
+				{progress.progressPercent === null ? "noch offen" : "Kriterien sicher"}
+			</Text>
+		</View>
+	);
+}
+
+export function AnalyticsProgressCard({
+	latestKnowledgeChange,
+	preliminary,
+	progress,
+}: {
+	latestKnowledgeChange: string | null;
+	preliminary: boolean;
+	progress: AnalyticsProgress;
+}) {
+	const { colors } = useDayovaTheme();
+	const { shouldStackInlineContent } = useContentSizeLayout();
+	const ringProgress = getRingProgress(progress);
+
+	return (
+		<Surface
+			className="gap-3 border border-border p-2"
+			style={continuousCardStyle}
+			testID="analysis-progress-card"
+			variant="flat"
+		>
+			<View
+				className={cn(
+					"gap-5 px-3 pt-3",
+					shouldStackInlineContent ? "items-start" : "flex-row items-center",
+				)}
+			>
+				<View className="min-w-0 flex-1 gap-2">
+					<Text className="font-poppins font-semibold text-body-5 text-success">
+						DEIN FORTSCHRITT
+					</Text>
+					<Text
+						selectable
+						className="font-poppins font-semibold text-body-1 text-text"
+					>
+						{getProgressHeadline({
+							preliminary,
+							progressPercent: ringProgress.progressPercent,
+						})}
+					</Text>
+					<Text
+						selectable
+						className="font-poppins text-body-4 text-secondary-text"
+					>
+						{getProgressDescription(progress)}
+					</Text>
+				</View>
+
+				<View className={shouldStackInlineContent ? "self-center" : undefined}>
+					<TopicProgressRing
+						large={shouldStackInlineContent}
+						progress={ringProgress}
+					/>
+				</View>
+			</View>
+
+			<View className="flex-row items-start gap-3 rounded-lg bg-system-subtle p-4">
+				<Sparkles size={19} color={colors.primaryStrong} strokeWidth={2.2} />
+				<Text
+					selectable
+					className="min-w-0 flex-1 font-poppins text-body-4 text-text"
+				>
+					{getProgressInsight({ latestKnowledgeChange, progress })}
+				</Text>
+			</View>
+		</Surface>
+	);
+}

--- a/src/features/analytics/analytics-progress-card.tsx
+++ b/src/features/analytics/analytics-progress-card.tsx
@@ -150,7 +150,7 @@ function AnswerAccuracyRing({
 					: `${progress.progressPercent}%`}
 			</Text>
 			<Text className="font-poppins text-body-5 text-secondary-text">
-				{progress.progressPercent === null ? "noch offen" : "Antworten richtig"}
+				{progress.progressPercent === null ? "noch offen" : "richtig"}
 			</Text>
 		</View>
 	);

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -166,6 +166,7 @@ const TOPIC_ANSWER_FLIP_DURATION_MS = 320;
 const TOPIC_ANSWER_CARD_MIN_HEIGHT = 240;
 const ANALYTICS_CONTENT_MAX_WIDTH = 560;
 const ANALYTICS_HORIZONTAL_PADDING = 24;
+const ANALYTICS_EXPANDED_CONTENT_MIN_WIDTH = 500;
 
 const formatTopicAnswerReview = (review: string) => {
 	const standaloneReview = review
@@ -1257,22 +1258,49 @@ function LoadingState() {
 }
 
 function EmptyState({ onCreatePlan }: { onCreatePlan: () => void }) {
+	const { usableWidth } = useContentSizeLayout({
+		containerMaxWidth: ANALYTICS_CONTENT_MAX_WIDTH,
+		requestedHorizontalPadding: ANALYTICS_HORIZONTAL_PADDING,
+	});
+	const expanded = usableWidth >= ANALYTICS_EXPANDED_CONTENT_MIN_WIDTH;
+
 	return (
-		<Surface className="items-center gap-5 px-6 py-10" variant="flat">
-			<View className="h-16 w-16 items-center justify-center rounded-full bg-system-subtle">
+		<Surface
+			className={cn(
+				"items-center gap-5 px-6 py-10",
+				expanded && "gap-6 px-10 py-12",
+			)}
+			testID="analysis-empty-state"
+			variant="flat"
+		>
+			<View
+				className={cn(
+					"h-16 w-16 items-center justify-center rounded-full bg-system-subtle",
+					expanded && "h-20 w-20",
+				)}
+				testID="analysis-empty-state-icon"
+			>
 				<Sparkles
-					size={30}
+					size={expanded ? 36 : 30}
 					color={DAYOVA_DESIGN_SYSTEM.colors.primaryStrong}
 					strokeWidth={2}
 				/>
 			</View>
-			<View className="items-center gap-2">
-				<Text className="text-center font-poppins font-semibold text-body-1 text-text">
+			<View className={cn("items-center gap-2", expanded && "gap-3")}>
+				<Text
+					className={cn(
+						"text-center font-poppins font-semibold text-body-1 text-text",
+						expanded && "text-heading-2",
+					)}
+				>
 					Deine erste Prüfungsanalyse
 				</Text>
 				<Text
 					selectable
-					className="text-center font-poppins text-body-4 text-secondary-text"
+					className={cn(
+						"text-center font-poppins text-body-4 text-secondary-text",
+						expanded && "text-body-3",
+					)}
 				>
 					Erstelle einen Lernplan. Danach zeigt Dayova, was du schon kannst, wo
 					dein Problem liegt und welcher Schritt dir als Nächstes hilft.
@@ -1280,9 +1308,12 @@ function EmptyState({ onCreatePlan }: { onCreatePlan: () => void }) {
 			</View>
 			<Button
 				accessibilityLabel="Ersten Lernplan erstellen"
+				className={expanded ? "min-h-16 px-10" : undefined}
 				onPress={onCreatePlan}
 			>
-				<Text>Ersten Lernplan erstellen</Text>
+				<Text className={expanded ? "text-body-1" : undefined}>
+					Ersten Lernplan erstellen
+				</Text>
 			</Button>
 		</Surface>
 	);

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -353,7 +353,6 @@ function AnalysisHub({
 	return (
 		<View className="gap-7">
 			<AnalyticsProgressCard
-				latestKnowledgeChange={analysis.latestKnowledgeChange}
 				preliminary={analysis.preliminary}
 				progress={{
 					assessedCriteria,
@@ -762,7 +761,7 @@ function TopicList({
 					</Text>
 				</View>
 				{requiredDimensions.length > 0 ? (
-					<View className="flex-row flex-wrap items-center gap-3">
+					<View className="flex-row items-center gap-3">
 						<View
 							accessibilityElementsHidden
 							importantForAccessibility="no-hide-descendants"
@@ -783,7 +782,7 @@ function TopicList({
 						</View>
 						<Text
 							selectable
-							className="font-poppins text-body-5 text-secondary-text"
+							className="min-w-0 flex-1 font-poppins text-body-5 text-secondary-text"
 						>
 							{`${secureDimensionCount} von ${requiredDimensions.length} Lernkriterien sicher`}
 						</Text>

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -5,7 +5,6 @@ import {
 	ActivityIndicator,
 	FlatList as NativeFlatList,
 	Pressable,
-	useWindowDimensions,
 	View,
 } from "react-native";
 import Animated, {
@@ -33,7 +32,10 @@ import {
 	Sparkles,
 	Time04,
 } from "~/components/ui/icon";
-import { useContentSizeLayout } from "~/components/ui/portrait-content";
+import {
+	PortraitContent,
+	useContentSizeLayout,
+} from "~/components/ui/portrait-content";
 import { Screen, ScreenScroll } from "~/components/ui/screen";
 import { SelectSheet } from "~/components/ui/select-sheet";
 import { ActionSurface, Surface } from "~/components/ui/surface";
@@ -162,6 +164,8 @@ const SESSION_PHASE_COPY = {
 
 const TOPIC_ANSWER_FLIP_DURATION_MS = 320;
 const TOPIC_ANSWER_CARD_MIN_HEIGHT = 240;
+const ANALYTICS_CONTENT_MAX_WIDTH = 560;
+const ANALYTICS_HORIZONTAL_PADDING = 24;
 
 const formatTopicAnswerReview = (review: string) => {
 	const standaloneReview = review
@@ -974,8 +978,10 @@ function TopicQuestionEvidenceSection({
 }: {
 	evidence: TopicQuestionEvidence | undefined;
 }) {
-	const { width } = useWindowDimensions();
-	const pagerWidth = Math.max(width - 48, 0);
+	const { usableWidth: pagerWidth } = useContentSizeLayout({
+		containerMaxWidth: ANALYTICS_CONTENT_MAX_WIDTH,
+		requestedHorizontalPadding: ANALYTICS_HORIZONTAL_PADDING,
+	});
 	const cardWidth = Math.max(pagerWidth - 24, 240);
 	const snapInterval = cardWidth + 12;
 	const questionCount = evidence?.questions.length ?? 0;
@@ -1308,59 +1314,66 @@ export function AnalyticsScreen({
 		<Screen>
 			<ThemedStatusBar />
 			<View
-				className="z-10 bg-background px-6 pb-5"
+				className="z-10 bg-background pb-5"
 				// Safe-area padding is runtime device geometry.
 				style={{ paddingTop: insets.top + 16 }}
 			>
-				<View
-					className={cn(
-						"gap-4",
-						!shouldStackInlineContent &&
-							"flex-row items-center justify-between",
-					)}
+				<PortraitContent
+					className="px-6"
+					maxWidth={ANALYTICS_CONTENT_MAX_WIDTH}
+					testID="analysis-header-content"
 				>
 					<View
 						className={cn(
-							shouldStackInlineContent ? "w-full" : "min-w-0 flex-1 pr-4",
+							"gap-4",
+							!shouldStackInlineContent &&
+								"flex-row items-center justify-between",
 						)}
 					>
-						<Text
-							accessibilityRole="header"
-							className="font-poppins font-semibold text-heading-2 text-text"
+						<View
+							className={cn(
+								shouldStackInlineContent ? "w-full" : "min-w-0 flex-1 pr-4",
+							)}
 						>
-							Analyse
-						</Text>
-						{selectedExamContext ? (
 							<Text
-								selectable
-								className="font-poppins text-body-4 text-secondary-text"
-								numberOfLines={shouldStackInlineContent ? undefined : 1}
+								accessibilityRole="header"
+								className="font-poppins font-semibold text-heading-2 text-text"
 							>
-								{selectedExamContext}
+								Analyse
 							</Text>
-						) : null}
+							{selectedExamContext ? (
+								<Text
+									selectable
+									className="font-poppins text-body-4 text-secondary-text"
+									numberOfLines={shouldStackInlineContent ? undefined : 1}
+								>
+									{selectedExamContext}
+								</Text>
+							) : null}
+						</View>
+						<View className="flex-row items-center gap-2 self-end">
+							{analysis?.hasData ? (
+								<ExamSwitcher
+									analysis={analysis}
+									onClose={() => setIsSelectorOpen(false)}
+									onOpen={() => setIsSelectorOpen(true)}
+									onSelect={setSelectedPlanId}
+									visible={isSelectorOpen}
+								/>
+							) : null}
+							<NotificationButton />
+						</View>
 					</View>
-					<View className="flex-row items-center gap-2 self-end">
-						{analysis?.hasData ? (
-							<ExamSwitcher
-								analysis={analysis}
-								onClose={() => setIsSelectorOpen(false)}
-								onOpen={() => setIsSelectorOpen(true)}
-								onSelect={setSelectedPlanId}
-								visible={isSelectorOpen}
-							/>
-						) : null}
-						<NotificationButton />
-					</View>
-				</View>
+				</PortraitContent>
 			</View>
 
 			<ScreenScroll
 				testID="analysis-scroll"
+				contentMaxWidth={ANALYTICS_CONTENT_MAX_WIDTH}
 				includeTopSafeArea={false}
 				topPadding={20}
 				bottomPadding={150}
-				horizontalPadding={24}
+				horizontalPadding={ANALYTICS_HORIZONTAL_PADDING}
 			>
 				<View className="gap-7">
 					{analysis === undefined ? (
@@ -1410,11 +1423,12 @@ export function AnalyticsHistoryScreen() {
 		<Screen>
 			<ThemedStatusBar />
 			<ScreenScroll
+				contentMaxWidth={ANALYTICS_CONTENT_MAX_WIDTH}
 				contentInsetAdjustmentBehavior="automatic"
 				includeTopSafeArea={false}
 				topPadding={24}
 				bottomPadding={72}
-				horizontalPadding={24}
+				horizontalPadding={ANALYTICS_HORIZONTAL_PADDING}
 			>
 				{overview === undefined ? (
 					<LoadingState />
@@ -1660,11 +1674,12 @@ export function AnalyticsDetailScreen({
 		<Screen>
 			<ThemedStatusBar />
 			<ScreenScroll
+				contentMaxWidth={ANALYTICS_CONTENT_MAX_WIDTH}
 				contentInsetAdjustmentBehavior="automatic"
 				includeTopSafeArea={false}
 				topPadding={24}
 				bottomPadding={72}
-				horizontalPadding={24}
+				horizontalPadding={ANALYTICS_HORIZONTAL_PADDING}
 			>
 				{analysis === undefined ? (
 					<LoadingState />

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -735,8 +735,7 @@ function TopicList({
 						strokeWidth={2.2}
 					/>
 				</View>
-				<View className="flex-row flex-wrap items-center gap-2">
-					<TopicStatusPill status={topic.status} />
+				<View className="flex-row flex-wrap items-center">
 					<Text
 						selectable
 						className="font-poppins text-body-5 text-secondary-text"

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -33,6 +33,7 @@ import {
 	Sparkles,
 	Time04,
 } from "~/components/ui/icon";
+import { useContentSizeLayout } from "~/components/ui/portrait-content";
 import { Screen, ScreenScroll } from "~/components/ui/screen";
 import { SelectSheet } from "~/components/ui/select-sheet";
 import { ActionSurface, Surface } from "~/components/ui/surface";
@@ -45,6 +46,7 @@ import { formatGermanUiText } from "~/lib/german-ui-text";
 import { ROUTES, withReturnTo } from "~/lib/routes";
 import { useDayovaTheme } from "~/lib/theme";
 import { cn } from "~/lib/utils";
+import { AnalyticsProgressCard } from "./analytics-progress-card";
 
 type ExamAnalysis = NonNullable<
 	ReturnType<typeof useQuery<typeof api.userAnalytics.getExamAnalysis>>
@@ -111,6 +113,28 @@ const TOPIC_STATUS_COPY: Record<
 		textClassName: "text-secondary-text",
 	},
 };
+
+const TOPIC_CRITERION_CLASS: Record<TopicStatus, string> = {
+	secure: "border-success bg-success",
+	developing: "border-info bg-info",
+	uncertain: "border-wrong bg-wrong",
+	unknown: "border-border bg-transparent",
+};
+
+function TopicCriterionIcon({ status }: { status: TopicStatus }) {
+	const iconColor = DAYOVA_DESIGN_SYSTEM.colors.buttonNeutral;
+
+	if (status === "secure") {
+		return <Check size={12} color={iconColor} strokeWidth={3} />;
+	}
+	if (status === "developing") {
+		return <ArrowUpRight size={12} color={iconColor} strokeWidth={3} />;
+	}
+	if (status === "uncertain") {
+		return <CircleAlert size={12} color={iconColor} strokeWidth={2.5} />;
+	}
+	return null;
+}
 
 const ANSWER_RATING_COPY = {
 	correct: {
@@ -316,12 +340,33 @@ function AnalysisHub({
 }) {
 	const { colors } = useDayovaTheme();
 	const recommendation = analysis.recommendation;
+	const requiredCriteria = analysis.topics.flatMap((topic) =>
+		topic.dimensions.filter((dimension) => dimension.required),
+	);
+	const secureCriteria = requiredCriteria.filter(
+		(criterion) => criterion.status === "secure",
+	).length;
+	const assessedCriteria = requiredCriteria.filter(
+		(criterion) => criterion.status !== "unknown",
+	).length;
 
 	return (
 		<View className="gap-7">
+			<AnalyticsProgressCard
+				latestKnowledgeChange={analysis.latestKnowledgeChange}
+				preliminary={analysis.preliminary}
+				progress={{
+					assessedCriteria,
+					secureCriteria,
+					secureTopics: analysis.readiness.secure,
+					totalCriteria: requiredCriteria.length,
+					totalTopics: analysis.topics.length,
+				}}
+			/>
+
 			<View className="gap-4">
 				<SectionHeading
-					title="Deine Prüfungsthemen"
+					title="Deine Themen im Detail"
 					description="Nach Prüfungsrelevanz und Lernrisiko sortiert."
 				/>
 				<Surface
@@ -670,6 +715,12 @@ function TopicList({
 
 	return topics.map((topic, index) => {
 		const status = TOPIC_STATUS_COPY[topic.status];
+		const requiredDimensions = topic.dimensions.filter(
+			(dimension) => dimension.required,
+		);
+		const secureDimensionCount = requiredDimensions.filter(
+			(dimension) => dimension.status === "secure",
+		).length;
 		const answerCountLabel =
 			topic.answeredQuestionCount === 0
 				? "Keine Antworten"
@@ -678,7 +729,7 @@ function TopicList({
 			<ActionSurface
 				key={topic.id}
 				accessibilityHint="Öffnet deinen Wissensstand und alle ausgewerteten Antworten für dieses Thema."
-				accessibilityLabel={`${topic.title}. ${status.label}. ${topic.answeredQuestionCount} ${topic.answeredQuestionCount === 1 ? "ausgewertete Antwort" : "ausgewertete Antworten"}.`}
+				accessibilityLabel={`${topic.title}. ${status.label}. ${topic.answeredQuestionCount} ${topic.answeredQuestionCount === 1 ? "ausgewertete Antwort" : "ausgewertete Antworten"}. ${secureDimensionCount} von ${requiredDimensions.length} Lernkriterien sicher belegt.`}
 				accessibilityRole="button"
 				className={cn(
 					"min-h-20 gap-2 rounded-none bg-card px-5 py-4",
@@ -710,6 +761,34 @@ function TopicList({
 						{answerCountLabel}
 					</Text>
 				</View>
+				{requiredDimensions.length > 0 ? (
+					<View className="flex-row flex-wrap items-center gap-3">
+						<View
+							accessibilityElementsHidden
+							importantForAccessibility="no-hide-descendants"
+							className="flex-row gap-2"
+						>
+							{requiredDimensions.map((dimension) => (
+								<View
+									key={dimension.kind}
+									className={cn(
+										"h-5 w-5 items-center justify-center rounded-full border-2",
+										TOPIC_CRITERION_CLASS[dimension.status],
+									)}
+									testID={`topic-criterion-${topic.id}-${dimension.kind}`}
+								>
+									<TopicCriterionIcon status={dimension.status} />
+								</View>
+							))}
+						</View>
+						<Text
+							selectable
+							className="font-poppins text-body-5 text-secondary-text"
+						>
+							{`${secureDimensionCount} von ${requiredDimensions.length} Lernkriterien sicher`}
+						</Text>
+					</View>
+				) : null}
 			</ActionSurface>
 		);
 	});
@@ -1228,6 +1307,7 @@ export function AnalyticsScreen({
 }) {
 	const router = useRouter();
 	const insets = useSafeAreaInsets();
+	const { shouldStackInlineContent } = useContentSizeLayout();
 	const [selectedPlanId, setSelectedPlanId] =
 		useState<Id<"learningPlans"> | null>(initialPlanId ?? null);
 	const [isSelectorOpen, setIsSelectorOpen] = useState(false);
@@ -1250,8 +1330,18 @@ export function AnalyticsScreen({
 				// Safe-area padding is runtime device geometry.
 				style={{ paddingTop: insets.top + 16 }}
 			>
-				<View className="flex-row items-center justify-between">
-					<View className="min-w-0 flex-1 pr-4">
+				<View
+					className={cn(
+						"gap-4",
+						!shouldStackInlineContent &&
+							"flex-row items-center justify-between",
+					)}
+				>
+					<View
+						className={cn(
+							shouldStackInlineContent ? "w-full" : "min-w-0 flex-1 pr-4",
+						)}
+					>
 						<Text
 							accessibilityRole="header"
 							className="font-poppins font-semibold text-heading-2 text-text"
@@ -1262,13 +1352,13 @@ export function AnalyticsScreen({
 							<Text
 								selectable
 								className="font-poppins text-body-4 text-secondary-text"
-								numberOfLines={1}
+								numberOfLines={shouldStackInlineContent ? undefined : 1}
 							>
 								{selectedExamContext}
 							</Text>
 						) : null}
 					</View>
-					<View className="flex-row items-center gap-2">
+					<View className="flex-row items-center gap-2 self-end">
 						{analysis?.hasData ? (
 							<ExamSwitcher
 								analysis={analysis}

--- a/src/features/analytics/analytics-screen.tsx
+++ b/src/features/analytics/analytics-screen.tsx
@@ -340,27 +340,11 @@ function AnalysisHub({
 }) {
 	const { colors } = useDayovaTheme();
 	const recommendation = analysis.recommendation;
-	const requiredCriteria = analysis.topics.flatMap((topic) =>
-		topic.dimensions.filter((dimension) => dimension.required),
-	);
-	const secureCriteria = requiredCriteria.filter(
-		(criterion) => criterion.status === "secure",
-	).length;
-	const assessedCriteria = requiredCriteria.filter(
-		(criterion) => criterion.status !== "unknown",
-	).length;
-
 	return (
 		<View className="gap-7">
 			<AnalyticsProgressCard
+				accuracy={analysis.answerAccuracy}
 				preliminary={analysis.preliminary}
-				progress={{
-					assessedCriteria,
-					secureCriteria,
-					secureTopics: analysis.readiness.secure,
-					totalCriteria: requiredCriteria.length,
-					totalTopics: analysis.topics.length,
-				}}
 			/>
 
 			<View className="gap-4">

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -178,6 +178,11 @@ const emptyAnalysis = {
 		uncertain: 0,
 		unknown: 0,
 	},
+	answerAccuracy: {
+		answeredQuestions: 0,
+		correctAnswers: 0,
+		percent: null,
+	},
 	abilities: [],
 	improvements: [],
 	latestKnowledgeChange: null,
@@ -227,6 +232,11 @@ const examAnalysis = {
 		developing: 0,
 		uncertain: 1,
 		unknown: 0,
+	},
+	answerAccuracy: {
+		answeredQuestions: 10,
+		correctAnswers: 9,
+		percent: 90,
 	},
 	abilities: [
 		{
@@ -467,21 +477,19 @@ describe("AnalyticsScreen", () => {
 		expect(screen.queryByText("1 unsicher")).not.toBeOnTheScreen();
 		expect(screen.getByText("Deine Themen im Detail")).toBeOnTheScreen();
 		expect(
-			screen.getByText("Guter Fortschritt – bleib dran"),
+			screen.getByText("Stark – du bist auf dem richtigen Weg"),
 		).toBeOnTheScreen();
-		expect(screen.getByText("67%")).toBeOnTheScreen();
+		expect(screen.getByText("90%")).toBeOnTheScreen();
 		expect(
-			screen.getByText(
-				"4 von 6 Lernkriterien sitzen sicher – du bist auf einem guten Weg.",
-			),
+			screen.getByText("9 von 10 Fragen richtig – das ist ein starker Stand."),
 		).toBeOnTheScreen();
 		expect(
 			screen.getByTestId("analysis-progress-ring").props.accessibilityValue,
 		).toEqual({
 			min: 0,
 			max: 100,
-			now: 67,
-			text: "67 Prozent der Lernkriterien sicher belegt",
+			now: 90,
+			text: "90 Prozent der Antworten richtig",
 		});
 		expect(screen.getByTestId("topic-list").props.className).toContain(
 			"border-border",
@@ -591,6 +599,11 @@ describe("AnalyticsScreen", () => {
 	test("does not show an aggregate knowledge card without evidence", async () => {
 		mockUseQuery.mockReturnValue({
 			...examAnalysis,
+			answerAccuracy: {
+				answeredQuestions: 0,
+				correctAnswers: 0,
+				percent: null,
+			},
 			readiness: {
 				secure: 0,
 				developing: 0,
@@ -618,7 +631,7 @@ describe("AnalyticsScreen", () => {
 		expect(screen.getByText("–")).toBeOnTheScreen();
 		expect(
 			screen.getByTestId("analysis-progress-ring").props.accessibilityValue,
-		).toEqual({ text: "Noch keine Lernkriterien bewertet" });
+		).toEqual({ text: "Noch keine Antworten bewertet" });
 		expect(
 			screen.queryByText("Noch keine Wissensbelege"),
 		).not.toBeOnTheScreen();

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -480,6 +480,8 @@ describe("AnalyticsScreen", () => {
 			screen.getByText("Stark – du bist auf dem richtigen Weg"),
 		).toBeOnTheScreen();
 		expect(screen.getByText("90%")).toBeOnTheScreen();
+		expect(screen.getByText("richtig")).toBeOnTheScreen();
+		expect(screen.queryByText("Antworten richtig")).not.toBeOnTheScreen();
 		expect(
 			screen.getByText("9 von 10 Fragen richtig – das ist ein starker Stand."),
 		).toBeOnTheScreen();
@@ -516,8 +518,13 @@ describe("AnalyticsScreen", () => {
 			}).props.className,
 		).toContain("bg-transparent");
 		expect(
-			within(screen.getByTestId("topic-row-steigung")).getByText("Unsicher"),
-		).toBeOnTheScreen();
+			within(screen.getByTestId("topic-row-steigung")).queryByText("Unsicher"),
+		).not.toBeOnTheScreen();
+		expect(
+			within(screen.getByTestId("topic-row-achsenschnitt")).queryByText(
+				"Sicher belegt",
+			),
+		).not.toBeOnTheScreen();
 		expect(
 			within(screen.getByTestId("topic-row-steigung")).getByText("2 Antworten"),
 		).toBeOnTheScreen();

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -468,6 +468,9 @@ describe("AnalyticsScreen", () => {
 
 	test("guides a new learner to create the first plan", async () => {
 		const screen = await render(<AnalyticsScreen />);
+		expect(
+			screen.getByTestId("analysis-empty-state-icon").props.className,
+		).toContain("h-20 w-20");
 		await fireEvent.press(
 			screen.getByRole("button", { name: "Ersten Lernplan erstellen" }),
 		);

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -465,7 +465,22 @@ describe("AnalyticsScreen", () => {
 		expect(screen.queryByText("1/2")).not.toBeOnTheScreen();
 		expect(screen.queryByText("1 von 2 sicher belegt")).not.toBeOnTheScreen();
 		expect(screen.queryByText("1 unsicher")).not.toBeOnTheScreen();
-		expect(screen.getByText("Deine Prüfungsthemen")).toBeOnTheScreen();
+		expect(screen.getByText("Deine Themen im Detail")).toBeOnTheScreen();
+		expect(
+			screen.getByText("Guter Fortschritt – bleib dran"),
+		).toBeOnTheScreen();
+		expect(screen.getByText("67%")).toBeOnTheScreen();
+		expect(
+			screen.getByText("1 von 2 Prüfungsthemen ist sicher belegt."),
+		).toBeOnTheScreen();
+		expect(
+			screen.getByTestId("analysis-progress-ring").props.accessibilityValue,
+		).toEqual({
+			min: 0,
+			max: 100,
+			now: 67,
+			text: "67 Prozent der Lernkriterien sicher belegt",
+		});
 		expect(screen.getByTestId("topic-list").props.className).toContain(
 			"border-border",
 		);
@@ -473,6 +488,23 @@ describe("AnalyticsScreen", () => {
 		expect(screen.getByText("Achsenschnittpunkte bestimmen")).toBeOnTheScreen();
 		expect(screen.getByText("2 Antworten")).toBeOnTheScreen();
 		expect(screen.getByText("3 Antworten")).toBeOnTheScreen();
+		expect(screen.getByText("1 von 3 Lernkriterien sicher")).toBeOnTheScreen();
+		expect(screen.getByText("3 von 3 Lernkriterien sicher")).toBeOnTheScreen();
+		expect(
+			screen.getByTestId("topic-criterion-steigung-understanding", {
+				includeHiddenElements: true,
+			}).props.className,
+		).toContain("bg-success");
+		expect(
+			screen.getByTestId("topic-criterion-steigung-problemSolving", {
+				includeHiddenElements: true,
+			}).props.className,
+		).toContain("bg-wrong");
+		expect(
+			screen.getByTestId("topic-criterion-steigung-independent", {
+				includeHiddenElements: true,
+			}).props.className,
+		).toContain("bg-transparent");
 		expect(
 			within(screen.getByTestId("topic-row-steigung")).getByText("Unsicher"),
 		).toBeOnTheScreen();
@@ -490,7 +522,7 @@ describe("AnalyticsScreen", () => {
 			screen.queryByText(
 				"Seit deinem letzten Check: Steigung gelingt dir jetzt sicherer.",
 			),
-		).not.toBeOnTheScreen();
+		).toBeOnTheScreen();
 		expect(screen.getByText("Dein nächster Schritt")).toBeOnTheScreen();
 		expect(screen.queryByText("Größte Lernhürde")).not.toBeOnTheScreen();
 		expect(screen.queryByText("Dein Prüfungsstoff")).not.toBeOnTheScreen();
@@ -509,7 +541,7 @@ describe("AnalyticsScreen", () => {
 
 		await fireEvent.press(
 			screen.getByRole("button", {
-				name: "Steigung erklären. Unsicher. 2 ausgewertete Antworten.",
+				name: "Steigung erklären. Unsicher. 2 ausgewertete Antworten. 1 von 3 Lernkriterien sicher belegt.",
 			}),
 		);
 		expect(mockPush).toHaveBeenCalledWith({
@@ -546,7 +578,7 @@ describe("AnalyticsScreen", () => {
 		expect(screen.queryByText("0/5")).not.toBeOnTheScreen();
 		expect(screen.queryByText("0 von 5 sicher belegt")).not.toBeOnTheScreen();
 		expect(screen.queryByText("5 im Aufbau")).not.toBeOnTheScreen();
-		expect(screen.getByText("Deine Prüfungsthemen")).toBeOnTheScreen();
+		expect(screen.getByText("Deine Themen im Detail")).toBeOnTheScreen();
 		expect(
 			screen.queryByText(
 				"Du arbeitest an allen 5 Prüfungsthemen, aber noch keines ist sicher belegt.",
@@ -581,12 +613,15 @@ describe("AnalyticsScreen", () => {
 		const screen = await render(<AnalyticsScreen />);
 
 		expect(screen.queryByText("Dein Wissensstand")).not.toBeOnTheScreen();
-		expect(screen.queryByText("–")).not.toBeOnTheScreen();
+		expect(screen.getByText("–")).toBeOnTheScreen();
+		expect(
+			screen.getByTestId("analysis-progress-ring").props.accessibilityValue,
+		).toEqual({ text: "Noch keine Lernkriterien bewertet" });
 		expect(
 			screen.queryByText("Noch keine Wissensbelege"),
 		).not.toBeOnTheScreen();
 		expect(screen.queryByText("0/2")).not.toBeOnTheScreen();
-		expect(screen.getByText("Deine Prüfungsthemen")).toBeOnTheScreen();
+		expect(screen.getByText("Deine Themen im Detail")).toBeOnTheScreen();
 	});
 
 	test("reveals evidence and starts the recommendation from focused pages", async () => {

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -100,11 +100,18 @@ jest.mock("~/components/ui/screen", () => {
 			React.createElement(Native.View, null, children),
 		ScreenScroll: ({
 			children,
+			contentMaxWidth,
 			testID,
 		}: {
 			children: ReactNode;
+			contentMaxWidth?: number;
 			testID?: string;
-		}) => React.createElement(Native.View, { testID }, children),
+		}) =>
+			React.createElement(
+				Native.View,
+				{ style: { maxWidth: contentMaxWidth }, testID },
+				children,
+			),
 	};
 });
 
@@ -476,6 +483,12 @@ describe("AnalyticsScreen", () => {
 		expect(screen.queryByText("1 von 2 sicher belegt")).not.toBeOnTheScreen();
 		expect(screen.queryByText("1 unsicher")).not.toBeOnTheScreen();
 		expect(screen.getByText("Deine Themen im Detail")).toBeOnTheScreen();
+		expect(screen.getByTestId("analysis-scroll").props.style.maxWidth).toBe(
+			560,
+		);
+		expect(screen.getByTestId("analysis-header-content").props.style).toEqual(
+			expect.arrayContaining([expect.objectContaining({ maxWidth: 560 })]),
+		);
 		expect(
 			screen.getByText("Stark – du bist auf dem richtigen Weg"),
 		).toBeOnTheScreen();
@@ -713,7 +726,7 @@ describe("AnalyticsScreen", () => {
 		).not.toBeOnTheScreen();
 		const answerPager = knowledgeScreen.getByTestId("topic-answer-pager");
 		expect(answerPager.props.horizontal).toBe(true);
-		expect(answerPager.props.snapToInterval).toBeGreaterThan(0);
+		expect(answerPager.props.snapToInterval).toBeLessThan(560);
 		expect(
 			knowledgeScreen.getByText("Erkläre die Steigung."),
 		).toBeOnTheScreen();

--- a/src/features/analytics/analytics-screen.ui.test.tsx
+++ b/src/features/analytics/analytics-screen.ui.test.tsx
@@ -471,7 +471,9 @@ describe("AnalyticsScreen", () => {
 		).toBeOnTheScreen();
 		expect(screen.getByText("67%")).toBeOnTheScreen();
 		expect(
-			screen.getByText("1 von 2 Prüfungsthemen ist sicher belegt."),
+			screen.getByText(
+				"4 von 6 Lernkriterien sitzen sicher – du bist auf einem guten Weg.",
+			),
 		).toBeOnTheScreen();
 		expect(
 			screen.getByTestId("analysis-progress-ring").props.accessibilityValue,
@@ -522,7 +524,7 @@ describe("AnalyticsScreen", () => {
 			screen.queryByText(
 				"Seit deinem letzten Check: Steigung gelingt dir jetzt sicherer.",
 			),
-		).toBeOnTheScreen();
+		).not.toBeOnTheScreen();
 		expect(screen.getByText("Dein nächster Schritt")).toBeOnTheScreen();
 		expect(screen.queryByText("Größte Lernhürde")).not.toBeOnTheScreen();
 		expect(screen.queryByText("Dein Prüfungsstoff")).not.toBeOnTheScreen();

--- a/src/features/settings/settings-screen.ui.test.tsx
+++ b/src/features/settings/settings-screen.ui.test.tsx
@@ -44,8 +44,20 @@ jest.mock("~/components/ui/screen", () => {
 	return {
 		Screen: ({ children }: { children: ReactNode }) =>
 			React.createElement(Native.View, null, children),
-		ScreenScroll: ({ children }: { children: ReactNode }) =>
-			React.createElement(Native.View, null, children),
+		ScreenScroll: ({
+			children,
+			contentMaxWidth,
+			testID,
+		}: {
+			children: ReactNode;
+			contentMaxWidth?: number;
+			testID?: string;
+		}) =>
+			React.createElement(
+				Native.View,
+				{ style: { maxWidth: contentMaxWidth }, testID },
+				children,
+			),
 	};
 });
 
@@ -69,6 +81,9 @@ describe("SettingsScreen", () => {
 		expect(screen.getByRole("header", { name: "Lernen" })).toBeOnTheScreen();
 		expect(screen.getByRole("header", { name: "App" })).toBeOnTheScreen();
 		expect(screen.getByRole("header", { name: "Konto" })).toBeOnTheScreen();
+		expect(screen.getByTestId("settings-scroll").props.style.maxWidth).toBe(
+			640,
+		);
 
 		await fireEvent.press(screen.getByRole("button", { name: "Stundenplan" }));
 		expect(mockPush).toHaveBeenCalledWith("/timetable");


### PR DESCRIPTION
## What changed

- add an evidence-based progress overview to the Analyse tab
- calculate incremental progress from secure learning criteria while keeping topic readiness explicit
- replace heavy criterion bars with compact semantic markers: check for secure, arrow for developing, alert for uncertain, and outline for unknown
- distinguish unassessed progress from a measured 0%
- keep the header and progress ring resilient at accessibility text sizes
- include topic-level progress in screen-reader labels

## Why

The previous Analyse view exposed topic statuses but did not give learners a clear at-a-glance sense of progress. This brings the hierarchy and visual rhythm of the supplied reference into Dayova without inventing an accuracy or strength score unsupported by the learning evidence.

## Validation

- `pnpm check`
- `pnpm test:unit` (635 Vitest tests plus repository script suites)
- `pnpm exec jest src/features/analytics/analytics-screen.ui.test.tsx --runInBand` (10 tests)
- live iOS simulator inspection with realistic Chemistry data in dark mode
- accessibility-large text-size inspection, then simulator settings restored

## Note

The full UI suite was also run once. Its Analyse tests passed; one unrelated pre-existing failure remains in `src/components/entry/exam-flow.ui.test.tsx` for the missing `Im Kalender auswählen` text.