### PR TITLE
Exclude Git metadata from EAS build archives

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -4,6 +4,9 @@
 node_modules/
 .pnpm-store/
 
+# Git history is not a build input and can contain large archived evidence blobs.
+.git
+
 # Expo
 .expo/
 dist/


### PR DESCRIPTION
## Summary\n- exclude local Git history from EAS source archives\n- prevent archived review-media blobs from inflating production uploads\n\n## Validation\n- EAS archive inspection succeeds\n- archive reduced from 274 MB expanded to 18 MB\n- generated archive contains no .git directory\n- source commit remains clean and is still recorded by EAS before packaging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build exclusions to omit Git history and related archived files, helping reduce unnecessary build input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->