### PR TITLE
Exclude release evidence from EAS archives

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -50,8 +50,8 @@ __pycache__/
 /android
 
 # Review evidence and local capture scratch space are not build inputs.
-/docs/evidence/
-/.tmp/
+docs/evidence/
+.tmp/
 
 # Downloaded store binaries are release evidence, not source artifacts.
-/release/google-play/artifacts/*.aab
+release/google-play/artifacts/*.aab


### PR DESCRIPTION
## Summary\n- fix root-relative EAS ignore patterns\n- keep local review evidence and downloaded store artifacts out of production build uploads\n\n## Validation\n- git diff --check\n- EAS archive inspection follows after this committed configuration is available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Packaging**
  - Updated file exclusion rules so documentation evidence, temporary files, and Google Play app bundles are consistently excluded from packaging, regardless of their directory depth.
  - This helps prevent unintended files and release artifacts from being included in build submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->