### PR TITLE
Lock iPad to full-screen portrait

### DIFF
--- a/app.config.cts
+++ b/app.config.cts
@@ -75,6 +75,7 @@ const config: ExpoConfig = {
 	},
 	ios: {
 		supportsTablet: true,
+		requireFullScreen: true,
 		bundleIdentifier: isProduction ? "de.dayova.app" : "de.dayova.app-dev",
 		runtimeVersion: APP_VERSION,
 		infoPlist: {

--- a/tests/app-config-loading.test.ts
+++ b/tests/app-config-loading.test.ts
@@ -1,9 +1,12 @@
 import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { spawnSync } from "node:child_process";
+import type { ExpoConfig } from "expo/config";
 import { describe, expect, it } from "vitest";
 
+const require = createRequire(import.meta.url);
 const APP_CONFIG_PATH = ["app.config.cts", "app.config.ts"]
 	.map((filename) => resolve(process.cwd(), filename))
 	.find(existsSync);
@@ -34,5 +37,29 @@ describe("Expo app config loading", () => {
 			"require is not defined in ES module scope",
 		);
 		expect(result.status, result.stderr).toBe(0);
+	});
+
+	it("keeps iPhone and iPad layouts in full-screen portrait", () => {
+		expect(APP_CONFIG_PATH).toBeDefined();
+
+		const previousAppVariant = process.env.APP_VARIANT;
+		process.env.APP_VARIANT = "development";
+
+		let appConfig: ExpoConfig;
+		try {
+			const appConfigPath = require.resolve(APP_CONFIG_PATH ?? "");
+			delete require.cache[appConfigPath];
+			appConfig = require(appConfigPath) as ExpoConfig;
+		} finally {
+			if (previousAppVariant === undefined) {
+				delete process.env.APP_VARIANT;
+			} else {
+				process.env.APP_VARIANT = previousAppVariant;
+			}
+		}
+
+		expect(appConfig.orientation).toBe("portrait");
+		expect(appConfig.ios?.supportsTablet).toBe(true);
+		expect(appConfig.ios?.requireFullScreen).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

- keep iPhone and iPad layouts portrait-only
- require full-screen iPad presentation, disabling Split View and Slide Over
- protect the orientation contract with an Expo config regression test

## Verification

- `pnpm exec vitest run tests/app-config-loading.test.ts`
- `pnpm check`
- `APP_VARIANT=development pnpm exec expo prebuild --platform ios --no-install`
- `APP_VARIANT=development pnpm exec expo run:ios --device 21A71B11-8E65-49AE-AED5-DAA304DFB186 --no-bundler`
- verified the installed iPad simulator binary has `UIRequiresFullScreen = true`, only portrait orientations, and no iPad-specific landscape list

## Simulator evidence

Screenshots captured on iPad Pro 11-inch (M5), iOS 26.5. Attachments follow.