### PR TITLE
Keep onboarding controls stationary between steps

### DIFF
--- a/src/app/(auth)/_layout.tsx
+++ b/src/app/(auth)/_layout.tsx
@@ -27,7 +27,11 @@ export default function AuthLayout() {
 			/>
 			<Stack.Screen
 				name="onboarding/[step]"
-				options={{ title: "Registrierung", gestureEnabled: true }}
+				options={{
+					animation: "none",
+					title: "Registrierung",
+					gestureEnabled: true,
+				}}
 			/>
 			<Stack.Screen
 				name="onboarding/verification"

--- a/src/features/auth/auth-layout.ui.test.tsx
+++ b/src/features/auth/auth-layout.ui.test.tsx
@@ -76,7 +76,11 @@ describe("AuthLayout", () => {
 		});
 		expect(mockStackScreens).toContainEqual({
 			name: "onboarding/[step]",
-			options: { title: "Registrierung", gestureEnabled: true },
+			options: {
+				animation: "none",
+				title: "Registrierung",
+				gestureEnabled: true,
+			},
 		});
 		expect(mockStackScreens).toContainEqual({
 			name: "onboarding/creating",


### PR DESCRIPTION
## Summary
- disable the native stack transition between dynamic onboarding steps
- keep the existing central question animation while the back button, progress header, and footer action remain anchored
- cover the route option in the auth layout UI test

## Root cause
Each onboarding answer pushes the next dynamic step to preserve native back history. The dynamic route inherited the native-stack page animation, so the entire screen moved even though the question content already has its own transition.

## Validation
- verified step 2 → step 3 on a local iPhone 17 Pro simulator (iOS 26.5)
- recorded the transition and confirmed the outer shell stays stationary
- TypeScript and lint checks pass
- Vitest: 113 files / 725 tests pass
- script tests: 17 pass
- Jest UI: 53 suites / 198 tests pass