### PR TITLE
DAY-248 Resolve production fingerprint outputs

### DIFF
--- a/.eas/workflows/ci.yml
+++ b/.eas/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
       - production_fingerprint
     if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
     environment: production
+    env:
+      APP_VARIANT: production
+      EAS_BUILD_PLATFORM: ios
+      OTA_ANDROID_FINGERPRINT: ${{ needs.production_fingerprint.outputs.android_fingerprint_hash }}
+      OTA_IOS_FINGERPRINT: ${{ needs.production_fingerprint.outputs.ios_fingerprint_hash }}
     outputs:
       ota_safe: ${{ steps.ota_guard.outputs.ota_safe }}
       ota_reason: ${{ steps.ota_guard.outputs.ota_reason }}
@@ -78,17 +83,9 @@ jobs:
       - uses: eas/checkout
       - uses: eas/install_node_modules
       - name: Verify Expo export
-        env:
-          APP_VARIANT: production
-          EAS_BUILD_PLATFORM: ios
         run: pnpm exec expo export --platform ios --output-dir dist
       - id: ota_guard
         name: Check OTA safety against distributed binaries
-        env:
-          APP_VARIANT: production
-          EAS_BUILD_PLATFORM: ios
-          OTA_ANDROID_FINGERPRINT: ${{ needs.production_fingerprint.outputs.android_fingerprint_hash }}
-          OTA_IOS_FINGERPRINT: ${{ needs.production_fingerprint.outputs.ios_fingerprint_hash }}
         run: |
           if ota_report="$(node scripts/ota-safety.mjs --json)"; then
             ota_safe=true
@@ -129,19 +126,17 @@ jobs:
       - deploy_convex
     if: ${{ github.event_name == 'push' && github.ref_name == 'main' && needs.ota_checks.outputs.ota_safe == 'true' }}
     environment: production
+    env:
+      APP_VARIANT: production
+      EAS_BUILD_PLATFORM: ios
+      OTA_ANDROID_FINGERPRINT: ${{ needs.production_fingerprint.outputs.android_fingerprint_hash }}
+      OTA_IOS_FINGERPRINT: ${{ needs.production_fingerprint.outputs.ios_fingerprint_hash }}
     steps:
       - uses: eas/checkout
       - uses: eas/install_node_modules
       - name: Verify production manifest and distributed-binary compatibility
-        env:
-          APP_VARIANT: production
-          EAS_BUILD_PLATFORM: ios
-          OTA_ANDROID_FINGERPRINT: ${{ needs.production_fingerprint.outputs.android_fingerprint_hash }}
-          OTA_IOS_FINGERPRINT: ${{ needs.production_fingerprint.outputs.ios_fingerprint_hash }}
         run: node scripts/ota-safety.mjs
       - name: Send production OTA rollout
-        env:
-          APP_VARIANT: production
         run: |
           pnpm dlx eas-cli@18.11.0 update \
             --branch production \

--- a/tests/ota-safety.test.ts
+++ b/tests/ota-safety.test.ts
@@ -423,7 +423,7 @@ describe("production release configuration", () => {
 		expect(otaChecks.needs).toEqual(
 			expect.arrayContaining(["main_checks", "production_fingerprint"]),
 		);
-		expect(otaGuard.env).toEqual({
+		expect(otaChecks.env).toEqual({
 			APP_VARIANT: "production",
 			EAS_BUILD_PLATFORM: "ios",
 			OTA_ANDROID_FINGERPRINT:
@@ -431,6 +431,7 @@ describe("production release configuration", () => {
 			OTA_IOS_FINGERPRINT:
 				"${{ needs.production_fingerprint.outputs.ios_fingerprint_hash }}",
 		});
+		expect(otaGuard.env).toBeUndefined();
 		const sendUpdates = workflow.jobs.send_updates;
 		const finalGuard = sendUpdates.steps.find(
 			(step: { name?: string }) =>
@@ -440,7 +441,8 @@ describe("production release configuration", () => {
 
 		expect(sendUpdates.needs).toContain("ota_checks");
 		expect(sendUpdates.needs).toContain("production_fingerprint");
-		expect(finalGuard.env).toEqual(otaGuard.env);
+		expect(sendUpdates.env).toEqual(otaChecks.env);
+		expect(finalGuard.env).toBeUndefined();
 	});
 
 	it("requires a clean commit before EAS builds upload source", () => {


### PR DESCRIPTION
## Summary

- move production fingerprint interpolation to custom-job `env`, the EAS-supported cross-job environment boundary
- share the same resolved values with the final publication guard
- update the regression test to reject step-local fingerprint expressions

## Why

The first post-merge DAY-248 workflow stayed fail-closed and sent no OTA, but its gate output showed literal `${{ needs.production_fingerprint.outputs.* }}` strings instead of the fingerprint job's hashes. EAS documents cross-job outputs through receiving job-level `env`; step-local `env` did not interpolate those values in the live run.

## Validation

- `APP_VARIANT=production eas workflow:validate .eas/workflows/ci.yml`
- `pnpm exec vitest run tests/ota-safety.test.ts` (20/20)
- `pnpm check`
- `pnpm format:check`
- `git diff --check`

The original main run was safe: `ota_safe=false`, `Send updates` skipped, and `OTA update skipped` succeeded. This follow-up makes the recorded fingerprint evidence accurate without opening production OTA.

Follow-up to #422 / DAY-248.