### PR TITLE
Fix paid entitlement schema compatibility

### DIFF
--- a/convex/entitlements.test.ts
+++ b/convex/entitlements.test.ts
@@ -71,6 +71,81 @@ test("authenticated account without an entitlement requires activation", async (
 	});
 });
 
+test("paid-only entitlement remains valid without trial metadata", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	await t.mutation(api.users.syncCurrentUser, {});
+	const now = Date.parse("2026-07-28T10:00:00.000Z");
+	const expiresAt = Date.parse("2026-08-28T10:00:00.000Z");
+
+	await t.run(async (ctx) => {
+		const storedUser = await ctx.db
+			.query("users")
+			.withIndex("by_tokenIdentifier", (query) =>
+				query.eq("tokenIdentifier", user.tokenIdentifier),
+			)
+			.unique();
+		if (!storedUser) throw new Error("Expected the test user to exist.");
+
+		await ctx.db.insert("accessEntitlements", {
+			ownerTokenIdentifier: user.tokenIdentifier,
+			userId: storedUser._id,
+			revenueCatEntitlementActive: true,
+			subscriptionExpiresAt: expiresAt,
+			subscriptionProductId: "dayova_annual_web",
+			subscriptionStore: "rc_billing",
+			subscriptionVerifiedAt: now,
+			subscriptionWillRenew: true,
+			createdAt: now,
+			updatedAt: now,
+		});
+	});
+
+	await expect(
+		t.query(api.entitlements.getMyAccess, { now }),
+	).resolves.toMatchObject({
+		canUseApp: true,
+		state: "paid",
+		subscriptionExpiresAt: expiresAt,
+	});
+	await expect(
+		t.query(api.entitlements.getMyAccess, { now: expiresAt }),
+	).resolves.toMatchObject({
+		canUseApp: false,
+		state: "expired",
+		subscriptionExpiresAt: expiresAt,
+	});
+});
+
+test("partial trial metadata is rejected", async () => {
+	const t = convexTest(schema, modules).withIdentity(user);
+	await t.mutation(api.users.syncCurrentUser, {});
+	const now = Date.parse("2026-07-28T10:00:00.000Z");
+
+	await expect(
+		t.run(async (ctx) => {
+			const storedUser = await ctx.db
+				.query("users")
+				.withIndex("by_tokenIdentifier", (query) =>
+					query.eq("tokenIdentifier", user.tokenIdentifier),
+				)
+				.unique();
+			if (!storedUser) throw new Error("Expected the test user to exist.");
+
+			const partialTrialEntitlement = {
+				ownerTokenIdentifier: user.tokenIdentifier,
+				userId: storedUser._id,
+				trialStartedAt: now,
+				createdAt: now,
+				updatedAt: now,
+			};
+			await ctx.db.insert(
+				"accessEntitlements",
+				partialTrialEntitlement as never,
+			);
+		}),
+	).rejects.toThrow();
+});
+
 test("trial access expires exactly 14 days after activation", async () => {
 	vi.useFakeTimers();
 	vi.setSystemTime(new Date("2026-07-28T10:00:00.000Z"));

--- a/convex/entitlements.ts
+++ b/convex/entitlements.ts
@@ -64,6 +64,28 @@ const toPaidAccess = (entitlement: {
 	willRenew: entitlement.subscriptionWillRenew ?? false,
 });
 
+const toExpiredAccess = (
+	entitlement: {
+		subscriptionExpiresAt?: number;
+		subscriptionGraceExpiresAt?: number;
+		subscriptionManagementUrl?: string;
+		subscriptionProductId?: string;
+		subscriptionStore?: string;
+		subscriptionWillRenew?: boolean;
+	},
+	trialAccess?: ReturnType<typeof toTrialAccess>,
+) => ({
+	...trialAccess,
+	canUseApp: false,
+	managementUrl: entitlement.subscriptionManagementUrl,
+	productId: entitlement.subscriptionProductId,
+	state: "expired" as const,
+	store: entitlement.subscriptionStore,
+	subscriptionExpiresAt: entitlement.subscriptionExpiresAt,
+	subscriptionGraceExpiresAt: entitlement.subscriptionGraceExpiresAt,
+	willRenew: entitlement.subscriptionWillRenew ?? false,
+});
+
 const getCurrentAccess = (
 	entitlement: Doc<"accessEntitlements">,
 	now: number,
@@ -75,21 +97,22 @@ const getCurrentAccess = (
 		return toPaidAccess(entitlement);
 	}
 
-	if (now >= entitlement.trialExpiresAt) {
-		return {
-			...toTrialAccess(entitlement),
-			canUseApp: false,
-			managementUrl: entitlement.subscriptionManagementUrl,
-			productId: entitlement.subscriptionProductId,
-			state: "expired" as const,
-			store: entitlement.subscriptionStore,
-			subscriptionExpiresAt: entitlement.subscriptionExpiresAt,
-			subscriptionGraceExpiresAt: entitlement.subscriptionGraceExpiresAt,
-			willRenew: entitlement.subscriptionWillRenew ?? false,
-		};
+	if (!("trialStartedAt" in entitlement)) {
+		return toExpiredAccess(entitlement);
 	}
 
-	return toTrialAccess(entitlement);
+	const trialAccess = toTrialAccess({
+		trialStartedAt: entitlement.trialStartedAt,
+		trialExpiresAt: entitlement.trialExpiresAt,
+		trialReminderAt: entitlement.trialReminderAt,
+		trialTermsVersion: entitlement.trialTermsVersion,
+	});
+
+	if (now >= entitlement.trialExpiresAt) {
+		return toExpiredAccess(entitlement, trialAccess);
+	}
+
+	return trialAccess;
 };
 
 const getCurrentUser = async (ctx: MutationCtx | QueryCtx) => {
@@ -204,6 +227,7 @@ export const deliverTrialReminder = internalMutation({
 			.unique();
 		if (
 			!entitlement ||
+			!("trialStartedAt" in entitlement) ||
 			entitlement.trialExpiresAt !== args.expectedTrialExpiresAt
 		) {
 			return { created: false };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -129,6 +129,30 @@ const sessionContentChoiceValidator = v.object({
 	text: v.string(),
 });
 
+const accessEntitlementWithoutTrialValidator = v.object({
+	ownerTokenIdentifier: v.string(),
+	userId: v.id("users"),
+	revenueCatEntitlementActive: v.optional(v.boolean()),
+	subscriptionExpiresAt: v.optional(v.number()),
+	subscriptionGraceExpiresAt: v.optional(v.number()),
+	subscriptionProductId: v.optional(v.string()),
+	subscriptionStore: v.optional(v.string()),
+	subscriptionWillRenew: v.optional(v.boolean()),
+	subscriptionBillingIssueDetectedAt: v.optional(v.number()),
+	subscriptionManagementUrl: v.optional(v.string()),
+	subscriptionVerifiedAt: v.optional(v.number()),
+	createdAt: v.number(),
+	updatedAt: v.number(),
+});
+
+const accessEntitlementWithTrialValidator =
+	accessEntitlementWithoutTrialValidator.extend({
+		trialStartedAt: v.number(),
+		trialExpiresAt: v.number(),
+		trialReminderAt: v.number(),
+		trialTermsVersion: v.string(),
+	});
+
 export default defineSchema({
 	users: defineTable({
 		tokenIdentifier: v.string(),
@@ -148,25 +172,12 @@ export default defineSchema({
 		.index("by_tokenIdentifier", ["tokenIdentifier"])
 		.index("by_clerkId", ["clerkId"])
 		.index("by_email", ["email"]),
-	accessEntitlements: defineTable({
-		ownerTokenIdentifier: v.string(),
-		userId: v.id("users"),
-		trialStartedAt: v.number(),
-		trialExpiresAt: v.number(),
-		trialReminderAt: v.number(),
-		trialTermsVersion: v.string(),
-		revenueCatEntitlementActive: v.optional(v.boolean()),
-		subscriptionExpiresAt: v.optional(v.number()),
-		subscriptionGraceExpiresAt: v.optional(v.number()),
-		subscriptionProductId: v.optional(v.string()),
-		subscriptionStore: v.optional(v.string()),
-		subscriptionWillRenew: v.optional(v.boolean()),
-		subscriptionBillingIssueDetectedAt: v.optional(v.number()),
-		subscriptionManagementUrl: v.optional(v.string()),
-		subscriptionVerifiedAt: v.optional(v.number()),
-		createdAt: v.number(),
-		updatedAt: v.number(),
-	}).index("by_ownerTokenIdentifier", ["ownerTokenIdentifier"]),
+	accessEntitlements: defineTable(
+		v.union(
+			accessEntitlementWithoutTrialValidator,
+			accessEntitlementWithTrialValidator,
+		),
+	).index("by_ownerTokenIdentifier", ["ownerTokenIdentifier"]),
 	validationUserStates: defineTable({
 		ownerTokenIdentifier: v.string(),
 		userId: v.id("users"),


### PR DESCRIPTION
## Summary

- allow RevenueCat-backed entitlements to exist without trial metadata
- preserve the all-or-none invariant for the four trial fields with an exact schema union
- return paid access while the subscription is active and expired access afterward
- reject malformed records containing only part of the trial metadata

## Root cause

PR #498 intentionally creates paid entitlements before trial activation. Those records omit all trial fields, but the schema on main still requires them. Any branch using that older schema therefore fails deployment as soon as it validates the shared Convex data.

This focused change extracts the schema/read-path compatibility prerequisite from #498 so existing branches can deploy safely while the larger redemption feature remains in review.

## Validation

- focused entitlement suite: 13 tests passing
- TypeScript typecheck
- ESLint and Biome checks for changed files
- Convex development push accepted the existing paid-only record
- independent standards review: no findings
- independent spec review: no findings
